### PR TITLE
add the 45 mag to the sec fab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -803,6 +803,8 @@
       - RiotShield
       - SpeedLoaderMagnum
       - SpeedLoaderMagnumEmpty
+      - MagazineMagnumEmpty #floof
+      - MagazineMagnum #floof
       - Stunbaton
       - TargetClown
       - ClothingOuterArmorPlateCarrier

--- a/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
@@ -1,0 +1,15 @@
+- type: latheRecipe
+  id: MagazineMagnumEmpty
+  result: MagazineMagnumEmpty
+  category: Ammo
+  completetime: 5
+  materials:
+    Steel: 50
+
+- type: latheRecipe
+  id: MagazineMagnum
+  result: MagazineMagnum
+  category: Ammo
+  completetime: 5
+  materials:
+     Steel: 55

--- a/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/security.yml
@@ -12,4 +12,4 @@
   category: Ammo
   completetime: 5
   materials:
-     Steel: 55
+     Steel: 210


### PR DESCRIPTION

# Description

as you know there isn't a way to get more 45 pistol mags for weapons like the N1984  this would allow sec to make empty and then regular mags for the pistol. since revolvers have speed loaders. and all the other guns (but like shotguns even then there is a mag shotgun) can be made why cant this one?
<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/767eaa04-ed57-43c1-b8ac-9c86722f9e02)

</p>
</details>

---

# Changelog

:cl:
- add: add .45 pistol mag to the Sec fab 