### PR TITLE
Vampireal

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Systems;
+using Content.Server.Floofstation.Traits;
 using Content.Server.Traits.Assorted;
 using Content.Shared.Body.Prototypes;
 using Content.Shared.FixedPoint;
@@ -45,7 +46,7 @@ namespace Content.Server.Body.Components
         ///     List of metabolizer types that this organ is. ex. Human, Slime, Felinid, w/e.
         /// </summary>
         [DataField]
-        [Access(typeof(MetabolizerSystem), typeof(LiquorLifelineSystem), Other = AccessPermissions.ReadExecute)] // FIXME Friends
+        [Access(typeof(MetabolizerSystem), typeof(LiquorLifelineSystem), typeof(VampirismSystem), Other = AccessPermissions.ReadExecute)] // Floofstation
         public HashSet<ProtoId<MetabolizerTypePrototype>>? MetabolizerTypes = null;
 
         /// <summary>

--- a/Content.Server/Body/Components/StomachComponent.cs
+++ b/Content.Server/Body/Components/StomachComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Body.Systems;
+using Content.Server.Floofstation.Traits;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Reagent;
@@ -45,6 +46,7 @@ namespace Content.Server.Body.Components
         ///     A whitelist for what special-digestible-required foods this stomach is capable of eating.
         /// </summary>
         [DataField]
+        [Access(Other = AccessPermissions.ReadWriteExecute)] // Floofstation
         public EntityWhitelist? SpecialDigestible = null;
 
         /// <summary>

--- a/Content.Server/FloofStation/Traits/Components/VampirismComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/VampirismComponent.cs
@@ -15,9 +15,6 @@ public sealed partial class VampirismComponent : Component
     [DataField]
     public HashSet<ProtoId<MetabolizerTypePrototype>> MetabolizerPrototypes = new() { "Vampiric", "Animal" };
 
-    [DataField]
-    public List<MetabolismGroupEntry> AddedMetabolismGroups = new(), RemovedMetabolismGroups = new();
-
     /// <summary>
     ///     A whitelist for what special-digestible-required foods the vampire's stomach is capable of eating.
     /// </summary>

--- a/Content.Server/FloofStation/Traits/Components/VampirismComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/VampirismComponent.cs
@@ -1,0 +1,32 @@
+using Content.Server.Body.Components;
+using Content.Shared.Body.Prototypes;
+using Content.Shared.Whitelist;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Floofstation.Traits.Components;
+
+/// <summary>
+///     Enables the mob to suck blood from other mobs to replenish its own saturation.
+///     Must be fully initialized before being added to a mob.
+/// </summary>
+[RegisterComponent]
+public sealed partial class VampirismComponent : Component
+{
+    [DataField]
+    public HashSet<ProtoId<MetabolizerTypePrototype>> MetabolizerPrototypes = new() { "Vampiric", "Animal" };
+
+    [DataField]
+    public List<MetabolismGroupEntry> AddedMetabolismGroups = new(), RemovedMetabolismGroups = new();
+
+    /// <summary>
+    ///     A whitelist for what special-digestible-required foods the vampire's stomach is capable of eating.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? SpecialDigestible = null;
+
+    [DataField]
+    public TimeSpan SuccDelay = TimeSpan.FromSeconds(1);
+
+    [DataField]
+    public float UnitsToSucc = 10;
+}

--- a/Content.Server/FloofStation/Traits/VampirismSystem.cs
+++ b/Content.Server/FloofStation/Traits/VampirismSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Body.Components;
 using Content.Server.Floofstation.Traits.Components;
 using Content.Server.Vampiric;
+using Content.Shared.Body.Components;
 using Content.Shared.Body.Systems;
 
 namespace Content.Server.Floofstation.Traits;
