### PR TITLE
Fixes Leporazine Temperature Shock

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -494,12 +494,12 @@
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          max: 293.15
+          max: 288.15
         amount: 100000 # thermal energy, not temperature!
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          min: 293.15
+          min: 298.15
         amount: -10000
       - !type:PopupMessage
         type: Local

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -494,12 +494,12 @@
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          max: 288.15
+          max: 288.15 # Floof
         amount: 100000 # thermal energy, not temperature!
       - !type:AdjustTemperature
         conditions:
         - !type:Temperature
-          min: 298.15
+          min: 298.15 # Floof
         amount: -10000
       - !type:PopupMessage
         type: Local


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a 10 degree buffer to leporazine's temperature effects so it doesn't wildly heat and cool you down in a loop.

Leporazine is a drug meant for stabilization of a body's temperature, but it has a tendency to heat someone way higher, and when cooling the body, it would trigger the heating effect of the chemical again, looping until the chemicals effect ends, where it's likely that you're left on a high temperature. Adding this buffer allows you to stay around 298k temp without being shocked all the way to 344k constantly every time you are cooled back down from lepo.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Tested Lepo in-game
---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Xavier
- tweak: Lepo now has a 10 degree buffer between it's heating and cooling effect to prevent looping temperature shocks.
