### PR TITLE
X-Wave trait price has been lowered!

### DIFF
--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -200,7 +200,7 @@
 - type: trait
   id: PsionicInsulation
   category: Mental
-  points: -10 #Buy a significant disability to get this.
+  points: -4 #Buy a significant disability to get this... NOT
   components:
     - type: PsionicInsulation
     - type: Mindbroken


### PR DESCRIPTION
After seeing the overwhelming trait, i see no reason that a trait that inhibits you from doing anything with psionics (including be brought back to life!) should be 10 points.



# Description
After seeing the overwhelming trait Thee is no reason that a trait that inhibits you from doing anything with psionics (including be brought back to life!) should be 10 points.


# Changelog


:cl:

- tweak: Lowered X waveform misalignment trait