@@ -18,12 +19,9 @@ public sealed class VampirismSystem : EntitySystem
     {
         EnsureBloodSucker(ent);
 
-        Log.Info($"Init vampire: {ent.Owner}");
-
-        if (!_body.TryGetBodyOrganComponents<MetabolizerComponent>(ent, out var comps))
+        if (!TryComp<BodyComponent>(ent, out var body)
+		    || !_body.TryGetBodyOrganComponents<MetabolizerComponent>(ent, out var comps, body))
             return;
-
-        Log.Info($"Init vampire: {ent.Owner}");
 
         foreach (var (metabolizer, organ) in comps)
         {

--- a/Content.Server/FloofStation/Traits/VampirismSystem.cs
+++ b/Content.Server/FloofStation/Traits/VampirismSystem.cs
@@ -1,0 +1,53 @@
+using Content.Server.Body.Components;
+using Content.Server.Floofstation.Traits.Components;
+using Content.Server.Vampiric;
+using Content.Shared.Body.Systems;
+
+namespace Content.Server.Floofstation.Traits;
+
+public sealed class VampirismSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<VampirismComponent, MapInitEvent>(OnInitVampire);
+    }
+
+    private void OnInitVampire(Entity<VampirismComponent> ent, ref MapInitEvent args)
+    {
+        EnsureBloodSucker(ent);
+
+        Log.Info($"Init vampire: {ent.Owner}");
+
+        if (!_body.TryGetBodyOrganComponents<MetabolizerComponent>(ent, out var comps))
+            return;
+
+        Log.Info($"Init vampire: {ent.Owner}");
+
+        foreach (var (metabolizer, organ) in comps)
+        {
+            if (!TryComp<StomachComponent>(organ.Owner, out var stomach))
+                continue;
+
+            metabolizer.MetabolizerTypes = ent.Comp.MetabolizerPrototypes;
+
+            if (ent.Comp.SpecialDigestible is {} whitelist)
+                stomach.SpecialDigestible = whitelist;
+        }
+    }
+
+    private void EnsureBloodSucker(Entity<VampirismComponent> uid)
+    {
+        if (HasComp<BloodSuckerComponent>(uid))
+            return;
+
+        AddComp(uid, new BloodSuckerComponent
+        {
+            Delay = uid.Comp.SuccDelay,
+            InjectWhenSucc = false, // The code for it is deprecated, might wanna make it inject something when (if?) it gets reworked
+            UnitsToSucc = uid.Comp.UnitsToSucc,
+            WebRequired = false
+        });
+    }
+}

--- a/Resources/Locale/en-US/Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/Floof/traits/traits.ftl
@@ -1,7 +1,11 @@
 trait-name-Vampirism = Vampirism
 trait-description-Vampirism =
-    Whether through implantation, genetic modification, or evolution, you have a pair of hollow, sharp fangs used to drink iron-based blood from the beings that contain it.
+    Your body has evolved to be able to suck blood from beings that contain it and metabolize it into useful compounds.
     You cannot eat normal food, but drinking blood satiates your hunger and thirst, and also improves your health.
+
+trait-name-HollowFangs = Hollow fangs
+trait-description-HollowFangs =
+    Whether through implantation, genetic modification, or evolution, you have a pair of hollow, sharp fangs used to drink iron-based blood from the beings that contain it.
 
 trait-name-CumProducer = Cock
 trait-description-CumProducer = You have a schlong between your legs.

--- a/Resources/Locale/en-US/Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/Floof/traits/traits.ftl
@@ -1,5 +1,7 @@
 trait-name-Vampirism = Vampirism
-trait-description-Vampirism = Whether through implantation, genetic modification, or evolution, you have a pair of hollow, sharp fangs used to drink iron-based blood from the beings that contain it.
+trait-description-Vampirism =
+    Whether through implantation, genetic modification, or evolution, you have a pair of hollow, sharp fangs used to drink iron-based blood from the beings that contain it.
+    You cannot eat normal food, but drinking blood satiates your hunger and thirst, and also improves your health.
 
 trait-name-CumProducer = Cock
 trait-description-CumProducer = You have a schlong between your legs.

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -82,7 +82,7 @@
   - type: Stomach
   - type: Metabolizer
     maxReagents: 3
