### PR TITLE
Prize Ball Crate

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
@@ -282,7 +282,7 @@
       - id: CrayonBox
         prob: 0.80
         orGroup: Prize
-      - id: BasePetRock
+      - id: PetRock
         prob: 0.80
         orGroup: Prize
       # Uncommon

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: FunPrizeBall
+  icon:
+    sprite: Objects/Fun/prizeticket.rsi
+    state: icon
+  product: CratePrizeBall
+  cost: 5000
+  category: cargoproduct-category-name-fun
+  group: market

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -2,9 +2,7 @@
   id: FunPrizeBall
   icon:
     sprite: Objects/Fun/prizeticket.rsi
-    layers:
-      - state: prizeball
-    state: icon
+    state: prizeball
   product: CratePrizeBall
   cost: 5000
   category: cargoproduct-category-name-fun

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -2,6 +2,8 @@
   id: FunPrizeBall
   icon:
     sprite: Objects/Fun/prizeticket.rsi
+    layers:
+      - state: prizeball
     state: icon
   product: CratePrizeBall
   cost: 5000

--- a/Resources/Prototypes/Floof/Catalog/Fills/Crates/prizeball.yml
+++ b/Resources/Prototypes/Floof/Catalog/Fills/Crates/prizeball.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: CratePrizeBall
+  parent: CrateGenericSteel
+  name: prize ball crate
+  description: For when you really, really suck at arcade games, like gacha games, or if your station does not have a prize vendor.
+  components:
+  - type: StorageFill
+    contents:
+      - id: PrizeBall
+        amount: 10


### PR DESCRIPTION

# Description


Adds a prize ball crate as a replacement for the plushie crate. It's 10 for 5k. This is the equivalent of buying the bulk carnival plushies instead of going to the carnival. I hope you like gacha games!

---

# Changelog


:cl:
- add: Prize Ball Crates can now be ordered from the market
