### PR TITLE
Bionics Changes

### DIFF
--- a/Resources/Locale/en-US/Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/Floof/traits/traits.ftl
@@ -23,3 +23,15 @@ trait-name-Lightweight = Lightweight
 trait-description-Lightweight =
     You are naturally lighter than other representatives of your species. Your body density is reduced to 2/3 of normal.
     Note: [color=red]this will not display in the character creation menu, and will only have effect in-game.[/color]
+
+trait-name-CyberEyesWeld = Cyber-Eyes Welding System
+trait-description-CyberEyesWeld =
+    One or more of your eyes have been replaced with a highly modular mechanical ocular implant.
+    Their most basic functionality is to provide amelioration for weaknesses of the wearer's natural eyes,
+    but additionally these implants provide protection from intense, ultraviolet light.
+
+trait-name-CyberEyesFlash = Cyber-Eyes Flash-Protection System
+trait-description-CyberEyesFlash =
+    One or more of your eyes have been replaced with a highly modular mechanical ocular implant.
+    Their most basic functionality is to provide amelioration for weaknesses of the wearer's natural eyes,
+    but additionally these implants provide protection from bright flashes of light at a temperature of around 5500K.

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: Vampirism # You may port this to EE, you have my permission!
   category: Physical
-  points: -3 # MD - Change from "3" tp "-3" for balancing.
+  points: -1 # Floof - Change from "-3" tp "-1" for balancing.
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -94,3 +94,44 @@
     min: 100
     factor: 0.66 # still not as light as felinids due to different fixture size
 
+- type: trait
+  id: CyberEyesFlash
+  category: Physical
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Photophobia
+        - Blindness
+        - Nearsighted
+  componentRemovals:
+    - Flashable
+  components:
+    - type: FlashImmunity
+    - type: CyberEyes
+
+- type: trait
+  id: CyberEyesWeld
+  category: Physical
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Photophobia
+        - Blindness
+        - Nearsighted
+  components:
+    - type: EyeProtection
+    - type: CyberEyes

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -365,6 +365,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       species:
         - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
@@ -403,6 +404,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -426,10 +428,11 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
   components:
     - type: Prying
       speedModifier: 1
-      pryPowered: true
+      pryPowered: false # Floof - Balancing
 
 - type: trait
   id: PlateletFactories
@@ -440,6 +443,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -469,6 +473,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       species:
         - Human
@@ -478,27 +483,28 @@
     - type: Damageable
       damageModifierSet: DermalArmor
 
-- type: trait
-  id: CyberEyes
-  category: Physical
-  points: -8
-  requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Photophobia
-        - Blindness
-        - Nearsighted
-  componentRemovals:
-    - Flashable
-  components:
-    - type: FlashImmunity
-    - type: EyeProtection
-    - type: CyberEyes
+# - type: trait
+#   id: CyberEyes
+#   category: Physical
+#   points: -8
+#   requirements:
+#     - !type:CharacterJobRequirement
+#       inverted: true
+#       jobs:
+#         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+#         - Gladiator # Floof
+#     - !type:CharacterTraitRequirement
+#       inverted: true
+#       traits:
+#         - Photophobia
+#         - Blindness
+#         - Nearsighted
+#   componentRemovals:
+#     - Flashable
+#   components:
+#     - type: FlashImmunity
+#     - type: EyeProtection
+#     - type: CyberEyes
 
 - type: trait
   id: CyberEyesSecurity
@@ -509,12 +515,14 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
     - !type:CharacterTraitRequirement
       traits:
-        - CyberEyes
+        - CyberEyesWeld
+        - CyberEyesFlash 
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -533,9 +541,11 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterTraitRequirement
       traits:
-        - CyberEyes
+        - CyberEyesWeld
+        - CyberEyesFlash 
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -558,9 +568,11 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterTraitRequirement
       traits:
-        - CyberEyes
+        - CyberEyesWeld
+        - CyberEyesFlash 
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -581,12 +593,14 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
     - !type:CharacterTraitRequirement
       traits:
-        - CyberEyes
+        - CyberEyesWeld
+        - CyberEyesFlash 
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
# Description

This PR changes a few things related to the Bionics and the a simple change to the Vampirism trait.

The Cyber Arm can't open powered doors, and all Bionics are restricted from gladiators due to abuse of the trait we seen.

Cyber Eyes has been split into two separate traits:
"Welding" Cyber Eyes and "Flash" Cyber Eyes.

Both cost 6 points each and you can have one or both.
So one for 6, two for 12, then you can add the other Cyber-Eye systems. (Security, Medical, Diagnostic, Omni).

---

# Changelog

:cl:
- tweak: Vampirism lowered to -1 instead of -3
- tweak: Bionic Arm can't pry open powered doors
- tweak: Cyber Eyes are split into a "Welding" and "Flash" resistant versions.
- fix: Gladiators can no longer have Bionics, just like prisoners.