### PR TITLE
Fix Rules Header

### DIFF
--- a/Resources/Locale/en-US/info/rules.ftl
+++ b/Resources/Locale/en-US/info/rules.ftl
@@ -1,6 +1,6 @@
 ﻿# Rules
 
-ui-rules-header = DeltaV Official Server Rules
-ui-rules-header-rp = DeltaV Roleplay Official Server Rules
+ui-rules-header = Floof Station Official Server Rules
+ui-rules-header-rp = Floof Station Roleplay Official Server Rules
 ui-rules-accept = I have read and agree to follow the rules
 ui-rules-wait = The accept button will be enabled after {$time} seconds.

--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -1,5 +1,3 @@
-﻿[color=#00ff00]Floof Station Server Rules[/color]
-
 [color=#ff0000]WARNING: You MUST be at least 18 years of age to play on Floof Station.[/color] 
 [color=#ff0000]Any user suspected of being under the age of 18 WILL be removed until they are of age.[/color]
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/88f1bbea-7c53-4b73-9b90-827e5477e0c2)
Server currently says it's DeltaV in the rules header, this changes that.

# Changelog

:cl:
- fix: Rules header now correctly displays server name.
