### PR TITLE
Leash Tweaks & Fixes

### DIFF
--- a/Content.Shared/Floofstation/Leash/Components/LeashComponent.cs
+++ b/Content.Shared/Floofstation/Leash/Components/LeashComponent.cs
@@ -47,27 +47,6 @@ public sealed partial class LeashComponent : Component
     public TimeSpan PullInterval = TimeSpan.FromSeconds(1.5f);
 
     /// <summary>
-    ///     How much damage each leash joint can sustain before it breaks.
-    /// </summary>
-    /// <remarks>Not currently implemented; needs to be reworked in order to work.</remarks>
-    [DataField, AutoNetworkedField]
-    public float BreakDamage = 20f;
-
-    /// <summary>
-    ///     How much damage each leash joint loses every <see cref="DamageInterval"/>.
-    /// </summary>
-    /// <remarks>Not currently implemented; needs to be reworked in order to work.</remarks>
-    [DataField, AutoNetworkedField]
-    public float JointRepairDamage = 1f;
-
-    /// <summary>
-    ///     Interval at which damage is calculated for each joint.
-    /// </summary>
-    /// <remarks>Not currently implemented; needs to be reworked in order to work.</remarks>
-    [DataField, AutoNetworkedField]
-    public TimeSpan DamageInterval = TimeSpan.FromMilliseconds(200);
-
-    /// <summary>
     ///     List of all joints and their respective pulled entities created by this leash.
     /// </summary>
     [DataField, AutoNetworkedField]
@@ -87,12 +66,6 @@ public sealed partial class LeashComponent : Component
         /// </summary>
         [DataField]
         public NetEntity? LeashVisuals = null;
-
-        [DataField]
-        public float Damage = 0f;
-
-        [DataField]
-        public TimeSpan NextDamage = TimeSpan.Zero;
 
         public LeashData(string jointId, NetEntity pulled)
         {

--- a/Content.Shared/Floofstation/Leash/LeashSystem.cs
+++ b/Content.Shared/Floofstation/Leash/LeashSystem.cs
@@ -85,26 +85,9 @@ public sealed class LeashSystem : EntitySystem
                 var targetXForm = Transform(target.Value);
                 if (targetXForm.MapUid != sourceXForm.MapUid
                     || !sourceXForm.Coordinates.TryDistance(EntityManager, targetXForm.Coordinates, out var dst)
-                    || dst > leash.MaxDistance)
+                    || dst > leash.MaxDistance
+                )
                     RemoveLeash(target.Value, (leashEnt, leash));
-
-                // Calculate joint damage
-                if (_timing.CurTime < data.NextDamage
-                    || !TryComp<JointComponent>(target, out var jointComp)
-                    || !jointComp.GetJoints.TryGetValue(data.JointId, out var joint))
-                    continue;
-
-                // TODO reaction force always returns 0 and thus damage doesn't work
-                // TODO find another way to calculate how much force is being excerted to hold the two entities together
-                // var damage = joint.GetReactionForce(1 / (float) leash.DamageInterval.TotalSeconds).Length() - leash.JointRepairDamage;
-                // data.Damage = Math.Max(0f, data.Damage + damage);
-                // data.NextDamage = _timing.CurTime + leash.DamageInterval;
-                //
-                // if (damage >= leash.BreakDamage && !_net.IsClient)
-                // {
-                //     _popups.PopupPredicted(Loc.GetString("leash-snap-popup", ("leash", leashEnt)), target, null, PopupType.SmallCaution);
-                //     RemoveLeash(target, (leashEnt, leash), true);
-                // }
             }
         }
 
@@ -287,6 +270,7 @@ public sealed class LeashSystem : EntitySystem
         joint.MaxLength = leash.Comp.Length;
         joint.Stiffness = 1f;
         joint.CollideConnected = true; // This is just for performance reasons and doesn't actually make mobs collide.
+        joint.Damping = 1f;
 
         return joint;
     }

--- a/Content.Shared/Floofstation/Leash/LeashSystem.cs
+++ b/Content.Shared/Floofstation/Leash/LeashSystem.cs
@@ -175,6 +175,7 @@ public sealed class LeashSystem : EntitySystem
         // If the entity still has a leashed comp, and is on the same map, and is within the max distance of the leash
         // Then the leash was likely broken due to some weird unforeseen fucking robust toolbox magic. We can try to recreate it.
         // This is hella unsafe to do. It will crash in debug builds under certain conditions. Luckily, release builds are safe.
