### PR TITLE
Thieves Outside of Traitor

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -20,7 +20,7 @@
   rules:
     - HellshiftStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule # Floof - Thieves in Hellshift!
+    - SubGamemodesRule # Floof - Thieves in Survival!
 
 - type: gamePreset
   id: AllAtOnce
@@ -45,7 +45,7 @@
   rules:
   - BasicStationEventScheduler
   - BasicRoundstartVariation
-    - SubGamemodesRule # Floof - Thieves in Extended!
+  - SubGamemodesRule # Floof - Thieves in Survival!
 
 - type: gamePreset
   id: Greenshift

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -20,6 +20,7 @@
   rules:
     - HellshiftStationEventScheduler
     - BasicRoundstartVariation
+    - SubGamemodesRule # Floof - Thieves in Hellshift!
 
 - type: gamePreset
   id: AllAtOnce

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -20,7 +20,7 @@
   rules:
     - HellshiftStationEventScheduler
     - BasicRoundstartVariation
-    - SubGamemodesRule # Floof - Thieves in Survival!
+    - SubGamemodesRule # Floof - Thieves in Hellshit!
 
 - type: gamePreset
   id: AllAtOnce
@@ -45,7 +45,7 @@
   rules:
   - BasicStationEventScheduler
   - BasicRoundstartVariation
-  - SubGamemodesRule # Floof - Thieves in Survival!
+  - SubGamemodesRule # Floof - Thieves in Extended!
 
 - type: gamePreset
   id: Greenshift

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -8,6 +8,7 @@
   rules:
     - RampingStationEventScheduler
     - BasicRoundstartVariation
+    - SubGamemodesRule # Floof - Thieves in Survival!
 
 - type: gamePreset
   id: SurvivalHellshift
@@ -43,6 +44,7 @@
   rules:
   - BasicStationEventScheduler
   - BasicRoundstartVariation
+    - SubGamemodesRule # Floof - Thieves in Extended!
 
 - type: gamePreset
   id: Greenshift


### PR DESCRIPTION
# Description


Thieves can now appear in Survival and Extended (And Hellshift). That is literally all this does. This is an easy revert in case something goes wrong with this. I am also PRing this to EE.

---

# Changelog


:cl:
- tweak: Thieves have started appearing without Traitors...