-    metabolizerPrototypes: [ Animal ]
+    metabolizerTypes: [ Animal ]
     groups:
     - id: Food
     - id: Drink

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -82,7 +82,7 @@
   - type: Stomach
   - type: Metabolizer
     maxReagents: 3
-    metabolizerTypes: [ Animal ]
+    metabolizerPrototypes: [ Animal ]
     groups:
     - id: Food
     - id: Drink

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -8,20 +8,19 @@
       jobs:
         - Borg
         - MedicalBorg
-    - !type:CharacterSpeciesRequirement # This will be removed once you can edit organs with traits
+    - !type:CharacterSpeciesRequirement
       inverted: true
       species:
-        - Moth
-        - Oni
-        - Diona
-        - SlimePerson
-        - Human
         - IPC
   components:
-  - type: BloodSucker
-    unitsToSucc: 10
-    injectWhenSucc: false
-    webRequired: false
+    - type: Vampirism
+      succDelay: 3
+      specialDigestible: # Vampires cannot eat food chat is that real
+        tags:
+        - IceCream
+        - Pill
+        - Crayon
+        - Paper
 
 - type: trait
   id: Weakness

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -12,6 +12,10 @@
       inverted: true
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - HollowFangs
   components:
     - type: Vampirism
       succDelay: 3
@@ -21,6 +25,30 @@
         - Pill
         - Crayon
         - Paper
+
+- type: trait
+  id: HollowFangs
+  category: Physical
+  points: -2
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - Borg
+    - MedicalBorg
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    - IPC
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - Vampirism
+  components:
+  - type: Vampirism
+    succDelay: 5
+    metabolizerPrototypes:
+    - Animal
 
 - type: trait
   id: Weakness

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Vampirism # You may port this to EE, you have my permission!
   category: Physical
-  points: -1
+  points: 3
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -51,6 +51,11 @@
         - !type:AdjustReagent
           reagent: UncookedAnimalProteins
           amount: 0.5
+          # Floofstation - prevent vampires from getting sick by drinking blood
+          conditions:
+          - !type:OrganType
+            type: Vampiric
+            shouldHave: false
     Medicine:
       effects:
       - !type:HealthChange

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -46,6 +46,12 @@
           type: Vampiric
         reagent: Omnizine
         amount: 0.2
+      # Floofstation - make vampires replenish their own blood by drinking blood
+      - !type:ModifyBloodLevel
+        amount: 0.3 # +0.6 units of blood for each unit drunk
+        conditions:
+        - !type:OrganType
+          type: Vampiric
     Food:
       effects:
         - !type:AdjustReagent

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -46,12 +46,6 @@
           type: Vampiric
         reagent: Omnizine
         amount: 0.2
-      # Floofstation - make vampires replenish their own blood by drinking blood
-      - !type:ModifyBloodLevel
-        amount: 0.3 # +0.6 units of blood for each unit drunk
-        conditions:
-        - !type:OrganType
-          type: Vampiric
     Food:
       effects:
         - !type:AdjustReagent


### PR DESCRIPTION
# Description
This revamps the vampirism trait:
- The trait now gives you vampiric metabolism, which means blood satiates your thirst and hunger, and slowly heals and replenishes your blood level.
- The trait now makes you unable to eat regular food (except for pills and ice cream), similarly to moth people, which means you *have* to drink blood to live.
- The trait is now considered negative, giving you 3 trait points.

To preserve the old behavior of just being able to drink blood, this also adds a new hollow fangs trait that does exactly what the old vampirism used to do.

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/eef53089-a887-45fd-ba94-e41e8f8cc650


![image](https://github.com/user-attachments/assets/9228eefe-f15a-4b9c-ae2a-7014e60cf68f)

![image](https://github.com/user-attachments/assets/40e5e8a9-375e-49e0-adf7-0d3a365ef0fb)

</p>
</details>

---

# Changelog
:cl:
- tweak: The vampirism trait now changes your body's metabolism to the vampiric type, making you unable to eat normal food and requiring you to drink blood to survive.
- add: A new "hollow fangs" trait has been added. It simply allows you to suck (and metabolize) blood, without the benefits and drawbacks of being a vampire.