### PR TITLE
Content.Integration Works Again

### DIFF
--- a/Resources/ConfigPresets/Floofstation/floofstation.toml
+++ b/Resources/ConfigPresets/Floofstation/floofstation.toml
@@ -1,2 +1,0 @@
-[floof]
-consent_rules = "test"

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -9,7 +9,7 @@
   components:
     - type: Construction
       graph: WebStructures
-      node: spiderweb
+      node: SpiderWeb
     - type: MeleeSound
       soundGroups:
         Brute:

--- a/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/spider_web.yml
@@ -7,9 +7,6 @@
     snap:
       - Wall
   components:
-    - type: Construction
-      graph: WebStructures
-      node: SpiderWeb
     - type: MeleeSound
       soundGroups:
         Brute:


### PR DESCRIPTION


# Description

Brings spider_web.yml to modern EE standards, and completely yeets an unused unloved config file. This will not have a CL, because it's bug busting. If this does not work, I might cry myself to sleep.

---