+        RemoveLeash(ent!, (puller, leash), false);
         DoLeash((ent.Comp.Anchor.Value, anchor), (puller, leash), ent);
     }
 

--- a/Content.Shared/Floofstation/Leash/LeashSystem.cs
+++ b/Content.Shared/Floofstation/Leash/LeashSystem.cs
@@ -41,9 +41,8 @@ public sealed class LeashSystem : EntitySystem
         UpdatesBefore.Add(typeof(SharedPhysicsSystem));
 
         SubscribeLocalEvent<LeashAnchorComponent, BeingUnequippedAttemptEvent>(OnAnchorUnequipping);
-        SubscribeLocalEvent<LeashedComponent, ContainerGettingInsertedAttemptEvent>(OnLeashedInserting);
-        SubscribeLocalEvent<LeashComponent, JointRemovedEvent>(OnJointRemoved);
         SubscribeLocalEvent<LeashAnchorComponent, GetVerbsEvent<EquipmentVerb>>(OnGetEquipmentVerbs);
+        SubscribeLocalEvent<LeashedComponent, JointRemovedEvent>(OnJointRemoved, after: [typeof(SharedJointSystem)]);
         SubscribeLocalEvent<LeashedComponent, GetVerbsEvent<InteractionVerb>>(OnGetLeashedVerbs);
 
         SubscribeLocalEvent<LeashAnchorComponent, LeashAttachDoAfterEvent>(OnAttachDoAfter);
@@ -109,34 +108,6 @@ public sealed class LeashSystem : EntitySystem
             args.Cancel();
     }
 
-    private void OnLeashedInserting(Entity<LeashedComponent> ent, ref ContainerGettingInsertedAttemptEvent args)
-    {
-        // Prevent the entity from entering crates and the like because that would instantly break all joints on it, including the leash
-        if (_timing.ApplyingState
-            || !Exists(ent.Comp.Puller)
-            || !Exists(ent.Comp.Anchor)
-            || !TryComp<LeashComponent>(ent.Comp.Puller, out var leashPuller)
-            || !TryComp<LeashAnchorComponent>(ent.Comp.Anchor, out var leashAnchor))
-            return;
-
-        args.Cancel();
-        // This is hella unsafe to do, but we recreate the joint because dumb storage system removes it before raising the event.
-        // We have to pray that OnJointRemoved already was called and that it deferred the removal of everything that used to exist
-        // I HATE STORAGE
-        DoLeash((ent.Comp.Anchor.Value, leashAnchor), (ent.Comp.Puller.Value, leashPuller), ent);
-    }
-
-    private void OnJointRemoved(Entity<LeashComponent> ent, ref JointRemovedEvent args)
-    {
-        var id = args.Joint.ID;
-        if (!ent.Comp.Leashed.TryFirstOrDefault(it => it.JointId == id, out var data)
-            || !TryGetEntity(data.Pulled, out var leashedEnt)
-            || !TryComp<LeashedComponent>(leashedEnt, out var leashed))
-            return;
-
-        RemoveLeash((leashedEnt.Value, leashed), ent!, false);
-    }
-
     private void OnGetEquipmentVerbs(Entity<LeashAnchorComponent> ent, ref GetVerbsEvent<EquipmentVerb> args)
     {
         if (!args.CanAccess
@@ -186,6 +157,25 @@ public sealed class LeashSystem : EntitySystem
             Text = Loc.GetString("verb-unleash-text"),
             Act = () => TryUnleash(ent!, (leash, leashComp), user)
         });
+    }
+
+    private void OnJointRemoved(Entity<LeashedComponent> ent, ref JointRemovedEvent args)
+    {
+        var id = args.Joint.ID;
+        if (_timing.ApplyingState
+            || ent.Comp.LifeStage >= ComponentLifeStage.Removing
+            || ent.Comp.Puller is not { } puller
+            || !TryComp<LeashAnchorComponent>(ent.Comp.Anchor, out var anchor)
+            || !TryComp<LeashComponent>(puller, out var leash)
+            || !Transform(ent).Coordinates.TryDistance(EntityManager, Transform(puller).Coordinates, out var dst)
+            || dst > leash.MaxDistance
+           )
+            return;
+
+        // If the entity still has a leashed comp, and is on the same map, and is within the max distance of the leash
+        // Then the leash was likely broken due to some weird unforeseen fucking robust toolbox magic. We can try to recreate it.
+        // This is hella unsafe to do. It will crash in debug builds under certain conditions. Luckily, release builds are safe.
+        DoLeash((ent.Comp.Anchor.Value, anchor), (puller, leash), ent);
     }
 
     private void OnAttachDoAfter(Entity<LeashAnchorComponent> ent, ref LeashAttachDoAfterEvent args)

