### PR TITLE
Add Hairflower and Explorer's Labcoat to Loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -75,6 +75,20 @@
     - ClothingOuterCoatLabSeniorResearcher
 
 - type: loadout
+  id: LoadoutScienceOuterExplorerLabcoat
+  category: Jobs
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Scientist
+        - ResearchAssistant
+        - ResearchDirector
+  items:
+    - ClothingOuterExplorerCoat
+
+- type: loadout
   id: LoadoutScienceHatBeret
   category: Jobs
   cost: 1

--- a/Resources/Prototypes/Loadouts/Jobs/science.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/science.yml
@@ -74,7 +74,7 @@
   items:
     - ClothingOuterCoatLabSeniorResearcher
 
-- type: loadout
+- type: loadout # Floofstation
   id: LoadoutScienceOuterExplorerLabcoat
   category: Jobs
   cost: 2

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -70,6 +70,14 @@
   exclusive: true
   items:
     - ClothingHeadHatBellhop
+
+- type: loadout
+  id: LoadoutHeadFlower
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatHairflower
 ## Color Hats
 - type: loadout
   id: LoadoutHeadHatBluesoft

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -74,7 +74,7 @@
 - type: loadout # FloofStation
   id: LoadoutHeadFlower
   category: Head
-  cost: 2
+  cost: 1
   exclusive: true
   items:
     - ClothingHeadHatHairflower

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -71,7 +71,7 @@
   items:
     - ClothingHeadHatBellhop
 
-- type: loadout
+- type: loadout # FloofStation
   id: LoadoutHeadFlower
   category: Head
   cost: 2


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Very simple PR. This adds the hairflower and Explorer's labcoat to the head loadout and Epistemics job loadouts respectively. This will go to upstream eventually, I've just got way too much open on that side and don't want to accidentally push kitsune stuff with this, so it gets to come here first

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] add hairflower to public head loadouts
- [x] add explorer's labcoat to epi

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://i.gyazo.com/5b8b46d930b005764289e8bd7e39d607.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Epistemics has been given a supply of new labcoats, and everyone has been authorized to wear hairflowers.
