### PR TITLE
Made RoundEnd Window Openable

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using Robust.Client.Graphics;
 using Robust.Client.State;
 using Robust.Shared.Utility;
+using Robust.Client.UserInterface;
 
 namespace Content.Client.GameTicking.Managers
 {
@@ -15,6 +16,7 @@ namespace Content.Client.GameTicking.Managers
     {
         [Dependency] private readonly IStateManager _stateManager = default!;
         [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
 
         [ViewVariables] private bool _initialized;
         private Dictionary<NetEntity, Dictionary<string, uint?>>  _jobsAvailable = new();
@@ -132,12 +134,7 @@ namespace Content.Client.GameTicking.Managers
             // Force an update in the event of this song being the same as the last.
             RestartSound = message.RestartSound;
 
-            // Don't open duplicate windows (mainly for replays).
-            if (_window?.RoundId == message.RoundId)
-                return;
-
-            //This is not ideal at all, but I don't see an immediately better fit anywhere else.
-            _window = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText, message.RoundDuration, message.RoundId, message.AllPlayersEndInfo, _entityManager);
+            _userInterfaceManager.GetUIController<RoundEndSummaryUIController>().OpenRoundEndSummaryWindow(message);
         }
     }
 }

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -38,6 +38,7 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.ZoomIn);
             common.AddFunction(ContentKeyFunctions.ResetZoom);
             common.AddFunction(ContentKeyFunctions.InspectEntity);
+            common.AddFunction(ContentKeyFunctions.ToggleRoundEndSummaryWindow);
 
             // Not in engine, because engine cannot check for sanbox/admin status before starting placement.
             common.AddFunction(ContentKeyFunctions.EditorCopyObject);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -218,6 +218,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.OpenLanguageMenu);
             AddButton(ContentKeyFunctions.OpenAHelp);
             AddButton(ContentKeyFunctions.OpenActionsMenu);
+            AddButton(ContentKeyFunctions.ToggleRoundEndSummaryWindow);
             AddButton(ContentKeyFunctions.OpenEntitySpawnWindow);
             AddButton(ContentKeyFunctions.OpenSandboxWindow);
             AddButton(ContentKeyFunctions.OpenTileSpawnWindow);

--- a/Content.Client/RoundEnd/RoundEndSummaryUIController.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryUIController.cs
@@ -1,0 +1,51 @@
+using Content.Client.GameTicking.Managers;
+using Content.Shared.GameTicking;
+using Content.Shared.Input;
+using JetBrains.Annotations;
+using Robust.Client.Input;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Client.RoundEnd;
+
+[UsedImplicitly]
+public sealed class RoundEndSummaryUIController : UIController,
+    IOnSystemLoaded<ClientGameTicker>
+{
+    [Dependency] private readonly IInputManager _input = default!;
+
+    private RoundEndSummaryWindow? _window;
+
+    private void ToggleScoreboardWindow(ICommonSession? session = null)
+    {
+        if (_window == null)
+            return;
+
+        if (_window.IsOpen)
+        {
+            _window.Close();
+        }
+        else
+        {
+            _window.OpenCenteredRight();
+            _window.MoveToFront();
+        }
+    }
+
+    public void OpenRoundEndSummaryWindow(RoundEndMessageEvent message)
+    {
+        // Don't open duplicate windows (mainly for replays).
+        if (_window?.RoundId == message.RoundId)
+            return;
+
+        _window = new RoundEndSummaryWindow(message.GamemodeTitle, message.RoundEndText,
+            message.RoundDuration, message.RoundId, message.AllPlayersEndInfo, EntityManager);
+    }
+
+    public void OnSystemLoaded(ClientGameTicker system)
+    {
+        _input.SetInputCommand(ContentKeyFunctions.ToggleRoundEndSummaryWindow,
+            InputCmdHandler.FromDelegate(ToggleScoreboardWindow));
+    }
+}

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -43,6 +43,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction MovePulledObject = "MovePulledObject";
         public static readonly BoundKeyFunction ReleasePulledObject = "ReleasePulledObject";
         public static readonly BoundKeyFunction MouseMiddle = "MouseMiddle";
+        public static readonly BoundKeyFunction ToggleRoundEndSummaryWindow = "ToggleRoundEndSummaryWindow";
         public static readonly BoundKeyFunction OpenConsentWindow = "OpenConsentWindow";
         public static readonly BoundKeyFunction OpenEntitySpawnWindow = "OpenEntitySpawnWindow";
         public static readonly BoundKeyFunction OpenSandboxWindow = "OpenSandboxWindow";

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -173,6 +173,7 @@ ui-options-function-open-crafting-menu = Open crafting menu
 ui-options-function-open-inventory-menu = Open inventory
 ui-options-function-open-a-help = Open admin help
 ui-options-function-open-abilities-menu = Open action menu
+ui-options-function-toggle-round-end-summary-window = Toggle round end summary window
 ui-options-function-open-entity-spawn-window = Open entity spawn menu
 ui-options-function-open-sandbox-window = Open sandbox menu
 ui-options-function-open-tile-spawn-window = Open tile spawn menu

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -461,6 +461,9 @@ binds:
 - function: OpenDecalSpawnWindow
   type: State
   key: F8
+- function: ToggleRoundEndSummaryWindow
+  type: Toggle
+  key: F9
 - function: OpenSandboxWindow
   type: State
   key: B


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Brought the Wizden _(finally saying wizden instead of upstream)_ change of being able to open the round end screen! It works, but oddly enough you have to press it twice to work, probably because it's a toggle, but it does work! 

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Xavier
- add: F9 now opens the RoundEnd Screen! May have to press twice.
