### PR TITLE
Edit Trait Max Temporarily

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -361,7 +361,7 @@ namespace Content.Shared.CCVar
         ///     How many traits a character can have at most.
         /// </summary>
         public static readonly CVarDef<int> GameTraitsMax =
-            CVarDef.Create("game.traits_max", 10, CVar.REPLICATED);
+            CVarDef.Create("game.traits_max", 12, CVar.REPLICATED);
 
         /// <summary>
         ///     How many points a character should start with.


### PR DESCRIPTION

# Description


Until the LewdTrait system is its own thing, this PR is a suggestion to make the default trait limit 12. People who don't use the lewd traits will probably use this to "game the system", but the truth is, the traits are at a proper enough balance where this can be uncapped (in my own opinion). However for the sake of consistency, leaving the max at 12 is good so you don't have those people who take ALL of the traits they can.

---


# Changelog

:cl:
- tweak: The Trait limit has been raised from 10 to 12
