### PR TITLE
Fix The Mispelling

### DIFF
--- a/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -89,7 +89,7 @@
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingLongcoatHoP
-  name: Head of Personell's Longcoat
+  name: Head of Personnel's Longcoat
   description: A Double-Breasted longcoat, specifically. This one is a navy blue with red shoulderpads, fit for the HoP. Longcoats are fairly robust, offering some protection from the wear and tear of the universe.
   components:
   - type: Sprite


### PR DESCRIPTION


# Description



Fixed the spelling mistake for the HoP coat

---

# Changelog


:cl:
- fix: Replaced the Head of Personell's Coat with the Head of Personnel's coat. We're not sure who the Head of Personell is, but godspeed you coatless soul.
