### PR TITLE
Epistemics Survival Box

### DIFF
--- a/Resources/Prototypes/Loadouts/items.yml
+++ b/Resources/Prototypes/Loadouts/items.yml
@@ -293,7 +293,6 @@
          - Security
          - Medical
          - Engineering
-         - Epistemics
     - !type:CharacterJobRequirement
        inverted: true
        jobs:


### PR DESCRIPTION


# Description


The civi survival box is now available for Epistemics

---
# Changelog

:cl:
- tweak: Space OSHA has required us to offer Epistemics the option to take a survival box
