### PR TITLE
The Maid Outfit Loadout Update

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -256,7 +256,7 @@
     sprite: Clothing/Hands/Gloves/tacticalmaidgloves.rsi
   - type: GloveHeatResistance
     heatResistance: 1400
-  - type: Insulated
+#  - type: Insulated- Removed this property because I'm adding them to loadouts, hopefully this doesn't break anything!
   - type: Fiber
     fiberColor: fibers-black
 

--- a/Resources/Prototypes/Loadouts/hands.yml
+++ b/Resources/Prototypes/Loadouts/hands.yml
@@ -122,7 +122,7 @@
   items:
     - ClothingHandsGlovesFingerless
 
-- type: loadout
+- type: loadout #FloofStation
   id: LoadoutHandsGlovesTacticalMaid
   category: Hands
   cost: 2

--- a/Resources/Prototypes/Loadouts/hands.yml
+++ b/Resources/Prototypes/Loadouts/hands.yml
@@ -121,3 +121,11 @@
   exclusive: true
   items:
     - ClothingHandsGlovesFingerless
+
+- type: loadout
+  id: LoadoutHandsGlovesTacticalMaid
+  category: Hands
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHandsTacticalMaidGloves

--- a/Resources/Prototypes/Loadouts/head.yml
+++ b/Resources/Prototypes/Loadouts/head.yml
@@ -503,6 +503,20 @@
   items:
     - ClothingHeadHatBowlerHat
 
+- type: loadout #FloofStation
+  id: LoadoutTacticalMaidHeadband
+  category: Head
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingHeadHatTacticalMaidHeadband
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
+
 # Flatcaps
 - type: loadout
   id: LoadoutHeadGreyFlatcap

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -1517,7 +1517,7 @@
        departments:
          - Command
 
-- type: loadout
+- type: loadout #FloofStation
   id: LoadoutUniformJumpskirtTacticalMaid
   category: Uniform
   cost: 3
@@ -1531,7 +1531,7 @@
          - Security
          - Command
 
-- type: loadout
+- type: loadout #FloofStation
   id: LoadoutUniformJumpskirtJanimaid
   category: Uniform
   cost: 3
@@ -1545,7 +1545,7 @@
          - Security
          - Command
 
-- type: loadout
+- type: loadout #FloofStation
   id: LoadoutUniformJumpskirtJanimaidmini
   category: Uniform
   cost: 3

--- a/Resources/Prototypes/Loadouts/uniform.yml
+++ b/Resources/Prototypes/Loadouts/uniform.yml
@@ -1516,3 +1516,45 @@
        inverted: true
        departments:
          - Command
+
+- type: loadout
+  id: LoadoutUniformJumpskirtTacticalMaid
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtTacticalMaid
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
+
+- type: loadout
+  id: LoadoutUniformJumpskirtJanimaid
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtJanimaid
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command
+
+- type: loadout
+  id: LoadoutUniformJumpskirtJanimaidmini
+  category: Uniform
+  cost: 3
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtJanimaidmini
+  requirements:
+    - !type:CharacterDepartmentRequirement
+       inverted: true
+       departments:
+         - Security
+         - Command


### PR DESCRIPTION


# Description



Added the Maid outfit, with and without miniskirt, and added the entire Tactical Maid Outfit, removing the insulation of the gloves in the process of manufacturing. All of these are available for everyone except for Security and Command.

---





# Changelog


:cl:
- add: Maid outfits, including the tactical variety, are now available for everyone but Security and Command!
- tweak: Tactical maid gloves are no longer insulated.