### PR TITLE
Increases Trait Limit From 5 to 7

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -361,7 +361,7 @@ namespace Content.Shared.CCVar
         ///     How many traits a character can have at most.
         /// </summary>
         public static readonly CVarDef<int> GameTraitsMax =
-            CVarDef.Create("game.traits_max", 5, CVar.REPLICATED);
+            CVarDef.Create("game.traits_max", 7, CVar.REPLICATED);
 
         /// <summary>
         ///     How many points a character should start with.


### PR DESCRIPTION

# Description



This PR hopefully changes the default trait limit from 5 to 7. The amount of points you get is left the same. The reason that I am changing it is due to the new lewd trait system. I believe that this server is roleplay-focused enough to where this will not be abused heavily. I believe the point costs of each trait is what balances them all. This is essentially so characters can have tits and a cock along with their normal trait loadouts.

---


# Changelog


:cl:
- tweak: Trait limit changed from 5 to 7.