### PR TITLE
Dark Portal Etheral Fix

### DIFF
--- a/Content.Server/Shadowkin/EtherealStunItemSystem.cs
+++ b/Content.Server/Shadowkin/EtherealStunItemSystem.cs
@@ -21,7 +21,8 @@ public sealed class EtherealStunItemSystem : EntitySystem
     {
         foreach (var ent in _lookup.GetEntitiesInRange(uid, component.Radius))
         {
-            if (!TryComp<EtherealComponent>(ent, out var ethereal))
+            if (!TryComp<EtherealComponent>(ent, out var ethereal)
+                || !ethereal.CanBeStunned)
                 continue;
 
             RemComp(ent, ethereal);

--- a/Content.Shared/Shadowkin/EtherealComponent.cs
+++ b/Content.Shared/Shadowkin/EtherealComponent.cs
@@ -23,6 +23,9 @@ public sealed partial class EtherealComponent : Component
     [DataField]
     public float DarkenRate = 0.084f;
 
+    [DataField]
+    public bool CanBeStunned = true;
+
     public List<EntityUid> DarkenedLights = new();
 
     public float DarkenAccumulator;

--- a/Resources/Prototypes/Floof/Entities/Structures/shadowkin.yml
+++ b/Resources/Prototypes/Floof/Entities/Structures/shadowkin.yml
@@ -75,6 +75,7 @@
     randomTeleport: false
   - type: DarkPortal
   - type: Ethereal
+    canBeStunned: false
 
 - type: entity
   name: Shadowkin Portal Spawner


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This is an fix for the Dark Portal being able to be yeeted into realspace when stunned by a bluespace crystal.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Dark Portals cannot be yeeted out of Ethereal by bluespace crystal anymore.
