### PR TITLE
Weakness and Lightweight Traits

### DIFF
--- a/Content.Shared/Floofstation/Traits/Components/FixtureDensityModifier.cs
+++ b/Content.Shared/Floofstation/Traits/Components/FixtureDensityModifier.cs
@@ -1,0 +1,14 @@
+namespace Content.Shared.Floofstation.Traits.Components;
+
+[RegisterComponent]
+public sealed partial class FixtureDensityModifierComponent : Component
+{
+    /// <summary>
+    ///     The minimum and maximum density that may be used as input for and achieved as a result of application of this component.
+    /// </summary>
+    [DataField]
+    public float Min = float.Epsilon, Max = float.PositiveInfinity;
+
+    [DataField]
+    public float Factor = 1f;
+}

--- a/Content.Shared/Floofstation/Traits/TraitStatModifierSystem.cs
+++ b/Content.Shared/Floofstation/Traits/TraitStatModifierSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Contests;
+using Content.Shared.Floofstation.Traits.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.Floofstation.Traits;
+
+public sealed partial class TraitStatModifierSystem : EntitySystem
+{
+    [Dependency] private readonly ContestsSystem _contests = default!;
+    [Dependency] private readonly FixtureSystem _fixtures = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FixtureDensityModifierComponent, MapInitEvent>(OnInitDensity); // Traits are added after CharacterSpawnedEvent so it's fine™
+    }
+
+    private void OnInitDensity(Entity<FixtureDensityModifierComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<FixturesComponent>(ent.Owner, out var fixtures))
+            return;
+
+        foreach (var (id, fix) in fixtures.Fixtures)
+        {
+            if (!fix.Hard || fix.Density < ent.Comp.Min || fix.Density > ent.Comp.Max)
+                continue;
+
+            var result = Math.Clamp(fix.Density * ent.Comp.Factor, ent.Comp.Min, ent.Comp.Max);
+            _physics.SetDensity(ent, id, fix, result, update: false, fixtures);
+        }
+
+        _fixtures.FixtureUpdate(ent, true, true, fixtures);
+    }
+}

--- a/Resources/Locale/en-US/Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/Floof/traits/traits.ftl
@@ -9,3 +9,11 @@ trait-description-MilkProducer = You have a pair of large mammaries.
 
 trait-name-SquirtProducer = Pussy
 trait-description-SquirtProducer = You have a slit between your legs.
+
+trait-name-Weakness = Weakness
+trait-description-Weakness = You are naturally more vulnerable to fatigue. Your stamina pool is halved, making you greately vulnerable to shoving and stunning attacks.
+
+trait-name-Lightweight = Lightweight
+trait-description-Lightweight =
+    You are naturally lighter than other representatives of your species. Your body density is reduced to 2/3 of normal.
+    Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -21,4 +21,48 @@
     unitsToSucc: 10
     injectWhenSucc: false
     webRequired: false
-    
+
+- type: trait
+  id: Weakness
+  category: Physical
+  points: 5
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Borg
+      - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+      - Oni
+      - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - Lethargy
+      - Vigor
+  components:
+    - type: StaminaCritModifier
+      critThresholdModifier: -50
+
+- type: trait
+  id: Lightweight
+  category: Physical
+  points: -2 # Has pros and cons, not sure
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - Borg
+    - MedicalBorg
+  - !type:CharacterSpeciesRequirement # TODO if lamia gets merged, ensure it is added too
+    inverted: true
+    species:
+    - Felinid # They don't need to be lighter
+    - IPC
+  components:
+  - type: FixtureDensityModifier
+    min: 100
+    factor: 0.66 # still not as light as felinids due to different fixture size
+

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -100,6 +100,7 @@
       inverted: true
       traits:
         - Lethargy
+        - Weakness # Floofstation
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -123,6 +124,7 @@
       inverted: true
       traits:
         - Vigor
+        - Weakness # Floofstation
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:


### PR DESCRIPTION
# Description
Adds two new traits:
- Weakness - negative +5 point trait that halves your stamina pool, making you greately vulnerable to stunning attacks and fatigue
- Lightweight - positive -2 points trait that reduces your body density to 2/3, effectively reducing your mass to 2/3 of that of your peers.

Note: shoving and mass contests are completely broken right now. I will be submitting a PR to EE to fix them. This PR is standalone and will function without the future fix, although it will still benefit from it.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/827ef57e-e8a8-49a4-8859-f16648a091dc)

![image](https://github.com/user-attachments/assets/1695bf15-fa0f-436b-b406-4e1d697fee15)



https://github.com/user-attachments/assets/6a99900d-e534-4ec5-81af-80a86bf30734


</p>
</details>

---

# Changelog
:cl:
- add: Added two new physical traits - weakness and lightweight