### PR TITLE
Cryo Overhaul

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -54,14 +54,15 @@ namespace Content.Server.Body.Components
         /// </summary>
         [DataField]
         public bool RemoveEmpty = false;
-
         /// <summary>
-        ///     How many reagents can this metabolizer process at once?
+        ///     floof
+        /// 
+        ///     How many poisons can this metabolizer process at once?
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
-        [DataField("maxReagents")]
-        public int MaxReagentsProcessable = 3;
+        [DataField("maxPoisons")]
+        public int MaxPoisonsProcessable = 3;
 
         /// <summary>
         ///     A list of metabolism groups that this metabolizer will act on, in order of precedence.

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -142,7 +142,7 @@ namespace Content.Server.Body.Systems
             var list = solution.Contents.ToArray();
             _random.Shuffle(list);
 
-            int reagents = 0;
+            int poisons = 0; // floof modified
             foreach (var (reagent, quantity) in list)
             {
                 if (!_prototypeManager.TryIndex<ReagentPrototype>(reagent.Prototype, out var proto))
@@ -159,9 +159,10 @@ namespace Content.Server.Body.Systems
                     continue;
                 }
 
-                // we're done here entirely if this is true
-                if (reagents >= ent.Comp1.MaxReagentsProcessable)
-                    return;
+                // floof modified
+                // Already processed all poisons, skip to the next reagent.
+                if (poisons >= ent.Comp1.MaxPoisonsProcessable && proto.Metabolisms.ContainsKey("Poison"))
+                    continue;
 
 
                 // loop over all our groups and see which ones apply
@@ -223,8 +224,10 @@ namespace Content.Server.Body.Systems
                 {
                     solution.RemoveReagent(reagent, mostToRemove);
 
-                    // We have processed a reagant, so count it towards the cap
-                    reagents += 1;
+                    // floof modified
+                    // We have processed a poison, so count it towards the cap
+                    if (proto.Metabolisms.ContainsKey("Poison"))
+                        poisons++;
                 }
             }
 

--- a/Content.Server/Medical/CryoPodSystem.cs
+++ b/Content.Server/Medical/CryoPodSystem.cs
@@ -113,8 +113,14 @@ public sealed partial class CryoPodSystem : SharedCryoPodSystem
                 {
                     continue;
                 }
+                // floof
 
-                var solutionToInject = _solutionContainerSystem.SplitSolution(containerSolution.Value, cryoPod.BeakerTransferAmount);
+                // Filter out a fixed amount of each reagent from the cryo pod's beaker
+                var solutionToInject = _solutionContainerSystem.SplitSolutionReagentsEvenly(containerSolution.Value, cryoPod.BeakerTransferAmount);
+                //  for every .25 units used, .5 units per second are added to the body, making cryo-pod more efficient than injections
+                solutionToInject.ScaleSolution(cryoPod.PotencyMultiplier);
+
+                // End floof
                 _bloodstreamSystem.TryAddToChemicals(patient.Value, solutionToInject, bloodstream);
                 _reactiveSystem.DoEntityReaction(patient.Value, solutionToInject, ReactionMethod.Injection);
             }

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -585,10 +585,11 @@ namespace Content.Shared.Chemistry.Components
 
             return sol;
         }
-
         /// <summary>
-        /// Splits a solution without the specified reagent prototypes.
+        /// splits the solution taking the specified amount of reagents proportionally to their quantity.
         /// </summary>
+        /// <param name="toTake">The total amount of solution to remove and return.</param>
+        /// <returns>a new solution of equal proportions to the original solution</returns>
         public Solution SplitSolutionWithOnly(FixedPoint2 toTake, params string[] includedPrototypes)
         {
             // First remove the non-included prototypes
@@ -675,6 +676,59 @@ namespace Content.Shared.Chemistry.Components
             newSolution.ValidateSolution();
 
             return newSolution;
+        }
+
+        /// <summary>
+        /// floof
+        /// splits the solution taking up to the specified amount of each reagent from the solution.
+        /// If the solution has less of a reagent than the specified amount, it will take all of that reagent.
+        /// </summary>
+        /// <param name="toTakePer">How much of each reagent to take</param>
+        /// <returns>a new solution containing the reagents taken from the original solution</returns>
+        public Solution SplitSolutionReagentsEvenly(FixedPoint2 toTakePer)
+        {
+            var splitSolution = new Solution();
+
+            if (toTakePer <= FixedPoint2.Zero)
+                return splitSolution;
+            var reagentsCount = Contents.Count;
+            var reagentsToRemove = new List<ReagentQuantity>();
+            for (var i = 0; i < reagentsCount; i++)
+            {
+                var currentReagent = Contents[i];
+
+                if (currentReagent.Quantity <= FixedPoint2.Zero)
+                {
+                    reagentsToRemove.Add(currentReagent);
+                    continue;
+                }
+
+                if (currentReagent.Quantity <= toTakePer)
+                {
+                    splitSolution.AddReagent(currentReagent);
+                    reagentsToRemove.Add(currentReagent);
+                }
+                else
+                {
+                    splitSolution.AddReagent(currentReagent.Reagent, toTakePer);
+                    RemoveReagent(currentReagent.Reagent, toTakePer);
+                }
+            }
+
+            foreach (var reagent in reagentsToRemove)
+            {
+                RemoveReagent(reagent);
+            }
+            if (Volume == FixedPoint2.Zero)
+                RemoveAllSolution();
+
+            _heatCapacityDirty = true;
+            splitSolution._heatCapacityDirty = true;
+
+            ValidateSolution();
+            splitSolution.ValidateSolution();
+
+            return splitSolution;
         }
 
         /// <summary>

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -296,9 +296,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
 
     /// <summary>
     ///     Removes part of the solution in the container.
