### PR TITLE
Swapped Hands HUD Fix

### DIFF
--- a/Resources/Prototypes/Body/Prototypes/ipc.yml
+++ b/Resources/Prototypes/Body/Prototypes/ipc.yml
@@ -12,10 +12,10 @@
     torso:
       part: TorsoIPC
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         brain: PositronicBrain
         heart: OrganIPCPump

--- a/Resources/Prototypes/Body/Prototypes/shadowkin.yml
+++ b/Resources/Prototypes/Body/Prototypes/shadowkin.yml
@@ -13,10 +13,10 @@
     torso:
       part: TorsoShadowkin
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         heart: OrganShadowkinHeart
         stomach: OrganShadowkinStomach

--- a/Resources/Prototypes/DeltaV/Body/Prototypes/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Body/Prototypes/harpy.yml
@@ -13,10 +13,10 @@
     torso:
       part: TorsoHarpy
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         heart: OrganHumanHeart
         lungs: OrganHarpyLungs

--- a/Resources/Prototypes/DeltaV/Body/Prototypes/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Body/Prototypes/vulpkanin.yml
@@ -19,10 +19,10 @@
         liver: OrganAnimalLiver
         kidneys: OrganHumanKidneys
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
     right arm:
       part: RightArmVulpkanin
       connections:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/arachne.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/arachne.yml
@@ -13,8 +13,8 @@
     torso:
       part: TorsoHuman
       connections:
-      - left arm
       - right arm
+      - left arm
       - thorax
       organs:
         heart: OrganHumanHeart

--- a/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Body/Prototypes/felinid.yml
@@ -13,10 +13,10 @@
     torso:
       part: TorsoHuman
       connections:
-      - left arm
       - right arm
-      - left leg
+      - left arm
       - right leg
+      - left leg
       organs:
         heart: OrganAnimalHeart
         lungs: OrganHumanLungs


### PR DESCRIPTION
# Description

Fixes that weird swapped hands visual bug on the HUD by swapping the actual hands on the species.

This should probably go to EE but I don't really know how to be honest xwx

---

<details><summary><h1>Media</h1></summary>
<p>

![harpy hands](https://cdn.discordapp.com/attachments/1255902264309321851/1299905110196883557/image.png?ex=671ee679&is=671d94f9&hm=68d9458c0828f36ef652b2c3762ad8425e307ad680ac24fdf9ae915dfe2b79bb&)

</p>
</details>

---

# Changelog

:cl:
- fix: fixed the backwards hand/description bug on the HUD for some species by swapping the hands :3
