### PR TITLE
Silly Loadouts

### DIFF
--- a/Resources/Locale/en-US/Floof/loadouts/categories.ftl
+++ b/Resources/Locale/en-US/Floof/loadouts/categories.ftl
@@ -1,0 +1,1 @@
+loadout-category-ItemsLewd = Lewd

--- a/Resources/Locale/en-US/Floof/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/Floof/loadouts/itemgroups.ftl
@@ -6,3 +6,5 @@ character-item-group-LoadoutNeck2 = Civilian Neckwear
 character-item-group-LoadoutOuter2 = Civilian Outerwear
 character-item-group-LoadoutShoes2 = Civilian Shoes
 character-item-group-LoadoutUniformsCivilian2 = Civilian Uniforms
+character-item-group-LoadoutFun = Fun
+character-item-group-LoadoutLewd = Lewd

--- a/Resources/Prototypes/Floof/CharacterItemGroups/funGroup.yml
+++ b/Resources/Prototypes/Floof/CharacterItemGroups/funGroup.yml
@@ -1,0 +1,46 @@
+- type: characterItemGroup
+  id: LoadoutFun
+  items:
+    - type: loadout
+      id: LoadoutItemLeashBasic
+    - type: loadout
+      id: LoadoutItemLeashShort
+
+# If you are ever going to add more: open regex101; in list mode, find "id: (.+)", replace with "- type: loadout\n  id: $1\n", paste the result here
+- type: characterItemGroup
+  id: LoadoutLewd
+  items:
+  - type: loadout
+    id: LoadoutItemLewdWand
+  - type: loadout
+    id: LoadoutItemLewdVibeGreen
+  - type: loadout
+    id: LoadoutItemLewdVibeTeal
+  - type: loadout
+    id: LoadoutItemLewdVibePink
+  - type: loadout
+    id: LoadoutItemLewdVibeRed
+  - type: loadout
+    id: LoadoutItemLewdVibeYellow
+  - type: loadout
+    id: LoadoutItemLewdFleshlightGreen
+  - type: loadout
+    id: LoadoutItemLewdFleshlightTeal
+  - type: loadout
+    id: LoadoutItemLewdFleshlightPink
+  - type: loadout
+    id: LoadoutItemLewdFleshlightRed
+  - type: loadout
+    id: LoadoutItemLewdFleshlightYellow
+  - type: loadout
+    id: LoadoutItemWhipPink
+  - type: loadout
+    id: LoadoutItemWhipTeal
+  - type: loadout
+    id: LoadoutItemWhipPinkCrotch
+  - type: loadout
+    id: LoadoutItemWhipTealCrotch
+  - type: loadout
+    id: LoadoutItemSpankPinkPaddle
+  - type: loadout
+    id: LoadoutItemSpankTealPaddle

--- a/Resources/Prototypes/Floof/Entities/Objects/Tools/leash.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Tools/leash.yml
@@ -26,6 +26,7 @@
     detachDelay: 4
     selfDetachDelay: 10
 
+# TODO this should be named LeashShort...
 - type: entity
   id: ShortLeash
   parent: BaseLeash

--- a/Resources/Prototypes/Floof/Loadouts/Categories/categories.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Categories/categories.yml
@@ -1,0 +1,4 @@
+# TODO make this a subcategory of items when EE splits items into subcategories
+- type: loadoutCategory
+  id: ItemsLewd
+  root: true

--- a/Resources/Prototypes/Floof/Loadouts/items.yml
+++ b/Resources/Prototypes/Floof/Loadouts/items.yml
@@ -11,3 +11,34 @@
   cost: 0
   items:
     - ClothingBeltSuspenders
+
+- type: loadout
+  id: LoadoutItemRemoteSignaller
+  category: Items
+  cost: 1
+  items:
+    - RemoteSignaller
+
+# Leashes
+- type: loadout
+  id: LoadoutItemLeashBasic
+  category: Items
+  cost: 2
+  exclusive: true
+  items:
+  - LeashBasic
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutFun
+
+- type: loadout
+  id: LoadoutItemLeashShort
+  category: Items
+  cost: 2
+  exclusive: true
+  items:
+  - ShortLeash
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutFun
+