-    /// </summary>
-    /// <param name="targetUid"></param>
-    /// <param name="solutionHolder"></param>
+    /// </summary>    /// <param name="soln">The container to remove solution from.</param>
     /// <param name="quantity">the volume of solution to remove.</param>
     /// <returns>The solution that was removed.</returns>
     public Solution SplitSolution(Entity<SolutionComponent> soln, FixedPoint2 quantity)
@@ -307,6 +305,22 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
         var solution = comp.Solution;
 
         var splitSol = solution.SplitSolution(quantity);
+        UpdateChemicals(soln);
+        return splitSol;
+    }
+
+    /// <summary>
+    /// Splits a solution removing a specified amount of each reagent, if available.
+    /// </summary>
+    /// <param name="soln">The container to split the solution from.</param>
+    /// <param name="quantity">The amount of each reagent to split.</param>
+    /// <returns></returns>
+    public Solution SplitSolutionReagentsEvenly(Entity<SolutionComponent> soln, FixedPoint2 quantity)
+    {
+        var (uid, comp) = soln;
+        var solution = comp.Solution;
+
+        var splitSol = solution.SplitSolutionReagentsEvenly(quantity);
         UpdateChemicals(soln);
         return splitSol;
     }

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.Containers;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -34,11 +34,20 @@ public sealed partial class CryoPodComponent : Component
     public TimeSpan? NextInjectionTime;
 
     /// <summary>
-    /// How many units to transfer per tick from the beaker to the mob?
+    /// How many units of each reagent to transfer per tick from the beaker to the mob?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("beakerTransferAmount")]
-    public float BeakerTransferAmount = 1f;
+    public float BeakerTransferAmount = .25f;// floof: 1<0.25
+
+    /// <summary>
+    /// Frontier 
+    /// How potent (multiplier) the reagents are when transferred from the beaker to the mob.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("PotencyAmount")]
+    public float PotencyMultiplier = 2f;
+
 
     /// <summary>
     ///     Delay applied when inserting a mob in the pod.

--- a/Resources/Locale/en-US/Floof/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/Floof/reagents/meta/chemicals.ftl
@@ -1,0 +1,5 @@
+reagent-name-salicylicacid = salicylic acid
+reagent-desc-salicylicacid = A powdery substance used for dermatological treatments.
+
+reagent-name-formaldehyde = formaldehyde
+reagent-desc-formaldehyde = A yellowish substance used for peservation of tissue.

--- a/Resources/Locale/en-US/Floof/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/Floof/reagents/meta/medicine.ftl
@@ -1,0 +1,5 @@
+reagent-name-traumoxadone = traumoxadone
+reagent-desc-traumoxadone = A cryogenics chemical. Used to treat severe trauma via regeneration of the damaged tissue. Works regardless of the patient being alive or dead.  Product of Mystic Medical
+
+reagent-name-stelloxadone = stelloxadone
+reagent-desc-stelloxadone = A cryogenics chemical. Used to aggressively dissolve toxins from the body. Works regardless of the patient being alive or dead.  Product of Mystic Medical

--- a/Resources/Locale/en-US/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/reagents/meta/medicine.ftl
@@ -13,11 +13,13 @@ reagent-desc-arithrazine = A mildly unstable medication used for the most extrem
 reagent-name-bicaridine = bicaridine
 reagent-desc-bicaridine = An analgesic which is highly effective at treating brute damage. It's useful for stabilizing people who have been severely beaten, as well as treating less life-threatening injuries.
 
+# Floof: consistent cryogenics descriptors
 reagent-name-cryoxadone = cryoxadone
