### PR TITLE
Added Beverage Jugs to Lathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -161,7 +161,7 @@
       - WeaponCapacitorRechargerCircuitboard
       - HandheldStationMap
       - ClothingHeadHatWelding
-      - CustomDrinkJug
+      - CustomDrinkJug # FloofStation
   - type: EmagLatheRecipes
     emagStaticRecipes:
        - CartridgePistol

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -161,6 +161,7 @@
       - WeaponCapacitorRechargerCircuitboard
       - HandheldStationMap
       - ClothingHeadHatWelding
+      - CustomDrinkJug
   - type: EmagLatheRecipes
     emagStaticRecipes:
        - CartridgePistol

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -98,7 +98,7 @@
   materials:
     Steel: 100
 
-- type: latheRecipe
+- type: latheRecipe # FloofStation
   id: CustomDrinkJug
   result: CustomDrinkJug
   completetime: 4

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -97,3 +97,10 @@
   completetime: 0.4
   materials:
     Steel: 100
+
+- type: latheRecipe
+  id: CustomDrinkJug
+  result: CustomDrinkJug
+  completetime: 4
+  materials:
+    Plastic: 400


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This adds the Beverage Jugs for the bartender back into the autolathe, as to make them easier to get a hold of for things like juices.

---

# Changelog

:cl: Tilkku
tweak: added beverage jugs to autolathe