### PR TITLE
No Zombies For Now

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -429,23 +429,23 @@
     - id: MobGiantSpiderVampireAngry
       prob: 0.01
 
-- type: entity
-  id: ZombieOutbreak
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    earliestStart: 60
-    reoccurrenceDelay: 60
-    minimumPlayers: 15
-    weight: 2
-    duration: 1
-  - type: ZombieRule
-    minStartDelay: 0 #let them know immediately
-    maxStartDelay: 10
-    maxInitialInfected: 2
-    minInitialInfectedGrace: 300
-    maxInitialInfectedGrace: 450
+#- type: entity
+#  id: ZombieOutbreak
+#  parent: BaseGameRule
+#  noSpawn: true
+#  components:
+#  - type: StationEvent
+#    earliestStart: 60
+#    reoccurrenceDelay: 60
+#    minimumPlayers: 15
+#    weight: 2
+#    duration: 1
+#  - type: ZombieRule
+#    minStartDelay: 0 #let them know immediately
+#    maxStartDelay: 10
+#    maxInitialInfected: 2
+#    minInitialInfectedGrace: 300
+#    maxInitialInfectedGrace: 450
 
 - type: entity
   id: LoneOpsSpawn

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,7 +3,7 @@
   weights:
     Survival: 0.44
     Nukeops: 0.14
-    Zombie: 0.03
+#    Zombie: 0.03
     Traitor: 0.39
     #Pirates: 0.15 #ahoy me bucko
 


### PR DESCRIPTION

# Description


This PR simply comments out the Zombie gamemode from appearing in Secret, and it comments out the Zombie outbreak that can happen at ANY time after an hour in survival and possibly extended. The gamemode still exists, but it wouldn't happen without admeme intervention. I believe this would be nice for the sake of this server in particular, as we're more on the roleplay side of things. Unclonable people are also just round removed when they become a zombie. Disaster roleplay could be "fun" but there are better ways to do that than zombies. 

---

# Changelog


:cl:
- remove: Zombies are gone from this sector, for now...
