### PR TITLE
Glasses Are Now Available for Nearsighted Crew

### DIFF
--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -9,11 +9,6 @@
   id: LoadoutEyesGlasses
   category: Eyes
   cost: 1
-  requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Nearsighted
   items:
     - ClothingEyesGlasses
 


### PR DESCRIPTION
# Description

Glasses for everyone, even nearsighted crew. I get the whole point of disuading trading trait points for loadout points, but this server is roleplay focused.

---
# Changelog


:cl:
- add: Glasses are now available for nearsighted crew.
