### PR TITLE
Fix Disposal Pipes Ejection

### DIFF
--- a/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
+++ b/Content.Server/Disposal/Unit/EntitySystems/DisposableSystem.cs
@@ -136,9 +136,9 @@ namespace Content.Server.Disposal.Unit.EntitySystems
                 {
                     _xformSystem.AttachToGridOrMap(entity, xform);
 
-                    if (holder.PreviousDirection != Direction.Invalid && _xformQuery.TryGetComponent(xform.ParentUid, out var parentXform))
+                    if (holder.PreviousDirection != Direction.Invalid && gridUid != null && _xformQuery.TryGetComponent(gridUid, out var parentXform))
                     {
-                        var direction = holder.PreviousDirection.ToAngle();
+                        var direction = holder.CurrentDirection.ToAngle();
                         direction += _xformSystem.GetWorldRotation(parentXform);
                         _throwing.TryThrow(entity, direction.ToWorldVec() * 3f, 10f);
                     }


### PR DESCRIPTION
# Description

This PR fixes an issue with disposal pipes that lead into space. The ejection would use the transform of the map instead of the one from the grid and throw into the wrong direction. 
Another issue this fixes is with disposal bends which would take direction from a previous pipe instead of the current one.

# Changelog


:cl:
- fix: Fix the disposal pipe ejection to space and after pipe bends.