-reagent-desc-cryoxadone = Required for the proper function of cryogenics. Heals all standard types of damage, but only works in temperatures under 213K. It can treat and rejuvenate plants when applied in small doses.
+reagent-desc-cryoxadone = Required for the proper function of cryogenics. Useful in treating asphyxiation and bloodloss, but only works in temperatures under 213K. It can treat and rejuvenate plants when applied in small doses. Works regardless of the patient being alive or dead.
 
 reagent-name-doxarubixadone = doxarubixadone
-reagent-desc-doxarubixadone = A cryogenics chemical. Heals certain types of cellular damage done by Slimes and improper use of other chemicals.
+reagent-desc-doxarubixadone = A cryogenics chemical. Heals certain types of cellular damage done by Slimes and improper use of other chemicals. Works regardless of the patient being alive or dead.
+# End Floof
 
 reagent-name-dermaline = dermaline
 reagent-desc-dermaline = An advanced chemical that is more effective at treating burn damage than kelotane.

--- a/Resources/Prototypes/Floof/Reagents/chemicals.yml
+++ b/Resources/Prototypes/Floof/Reagents/chemicals.yml
@@ -1,0 +1,13 @@
+- type: reagent
+  id: SalicylicAcid
+  name: reagent-name-salicylicacid
+  desc: reagent-desc-salicylicacid
+  physicalDesc: reagent-physical-desc-powdery
+  color: "#EEEEEE"
+
+- type: reagent
+  id: Formaldehyde
+  name: reagent-name-formaldehyde
+  desc: reagent-desc-formaldehyde
+  physicalDesc: reagent-physical-desc-sickly
+  color: "#F26724"

--- a/Resources/Prototypes/Floof/Reagents/medicine.yml
+++ b/Resources/Prototypes/Floof/Reagents/medicine.yml
@@ -1,0 +1,47 @@
+- type: reagent
+  id : Traumoxadone
+  name: reagent-name-traumoxadone
+  group: Medicine
+  desc: reagent-desc-traumoxadone
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: medicine
+  color: "#880077"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 213.0
+        damage:
+          types:
+            Blunt: -2
+            Piercing: -2
+            Slash: -2
+            
+            
+- type: reagent
+  id : Stelloxadone
+  name: reagent-name-stelloxadone
+  group: Medicine
+  desc: reagent-desc-stelloxadone
+  physicalDesc: reagent-physical-desc-soothing
+  flavor: medicine
+  color: "#FFA861"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 213.0
+        damage:
+          types:
+            Poison: -6
+            Radiation: -3
+            Cellular: 1
+          groups:
+            Brute: 3
+            

--- a/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
@@ -13,3 +13,41 @@
       amount: 5
   products:
     Libidozenithizine: 5
+
+- type: reaction
+  id : SalicylicAcid
+  reactants:
+    Phenol:
+      amount: 1
+    Sodium:
+      amount: 1
+    Carbon:
+      amount: 1
+    Oxygen:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+  products:
+    SalicylicAcid: 3
+    
+- type: reaction
+  id : Formaldehyde
+  reactants:
+    Ethanol:
+      amount: 1
+    Oxygen:
+      amount: 1
+    Silver:
+      amount: 1
+  products:
+    Formaldehyde: 3
+    
+- type: reaction
+  id : Formaldehyde
+  reactants:
+    Vinegar:
+      amount: 2
+    Silver:
+      amount: 1
+  products:
+    Formaldehyde: 3

--- a/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Floof/Recipes/Reactions/chemicals.yml
@@ -33,18 +33,6 @@
 - type: reaction
   id : Formaldehyde
   reactants:
-    Ethanol:
-      amount: 1
-    Oxygen:
-      amount: 1
-    Silver:
-      amount: 1
-  products:
-    Formaldehyde: 3
-    
-- type: reaction
-  id : Formaldehyde
-  reactants:
     Vinegar:
       amount: 2
     Silver:

--- a/Resources/Prototypes/Floof/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Floof/Recipes/Reactions/medicine.yml
@@ -12,3 +12,29 @@
       amount: 1
   products:
       Philterex: 5
+
+- type: reaction
+  id: Traumoxadone
+  reactants:
+    Cryoxadone:
+      amount: 1
+    SalicylicAcid:
+      amount: 1
+    Lipozine:
+      amount: 1
+  products:
+    Traumoxadone: 2
+    
+- type: reaction
+  id: Stelloxadone
+  reactants:
+    Cryoxadone:
+      amount: 3
+    Stellibinin:
+      amount: 5
+    Arithrazine:
+      amount: 2
+  products:
+    Stelloxadone: 5
+    Water: 3
+    Fiber: 2

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -168,7 +168,7 @@
         - !type:ReagentThreshold
           min: 15
       - !type:Drunk
-
+      
 - type: reagent
   id: Cryoxadone
   name: reagent-name-cryoxadone
@@ -177,6 +177,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
+  worksOnTheDead: true # Floof 
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5
@@ -194,10 +195,12 @@
           damage:
           # todo scale with temp like SS13
             groups:
