### PR TITLE
Add Cowboy Hats to Loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -63,7 +63,6 @@
   items:
     - ClothingHeadHatCowboyBrown
 
-
 - type: loadout
   id: LoadoutHeadHatCowboyBlack
   category: Head

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -56,6 +56,55 @@
     - ClothingHeadHatFlatBrown
 
 - type: loadout
+  id: LoadoutHeadHatCowboyBrown
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBrown
+
+
+- type: loadout
+  id: LoadoutHeadHatCowboyBlack
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBlack
+
+- type: loadout
+  id: LoadoutHeadHatCowboyGrey
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyGrey
+
+- type: loadout
+  id: LoadoutHeadHatCowboyRed
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyRed
+
+- type: loadout
+  id: LoadoutHeadHatCowboyWhite
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyWhite
+
+- type: loadout
+  id: LoadoutHeadHatCowboyBountyHunter
+  category: Head
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingHeadHatCowboyBountyHunter
+
+- type: loadout
   id: LoadoutHeadTinfoil
   category: Head
   cost: 3


### PR DESCRIPTION
# Description

Adds the roster of cowboy hats to the loadout selection menu. Bounty Hunter's costs one extra due to its more "rare" design.

this is my second PR ever so if i messed up i am sorrys 😭😭😭

---

<details><summary><h1>Media</h1></summary>
<p>

![the hats](https://cdn.discordapp.com/attachments/945000186315423774/1265855880537047071/image.png?ex=66a307a8&is=66a1b628&hm=fce3383556a3784502ed242373bb50bada1337950a9a5943775287ef21dabded&)

![silly harpy with hat](https://cdn.discordapp.com/attachments/945000186315423774/1265855925663563808/image.png?ex=66a307b3&is=66a1b633&hm=c14478f1c11a8f90de98d545907f7041b64604482663908437caa3a2256070bf&)

</p>
</details>

---

# Changelog

:cl:
- add: added cowboy hats into the loadout selection menu