--- a/Content.Shared/Floofstation/Leash/LeashSystem.cs
+++ b/Content.Shared/Floofstation/Leash/LeashSystem.cs
@@ -73,6 +73,14 @@ public sealed class LeashSystem : EntitySystem
                 if (data.Pulled == NetEntity.Invalid || !TryGetEntity(data.Pulled, out var target))
                     continue;
 
+                // Client side only: set max distance to infinity to prevent the client from ever predicting leashes.
+                if (_net.IsClient
+                    && TryComp<JointComponent>(target, out var jointComp)
+                    && jointComp.GetJoints.TryGetValue(data.JointId, out var joint)
+                    && joint is DistanceJoint distanceJoint
+                )
+                    distanceJoint.MaxLength = float.MaxValue;
+
                 // Break each leash joint whose entities are on different maps or are too far apart
                 var targetXForm = Transform(target.Value);
                 if (targetXForm.MapUid != sourceXForm.MapUid

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -114,6 +114,7 @@
     - GalacticCommon
     - RobotTalk
   - type: PsionicInsulation
+  - type: LeashAnchor # Floofstation
 
 - type: entity
   parent: MobSiliconBase

--- a/Resources/Prototypes/Floof/Entities/Objects/Tools/leash.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Tools/leash.yml
@@ -2,7 +2,7 @@
   id: BaseLeash
   parent: BaseItem
   name: leash
-  description: Helps keep your animals close to you, as well as your friends. Attach to supported object or clothing (such as collars) to use. You can pull attached entities while holding the leash.
+  description: Helps keep your animals or friends close to you. Attach to supported objects or clothing (such as collars) to use. You can pull attached entities while holding the leash.
   noSpawn: true
   components:
   - type: Sprite
@@ -10,6 +10,7 @@
     layers:
     - state: icon
   - type: Leash
+    pullInterval: 0.75
     leashSprite:
       sprite: Floof/Objects/Tools/leash-rope.rsi
       state: rope
@@ -19,9 +20,10 @@
   parent: BaseLeash
   components:
   - type: Leash
-    length: 3.5
-    attachDelay: 4.5 # Gotta be at least as high as cuffs or antags may abuse it
-    detachDelay: 3
+    length: 3
+    maxDistance: 6
+    attachDelay: 4
+    detachDelay: 4
     selfDetachDelay: 10
 
 - type: entity
@@ -31,6 +33,7 @@
   components:
   - type: Leash
     length: 1.5
+    maxDistance: 3
     attachDelay: 4.5
     detachDelay: 3
     selfDetachDelay: 10
@@ -54,6 +57,7 @@
   suffix: DEBUG, DO NOT MAP
   components:
   - type: Leash
+    maxDistance: 100
     maxJoints: 25
     attachDelay: 0
     detachDelay: 10000 # will still be instant for admin ghosts or whatever with instant doafters tag


### PR DESCRIPTION
# Description
This:
- Effectively disables client-side prediction for leash joints (by setting their maximum distance to +inf on the client side), thus fixing the visual glitches happening client-side  when you are dragged via a leash.
- Makes it so that leash joints are re-created if they are broken illegally (mostly by the ss14 physics engine when an entity enters a container or such), which allows leashed entities to be in containers and more, as well as preserves leashes during FTL.
- Tweaks some parameters of the existing leashes (normal leash length reduced from 3.5m to 3m, maxDistance was adjusted on all leashes to be ~double of their lengths)
- Adds leash anchors to bots (medibot, janibot, mimebot, two clownbots), for obvious reasons.
- Removes some redundant code.


<!-- TODO media?

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>
-->

---

# Changelog
:cl:
- add: You can now leash janibots, medibots, and more.
- fix: Leashes no longer cause broken client-side behavior, and no longer break during FTL.
