### PR TITLE
Make R&D Servers More Common

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/techboard.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/techboard.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: RandomBoard
   name: random board spawner
   parent: MarkerBase
@@ -27,10 +27,11 @@
     - WeaponCapacitorRechargerCircuitboard # Delta V - Add additional boards
     - StationMapCircuitboard # Delta V - Add additional boards
     - DeepFryerMachineCircuitboard # Delta V - Add additional boards
-    chance: 0.95
+    - ResearchAndDevelopmentServerMachineCircuitboard # Floof - Increase chance for R&D Server Boards
+    chance: 0.9
     rarePrototypes:
     - CommsComputerCircuitboard
-    #- ShuttleConsoleCircuitboard # Delta V - Remove shuttle boards
+    - ShuttleConsoleCircuitboard # Floof - Added Shuttle boards back
     - ComputerMassMediaCircuitboard
     - AutolatheMachineCircuitboard
     - ProtolatheMachineCircuitboard
@@ -38,7 +39,6 @@
     - PortableGeneratorSuperPacmanMachineCircuitboard # Delta V - Add additional boards
     - PortableGeneratorJrPacmanMachineCircuitboard # Delta V - Add additional boards
     - MedicalTechFabCircuitboard # Delta V - Add additional boards
-    - ResearchAndDevelopmentServerMachineCircuitboard # Delta V - Add additional boards
     - UniformPrinterMachineCircuitboard # Delta V - Add additional boards
     - ArtifactAnalyzerMachineCircuitboard # Delta V - Add additional boards
-    rareChance: 0.05
+    rareChance: 0.1


### PR DESCRIPTION
# Description

This PR attempts to make R&D Servers more common to alleviate issues with Epi. It ALSO adds back shuttle boards to the tech board loot pool.
This reduces the amount of dice rolls for R&D servers by one, hopefully making it easier to find servers for epi whilst I work on reworking the servers overall.

---

# Changelog

:cl:
- add: Shuttle Console Boards added to the Tech Board loot pool.
- tweak: R&D Server boards are now common finds.