--- a/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
+++ b/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
@@ -44,7 +44,7 @@
   - LewdVibePink
   requirements:
   - !type:CharacterItemGroupRequirement
-    group: LoadoutFun
+    group: LoadoutLewd
 
 - type: loadout
   id: LoadoutItemLewdVibeRed

--- a/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
+++ b/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
@@ -72,7 +72,7 @@
 - type: loadout
   id: LoadoutItemLewdFleshlightGreen
   category: ItemsLewd
-  cost: 0
+  cost: 2
   items:
   - LewdFleshlightGreen
   requirements:

--- a/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
+++ b/Resources/Prototypes/Floof/Loadouts/itemsLewd.yml
@@ -1,0 +1,181 @@
+# Note: only explicitly lewd items go into this category.
+# Items with ambiguous uses like leashes should go into Items
+
+# Wands
+- type: loadout
+  id: LoadoutItemLewdWand
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdWand
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdVibeGreen
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdVibeGreen
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdVibeTeal
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdVibeTeal
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdVibePink
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdVibePink
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutFun
+
+- type: loadout
+  id: LoadoutItemLewdVibeRed
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdVibeRed
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdVibeYellow
+  category: ItemsLewd
+  cost: 2
+  exclusive: true
+  items:
+  - LewdVibeYellow
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+# Fleshlights
+- type: loadout
+  id: LoadoutItemLewdFleshlightGreen
+  category: ItemsLewd
+  cost: 0
+  items:
+  - LewdFleshlightGreen
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdFleshlightTeal
+  category: ItemsLewd
+  cost: 2
+  items:
+  - LewdFleshlightTeal
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdFleshlightPink
+  category: ItemsLewd
+  cost: 2
+  items:
+  - LewdFleshlightPink
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdFleshlightRed
+  category: ItemsLewd
+  cost: 2
+  items:
+  - LewdFleshlightRed
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemLewdFleshlightYellow
+  category: ItemsLewd
+  cost: 2
+  items:
+  - LewdFleshlightYellow
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+# Whips
+- type: loadout
+  id: LoadoutItemWhipPink
+  category: ItemsLewd
+  cost: 2
+  items:
+  - WhipPink
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemWhipTeal
+  category: ItemsLewd
+  cost: 2
+  items:
+  - WhipTeal
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemWhipPinkCrotch
+  category: ItemsLewd
+  cost: 2
+  items:
+  - WhipPinkCrotch
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemWhipTealCrotch
+  category: ItemsLewd
+  cost: 2
+  items:
+  - WhipTealCrotch
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemSpankPinkPaddle
+  category: ItemsLewd
+  cost: 2
+  items:
+  - SpankPinkPaddle
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd
+
+- type: loadout
+  id: LoadoutItemSpankTealPaddle
+  category: ItemsLewd
+  cost: 2
+  items:
+  - SpankTealPaddle
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutLewd

--- a/Resources/Prototypes/Floof/Loadouts/neck.yml
+++ b/Resources/Prototypes/Floof/Loadouts/neck.yml
@@ -53,3 +53,14 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutNeck2
+
+- type: loadout
+  id: LoadoutItemsNeckShockCollar
+  category: Neck
+  cost: 1
+  exclusive: true
+  items:
+    - ShockCollar
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutNeck2


### PR DESCRIPTION
# Description
- Adds two leashes and a remote signaler to the Items loadout category
- Adds a shock collar to the Neck loadout category
- Adds a new Lewd loadout category, containing all lewd items featured by floof (it is going to be made a subcategory of Items after EE splits Items into separate subcategories [just a week away])

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/1c571a6b-1a0a-4437-a356-fef4d9c0707f)
![image](https://github.com/user-attachments/assets/f3ac5b94-8702-4361-a8fb-5aa9c072bd21)
![image](https://github.com/user-attachments/assets/853b49fa-a6d4-424c-b326-7537527dac0c)

</p>
</details>

---

# Changelog
:cl:
- add: Loadouts have been expanded with leashes, remote signalers, shock collars, and a wide variety of lewd items.