### PR TITLE
Added Opporozidone and ReduceRotting Effect

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/ReduceRotting.cs
+++ b/Content.Server/Chemistry/ReagentEffects/ReduceRotting.cs
@@ -1,0 +1,30 @@
+using Content.Server.Stunnable;
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+using Content.Server.Atmos.Rotting;
+
+namespace Content.Server.Chemistry.ReagentEffects
+{
+    /// <summary>
+    /// Reduces the rotting accumulator on the patient, making them revivable.
+    /// </summary>
+    public sealed partial class ReduceRotting : ReagentEffect
+    {
+        [DataField("seconds")]
+        public double RottingAmount = 10;
+
+        protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+            => Loc.GetString("reagent-effect-guidebook-reduce-rotting",
+                ("chance", Probability),
+                ("time", RottingAmount));
+        public override void Effect(ReagentEffectArgs args)
+        {
+            if (args.Scale != 1f)
+                return;
+
+            var rottingSys = args.EntityManager.EntitySysManager.GetEntitySystem<RottingSystem>();
+
+            rottingSys.ReduceAccumulator(args.SolutionEntity, TimeSpan.FromSeconds(RottingAmount));
+        }
+    }
+}

--- a/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
+++ b/Content.Shared/Atmos/Rotting/SharedRottingSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Examine;
+using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mobs.Components;
 
@@ -40,5 +40,27 @@ public abstract class SharedRottingSystem : EntitySystem
             description += "-nonmob";
 
         args.PushMarkup(Loc.GetString(description, ("target", Identity.Entity(uid, EntityManager))));
+    }
+
+    public void ReduceAccumulator(EntityUid uid, TimeSpan time)
+    {
+        if (!TryComp<PerishableComponent>(uid, out var perishable))
+            return;
+
+        if (!TryComp<RottingComponent>(uid, out var rotting))
+        {
+            perishable.RotAccumulator -= time;
+            return;
+        }
+        var total = (rotting.TotalRotTime + perishable.RotAccumulator) - time;
+
+        if (total < perishable.RotAfter)
+        {
+            RemCompDeferred(uid, rotting);
+            perishable.RotAccumulator = total;
+        }
+
+        else
+            rotting.TotalRotTime = total - perishable.RotAfter;
     }
 }

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -1,4 +1,4 @@
-﻿-create-3rd-person =
+-create-3rd-person =
     { $chance ->
         [1] Creates
         *[other] create
@@ -338,6 +338,12 @@ reagent-effect-guidebook-innoculate-zombie-infection =
         [1] Cures
         *[other] cure
     } an ongoing zombie infection, and provides immunity to future infections
+
+reagent-effect-guidebook-reduce-rotting =
+    { $chance ->
+        [1] Regenerates
+        *[other] regenerate
+    } {NATURALFIXED($time, 3)} {MANY("second", $time)} of rotting
 
 reagent-effect-guidebook-missing =
     { $chance ->

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -127,6 +127,9 @@ reagent-desc-pyrazine = Efficiently heals burns from the hottest of fires. Cause
 reagent-name-insuzine = insuzine
 reagent-desc-insuzine = Rapidly repairs dead tissue caused by electrocution, but cools you slightly. Completely freezes the patient when overdosed.
 
+reagent-name-opporozidone = opporozidone
+reagent-desc-opporozidone= A difficult to synthesize cryogenic drug used to regenerate rotting tissue and brain matter.
+
 reagent-name-necrosol = necrosol
 reagent-desc-necrosol = A necrotic substance that seems to be able to heal frozen corpses. It can treat and rejuvenate plants when applied in small doses.
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1122,6 +1122,27 @@
           min: 12
 
 - type: reagent
+  id: Opporozidone #Name based of an altered version of the startreck chem "Opporozine"
+  name: reagent-name-opporozidone
+  group: Medicine
+  desc: reagent-desc-opporozidone
+  physicalDesc: reagent-physical-desc-sickly
+  flavor: acid
+  color: "#b5e36d"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+        - !type:ReduceRotting
+          seconds: 20
+          conditions:
+          #Patient must be dead and in a cryo tube (or something cold)
+          - !type:Temperature
+            max: 150.0
+          - !type:MobStateCondition
+            mobstate: Dead
+
+- type: reagent
   id: Necrosol
   name: reagent-name-necrosol
   group: Medicine

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -549,6 +549,19 @@
     Ash: 1
 
 - type: reaction
+  id: Opporozidone
+  minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
+  reactants:
+    Cognizine: 
+      amount: 1
+    Plasma:
+      amount: 2
+    Doxarubixadone:
+      amount: 1
+  products:
+    Opporozidone: 3
+
+- type: reaction
   id: Necrosol
   impact: Medium
   minTemp: 370


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Added Opporozidone, the chemical that reduces rot, from upsteam! Allows people to be revived even if their bodies are rotting, which reduces the use of cloning and losing your character. The code for this may be a bit botched, as I patched in the Wizden code, which required adding a method from upstream to the sharedRottingSystem. Not sure if it was the right place to put it but the chemical DOES work, so.

---


<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![opporozidone chemical](https://github.com/user-attachments/assets/02e79b6d-3e43-4da9-b46c-781851226193)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Xavier
- add: Opporozine, upstream chemical that allows you to remove rotting by cryopods!
