### PR TITLE
Cosmetic Goggles and Animal Mask Loadout Options

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -234,3 +234,14 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
+
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesThermalBudget
+  name: knockoff optical thermal scanner
+  description: These don't have any real function, but they do look cool!
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Glasses/thermal.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Glasses/thermal.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -235,13 +235,36 @@
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
 
+# Cosmetic Goggles FloofStation
 - type: entity
   parent: ClothingEyesBase
   id: ClothingEyesGlassesThermalBudget
-  name: knockoff optical thermal scanner
+  name: red goggles
   description: These don't have any real function, but they do look cool!
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/thermal.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/thermal.rsi
+
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesChemicalBudget
+  name: purple goggles
+  description: These don't have any real function, but they do look cool!
+  components:
+    - type: Sprite
+      sprite: Clothing/Eyes/Glasses/science.rsi
+    - type: Clothing
+      sprite: Clothing/Eyes/Glasses/science.rsi
+
+- type: entity
+  parent: ClothingEyesBase
+  id: ClothingEyesGlassesMesonBudget
+  name: green goggles 
+  description: These don't have any real function, but they do look cool!
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Glasses/meson.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Glasses/meson.rsi

--- a/Resources/Prototypes/Loadouts/eyes.yml
+++ b/Resources/Prototypes/Loadouts/eyes.yml
@@ -50,3 +50,31 @@
   exclusive: true
   items:
     - ClothingEyesGlassesSunglasses
+
+# Cosmetic Goggles FloofStation
+
+- type: loadout
+  id: LoadoutEyesThermalBudget
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesThermalBudget
+
+- type: loadout
+  id: LoadoutEyesChemicalBudget
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesChemicalBudget
+
+
+- type: loadout
+  id: LoadoutEyesMesonBudget
+  category: Eyes
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingEyesGlassesMesonBudget
+

--- a/Resources/Prototypes/Loadouts/mask.yml
+++ b/Resources/Prototypes/Loadouts/mask.yml
@@ -141,6 +141,7 @@
   exclusive: true
   items:
     - ClothingMaskNeckGaiterRed
+
 # Costume Masks FloofStation
 - type: loadout
   id: LoadoutMaskPlague

--- a/Resources/Prototypes/Loadouts/mask.yml
+++ b/Resources/Prototypes/Loadouts/mask.yml
@@ -141,3 +141,67 @@
   exclusive: true
   items:
     - ClothingMaskNeckGaiterRed
+# Costume Masks FloofStation
+- type: loadout
+  id: LoadoutMaskPlague
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskPlague
+
+- type: loadout
+  id: LoadoutMaskRat
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskRat
+
+- type: loadout
+  id: LoadoutMaskFox
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskFox
+
+- type: loadout
+  id: LoadoutMaskBee
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskBee
+
+- type: loadout
+  id: LoadoutMaskBear
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskBear
+
+- type: loadout
+  id: LoadoutMaskRaven
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskRaven
+
+- type: loadout
+  id: LoadoutMaskJackal
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskJackal
+
+- type: loadout
+  id: LoadoutMaskBat
+  category: Mask
+  cost: 2
+  exclusive: true
+  items:
+    - ClothingMaskBat


### PR DESCRIPTION
# Description



Adds 3 new completely cosmetic goggles of the red, green, and purple variety, and adds them to loadouts. I have simply cloned the functional goggles and removed the functions from them, and put Budget at the end, because I think they'd look pretty cool. Also adds all the animal masks to loadouts.

---


# Changelog


:cl:
- add: Completely cosmetic goggles are now being sold for the low cost of 2 loadout points.
- add: We've realized we'd make more money selling the animal masks to crew instead of leaving them in maints.
