### PR TITLE
Add Skirt Tag to Thongs and Sex Comp Outfits

### DIFF
--- a/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/Uniforms/misc.yml
@@ -56,6 +56,9 @@
     sprite: Floof/Clothing/Uniforms/plainthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/plainthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -67,6 +70,9 @@
     sprite: Floof/Clothing/Uniforms/beethong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/beethong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -78,6 +84,9 @@
     sprite: Floof/Clothing/Uniforms/coderthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/coderthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -89,6 +98,9 @@
     sprite: Floof/Clothing/Uniforms/codervalidthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/codervalidthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -100,6 +112,9 @@
     sprite: Floof/Clothing/Uniforms/stripethongwhite.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/stripethongwhite.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -111,6 +126,9 @@
     sprite: Floof/Clothing/Uniforms/stripethongpurple.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/stripethongpurple.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -122,6 +140,9 @@
     sprite: Floof/Clothing/Uniforms/stripethongrainbow.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/stripethongrainbow.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -133,6 +154,9 @@
     sprite: Floof/Clothing/Uniforms/sexcompred.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/sexcompred.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase
@@ -144,6 +168,9 @@
     sprite: Floof/Clothing/Uniforms/sexcompblue.rsi
   - type: Clothing
     sprite: Floof/Clothing/Uniforms/sexcompblue.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/Floof/Entities/Clothing/departmental_clothes.yml
@@ -38,6 +38,9 @@
     sprite: Floof/Clothing/Departmental/Command/captthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Command/captthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #General Command
 
@@ -77,6 +80,9 @@
     sprite: Floof/Clothing/Departmental/Command/commandthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Command/commandthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Engineering Outfits
 #
@@ -117,6 +123,9 @@
     sprite: Floof/Clothing/Departmental/Engineering/engithong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Engineering/engithong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 
 #Epistemics Outfits
@@ -158,6 +167,9 @@
     sprite: Floof/Clothing/Departmental/Epistemics/epithong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Epistemics/epithong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Chaplain
 - type: entity
@@ -196,6 +208,9 @@
     sprite: Floof/Clothing/Departmental/Epistemics/chaplainthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Epistemics/chaplainthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -259,6 +274,9 @@
     sprite: Floof/Clothing/Departmental/Logistics/logithong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Logistics/logithong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Medical Outfits
 #
@@ -299,6 +317,9 @@
     sprite: Floof/Clothing/Departmental/Medical/medicalthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Medical/medicalthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Security Outfits
 #
@@ -363,6 +384,9 @@
         Piercing: 0.1
         Heat: 0.3
   - type: GroupExamine
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Service Outfits
 #
@@ -403,6 +427,9 @@
     sprite: Floof/Clothing/Departmental/Service/servicethong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Service/servicethong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt
 
 #Janitorial
 - type: entity
@@ -441,3 +468,6 @@
     sprite: Floof/Clothing/Departmental/Service/janitorthong.rsi
   - type: Clothing
     sprite: Floof/Clothing/Departmental/Service/janitorthong.rsi
+  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    tags:
+    - Skirt


### PR DESCRIPTION
# Description

Added the Skirt tag to all the thongs, and to the sex competition outfits, allowing Harpy's and other skirt-only species to wear them! This is a really simple fix, so I didn't add any media.

---

# Changelog

:cl:
- fix: harpies can now wear thongs, and the sex competition outfits! rejoice! :3
