### PR TITLE
Reducing Antag Amount for Security Balance

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -147,7 +147,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
-      max: 12
+      max: 6 # Floof - Balance around Security Pop
       playerRatio: 10
       lateJoinAdditional: true
       mindComponents:


### PR DESCRIPTION
# Description

Reduces the max amount of traitors that can spawn in a round.

---

# Changelog

:cl:
- tweak: Reduced the max amount of traitors in a shift.
