### PR TITLE
Fix: Rice Pudding After Cream Change

### DIFF
--- a/Resources/Prototypes/Floof/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Floof/Recipes/Cooking/meal_recipes.yml
@@ -110,3 +110,15 @@
     Ketchup: 15
   solids:
     IceCreamBowl: 1
+
+- type: microwaveMealRecipe
+  id: RecipeRicePudding2
+  name: rice pudding recipe
+  result: FoodRicePudding
+  time: 15
+  reagents:
+    Rice: 15
+    Cream: 15
+  solids:
+    FoodBowlBig: 1
+    


### PR DESCRIPTION
Rice pudding can now be made using 15 units of cream (10 milk 5 sugar) the old recipe still exists if you place them in to the microwave in different containers rather than mixing them


Description.
added a secondary recipe for rice pudding due to the sugar milk mixing into cream when all ingredients were mixed together
https://discord.com/channels/1255902263667331193/1274971717252415529

:cl:
- fix: Fixed Rice Pudding
