### PR TITLE
Another Leash Fix

### DIFF
--- a/Content.Shared/Floofstation/Leash/Components/LeashComponent.cs
+++ b/Content.Shared/Floofstation/Leash/Components/LeashComponent.cs
@@ -55,8 +55,12 @@ public sealed partial class LeashComponent : Component
     [DataDefinition, Serializable, NetSerializable]
     public sealed partial class LeashData
     {
+        /// <summary>
+        ///     Id of the joint created by this leash. May be null if this leash does not currently create a joint
+        ///     (e.g. because it's attached to the same entity who holds it)
+        /// </summary>
         [DataField]
-        public string JointId = string.Empty;
+        public string? JointId = null;
 
         [DataField]
         public NetEntity Pulled = NetEntity.Invalid;
@@ -67,7 +71,7 @@ public sealed partial class LeashComponent : Component
         [DataField]
         public NetEntity? LeashVisuals = null;
 
-        public LeashData(string jointId, NetEntity pulled)
+        public LeashData(string? jointId, NetEntity pulled)
         {
             JointId = jointId;
             Pulled = pulled;


### PR DESCRIPTION
# Description
So uhhh the last fix introduced a severe bug that caused FTL to fail if the FTLing shuttle contained an entity who had a leash attached to themselves in their inventory (sorry :sob:). This reworks the system to fix that and more bugs.

Leash joints can now be created/disposed of dynamically throughout the lifespan of a leash, without forcing the removal of the latter. This is used to prevent the physics engine from creating a joint that would connect an entity with itself (which is exactly what happens when you put a leash attached to yourself in your inventory.

This also indirectly fixes the issue with leashes breaking when put in the inventory of the leashed person, and allows a person to attach a leash to themselves, and ensures that leashes break when going through portals, unless the destination portal is close enough.

# Media
<details>

https://github.com/user-attachments/assets/d199b84e-2e42-4be7-b99e-bf3440190867

</details>

# Changelog
:cl:
- fix: Fixed several major issues with leashes. Again.
