### PR TITLE
Fix ethereal.swsl not compiling in Compatibility Mode

### DIFF
--- a/Resources/Textures/Shaders/ethereal.swsl
+++ b/Resources/Textures/Shaders/ethereal.swsl
@@ -64,7 +64,7 @@ void fragment() {
 
     highp vec4 background = zTextureSpec(SCREEN_TEXTURE, ( FRAGCOORD.xy + vec2(w) ) * SCREEN_PIXEL_SIZE );
     highp vec3 hsvBg = rgb2hsv(background.rgb);
-    hsvBg.x *= -1;
+    hsvBg.x *= -1.0;
     background.rgb = hsv2rgb(hsvBg);
 
     color.xyz = mix(background.xyz, color.xyz, 0.75);

--- a/Resources/Textures/Shaders/ethereal.swsl
+++ b/Resources/Textures/Shaders/ethereal.swsl
@@ -60,7 +60,7 @@ void fragment() {
     // visualize distortion via:
     // COLOR = vec4(w,w,w,1.0);
 
-    w *= (3.0 + 1 * 2.0);
+    w *= 5.0;
 
     highp vec4 background = zTextureSpec(SCREEN_TEXTURE, ( FRAGCOORD.xy + vec2(w) ) * SCREEN_PIXEL_SIZE );
     highp vec3 hsvBg = rgb2hsv(background.rgb);


### PR DESCRIPTION
# Description

This should fix a regression introduced by #244 that prevents Floofstation from starting when Compatibility Mode is on in the launcher. The launch fail is due to type issues in the shader code. The PR does not change the meaning of the code, just fixes the type issues.

```
ERROR: 0:263: '*' : wrong operand types - no operation '*' exists that takes a left-hand operand of type 'const int' and a right operand of type 'const float' (or there is no acceptable conversion)
ERROR: 0:263: '+' : wrong operand types - no operation '+' exists that takes a left-hand operand of type 'const float' and a right operand of type 'const int' (or there is no acceptable conversion)
ERROR: 0:266: 'assign' : cannot convert from 'const int' to 'highp float'
```

# Changelog

:cl:
- fix: Fixed regression bug that prevents Floofstation from starting when Compatibility Mode is enabled in the SS14 Launcher