-              Airloss: -6
-              Brute: -4
-              Burn: -6
-              Toxin: -4
+              Airloss: -10 # Floof: -6<-10
+              # Brute: -4 # Floof
+              # Burn: -6 # Floof
+              # Toxin: -4 # Floof
+        - !type:ModifyBloodLevel # Floof
+          amount: 5 # Floof
 
 - type: reagent
   id: Doxarubixadone
@@ -207,6 +210,7 @@
   physicalDesc: reagent-physical-desc-bubbling
   flavor: medicine
   color: "#32cd32"
+  worksOnTheDead: true # Floof
   metabolisms:
     Medicine:
       effects:
@@ -216,7 +220,9 @@
             max: 213.0
           damage:
             types:
-             Cellular: -2
+             Cellular: -4 # Floof: -2<-4
+            groups: # Floof
+                Brute: 1 # Floof
 
 - type: reagent
   id: Dermaline
@@ -1191,4 +1197,5 @@
           types:
             Heat: -3.0
             Shock: -3.0
+            Cold: -3.0 # Floof 
             Caustic: -1.0

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -71,7 +71,7 @@
   reactants:
     Cryoxadone:
       amount: 1
-    UnstableMutagen:
+    Phalanximine: # Floof: 1 UnstableMutagen < 1 Phalanximine
       amount: 1
   products:
     Doxarubixadone: 2
@@ -552,7 +552,7 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine: 
+    Formaldehyde: 
       amount: 1
     Plasma:
       amount: 2

--- a/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
+++ b/Resources/ServerInfo/Guidebook/Medical/Cryogenics.xml
@@ -37,14 +37,20 @@ Not every network will look like this, but hopefully, it's enough to give you th
 An important thing to note, winter clothing (and hardsuits) will make cryogenic treatment less, or completely ineffective. Be sure to remove cold preventative clothing before placing people in the pod.
 
 ## Using the Pod
-Once things have been set up, you're going to require a specific medication, Cryoxadone. Cryoxadone heals all damage types when a patient is chilled, and can either be pre-adminsitered (with a pill), or loaded into the cell directly with a beaker. Do note, patients won't begin to heal until they've chilled to the appropriate temperature, it may be worthwhile to wait a bit before placing a beaker inside.
+Once things have been set up, you're going to require cryogenic medications (all listed below). They each provide healing when a patient is chilled, and should be loaded into the pod directly with a beaker. Do note, patients won't begin to heal until they've chilled to the appropriate temperature, it may be worthwhile to wait a bit before placing a beaker inside.
 
 ## Additional Information:
 
-The standard pressure for a gas pump is 100.325 kpa. Cryoxadone works at under 170K, but it is standard practice to set the freezer to 100K for faster freezing.
+The standard pressure for a gas pump is 100.325 kpa. Cryogenics medicines work at under 213K (150K for Opporozidone), but it is standard practice to set the freezer to 100K for faster freezing.
+
+Cryo pods separate out each reagent from the beaker in the pod, injecting a small, steady amount of each into the patient.  This allows for medicine to be administered twice as efficiently than with injection or oral administration.
 
 <GuideReagentEmbed Reagent="Cryoxadone"/>
+<GuideReagentEmbed Reagent="Traumoxadone"/>
+<GuideReagentEmbed Reagent="Aloxadone"/>
+<GuideReagentEmbed Reagent="Stelloxadone"/>
 <GuideReagentEmbed Reagent="Doxarubixadone"/>
-<GuideReagentEmbed Reagent="Dexalin"/>
+<GuideReagentEmbed Reagent="Necrosol"/>
+<GuideReagentEmbed Reagent="Opporozidone"/>
 
 </Document>


### PR DESCRIPTION
Description.
added 2 intermidiate chems
- SalicylicAcid
- Formaldehyde

added 2 Cryo Chems
-Traumoxadone (Brute Damages)
-Stelloxadone (Tox Damages)

modified existing cryo chems to be more viable yet still balanced improved efficiency of cryo chambers
- Cryox only heals blood loss and air loss damage on a body, now useable after death
- Alox now also heals cold damage
- Doxa now uses Phalanximine not UnstableMutagen works after death twice as effective
- Oppo now uses Formaldehyde not Cognizine

updated cryo guide book to show all cryo chems

modified body metabolism
- the body no longer only metabolizes 2 chems at once but all chems in the system
- restrictive logic still somewhat in tact to prevent poison power gaming max 3 toxins

modified cryopods
- cryopods now split chems and inject them independently rather than a mixed solution
- cryopods require 1/2 the amount of chems to do the same healing

:cl:
- add: new cryo chems
- tweak: old cryo chems
- fix: death
- remove: metabolism restrictions
