### PR TITLE
Fixed Cum/Milk Generation

### DIFF
--- a/Content.Server/FloofStation/Traits/Components/CumProducerComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/CumProducerComponent.cs
@@ -13,7 +13,7 @@ namespace Content.Server.FloofStation.Traits;
 public sealed partial class CumProducerComponent : Component
 {
     [DataField("solutionname"), ViewVariables(VVAccess.ReadWrite)]
-    public string SolutionName;
+    public string SolutionName = "penis";
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<ReagentPrototype> ReagentId = "Cum";
@@ -24,15 +24,15 @@ public sealed partial class CumProducerComponent : Component
     [DataField]
     public Entity<SolutionComponent>? Solution = null;
 
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public FixedPoint2 QuantityPerUpdate = 25;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 QuantityPerUpdate = 5;
 
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float HungerUsage = 10f;
 
-    [DataField]
-    public TimeSpan GrowthDelay = TimeSpan.FromMinutes(1);
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan GrowthDelay = TimeSpan.FromSeconds(10);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextGrowth = TimeSpan.FromSeconds(0);
 }

--- a/Content.Server/FloofStation/Traits/Components/CumProducerComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/CumProducerComponent.cs
@@ -12,10 +12,10 @@ namespace Content.Server.FloofStation.Traits;
 [RegisterComponent, Access(typeof(LewdTraitSystem))]
 public sealed partial class CumProducerComponent : Component
 {
-    [DataField("solutionname"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("solutionname")]
     public string SolutionName = "penis";
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public ProtoId<ReagentPrototype> ReagentId = "Cum";
 
     [DataField]
@@ -24,15 +24,15 @@ public sealed partial class CumProducerComponent : Component
     [DataField]
     public Entity<SolutionComponent>? Solution = null;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public FixedPoint2 QuantityPerUpdate = 5;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float HungerUsage = 10f;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan GrowthDelay = TimeSpan.FromSeconds(10);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextGrowth = TimeSpan.FromSeconds(0);
 }

--- a/Content.Server/FloofStation/Traits/Components/MilkProducerComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/MilkProducerComponent.cs
@@ -13,26 +13,26 @@ namespace Content.Server.FloofStation.Traits;
 public sealed partial class MilkProducerComponent : Component
 {
     [DataField("solutionname"), ViewVariables(VVAccess.ReadWrite)]
-    public string SolutionName;
+    public string SolutionName = "breasts";
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<ReagentPrototype> ReagentId = "Milk";
 
     [DataField]
-    public FixedPoint2 MaxVolume = FixedPoint2.New(25);
+    public FixedPoint2 MaxVolume = FixedPoint2.New(50);
 
     [DataField]
     public Entity<SolutionComponent>? Solution = null;
 
-    [DataField, ViewVariables(VVAccess.ReadOnly)]
-    public FixedPoint2 QuantityPerUpdate = 25;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 QuantityPerUpdate = 5;
 
-    [DataField]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float HungerUsage = 10f;
 
-    [DataField]
-    public TimeSpan GrowthDelay = TimeSpan.FromMinutes(1);
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan GrowthDelay = TimeSpan.FromSeconds(10);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan NextGrowth = TimeSpan.FromSeconds(0);
 }

--- a/Content.Server/FloofStation/Traits/Components/MilkProducerComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/MilkProducerComponent.cs
@@ -12,10 +12,10 @@ namespace Content.Server.FloofStation.Traits;
 [RegisterComponent, Access(typeof(LewdTraitSystem))]
 public sealed partial class MilkProducerComponent : Component
 {
-    [DataField("solutionname"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField("solutionname")]
     public string SolutionName = "breasts";
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public ProtoId<ReagentPrototype> ReagentId = "Milk";
 
     [DataField]
@@ -24,15 +24,15 @@ public sealed partial class MilkProducerComponent : Component
     [DataField]
     public Entity<SolutionComponent>? Solution = null;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public FixedPoint2 QuantityPerUpdate = 5;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float HungerUsage = 10f;
 
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public TimeSpan GrowthDelay = TimeSpan.FromSeconds(10);
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextGrowth = TimeSpan.FromSeconds(0);
 }

--- a/Resources/Prototypes/Floof/Traits/lewd.yml
+++ b/Resources/Prototypes/Floof/Traits/lewd.yml
@@ -13,10 +13,10 @@
     - type: SolutionContainerManager
       solutions:
         penis:
-          maxVol: 250
+          maxVol: 25
           reagents:
           - ReagentId: Cum
-            Quantity: 30
+            Quantity: 25
 
 - type: trait
   id: MilkProducer
@@ -33,10 +33,10 @@
     - type: SolutionContainerManager
       solutions:
         breasts:
-          maxVol: 250
+          maxVol: 50
           reagents:
           - ReagentId: Milk
-            Quantity: 30
+            Quantity: 50
 
 # WIP - Needs a Reagent
 # - type: trait


### PR DESCRIPTION
# Description

This PR fixes the cum and milk generation so that it works properly now.
It also removes the "Floofstation" folder and instead uses "Floof" so now there is only one Floof folder.

It works with one or more traits as my testing has shown so far.

---

# Changelog

:cl:
- tweak: Tweaked starting max milk amount. 25u -> 50u
- tweak: Gave cumProducer a default SolutionName ("penis").
- tweak: Gave milkProducer a default SolutionName ("breasts").
- tweak: cumProducer takes less time to generate, but generates less per growth.
- tweak: milkProducer takes less time to generate, but generates less per growth.
- fix: Cum generation - When you eat something, your tank will refill and use hunger.
- fix: Milk generation - When you eat something, your tank will refill and use hunger.
- remove: Duplicate "Floof" folder.
