### PR TITLE
returning it to the Formaldehyde recipe for Oppo

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -561,8 +561,8 @@
   id: Opporozidone
   minTemp: 400 #Maybe if a method of reducing reagent temp exists one day, this could be -50
   reactants:
-    Cognizine:
-      amount: 1
+    Formaldehyde: #Floof
+      amount: 2
     Plasma:
       amount: 2
     Doxarubixadone:


### PR DESCRIPTION
Description.
upstream merge overwrote oppo recipe, this is returning it to the Formaldehyde recipe

---

:cl:
- fix: Changed the Opporizadone recipe to use Formaldehyde again.