### PR TITLE
Sydicate Uplink Fixes

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -402,7 +402,7 @@
   cost:
     Telecrystal: 40
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   conditions:
   - !type:StoreWhitelistCondition
     whitelist:
@@ -422,7 +422,7 @@
   cost:
     Telecrystal: 6
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   saleLimit: 1
 
 - type: listing
@@ -433,7 +433,7 @@
   cost:
     Telecrystal: 5
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   saleLimit: 1
 
 - type: listing
@@ -444,7 +444,7 @@
   cost:
     Telecrystal: 4
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   saleLimit: 1
 
 - type: listing
@@ -455,7 +455,7 @@
   cost:
     Telecrystal: 4
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   saleLimit: 1
 
 - type: listing
@@ -466,7 +466,7 @@
   cost:
     Telecrystal: 12
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   saleLimit: 1
 
 - type: listing
@@ -477,7 +477,7 @@
   cost:
     Telecrystal: 2
   categories:
-  - UplinkChemicals
+  - UplinkMisc
 
 - type: listing
   id: UplinkMedsBundle
@@ -487,7 +487,7 @@
   cost:
     Telecrystal: 20
   categories:
-  - UplinkChemicals
+  - UplinkMisc
   conditions:
     - !type:StoreWhitelistCondition
       whitelist:
@@ -509,7 +509,7 @@
   cost:
     Telecrystal: 3
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkStealthBox
@@ -519,7 +519,7 @@
   cost:
     Telecrystal: 5
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkChameleonProjector
@@ -529,7 +529,7 @@
   cost:
     Telecrystal: 7
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkCyberpen
@@ -539,7 +539,7 @@
   cost:
     Telecrystal: 1
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkDecoyDisk
@@ -549,7 +549,7 @@
   cost:
     Telecrystal: 1
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkUltrabrightLantern
@@ -559,7 +559,7 @@
   cost:
     Telecrystal: 2
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 - type: listing
   id: UplinkBribe
@@ -569,7 +569,7 @@
   cost:
     Telecrystal: 4
   categories:
-    - UplinkDeception
+    - UplinkUtility
 
 # - type: listing
 #   id: UplinkGigacancerScanner
@@ -579,7 +579,7 @@
 #   cost:
 #     Telecrystal: 5
 #   categories:
-#   - UplinkDeception
+#   - UplinkUtility
 
 - type: listing
   id: UplinkHolster
@@ -974,7 +974,7 @@
   cost:
     Telecrystal: 4
   categories:
-  - UplinkDeception
+  - UplinkUtility
 
 # Disruption
 
@@ -1778,3 +1778,4 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+    

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -8,6 +8,7 @@
   - UplinkMisc
   - UplinkBundles
   - UplinkTools
+  - UplinkUtility
   - UplinkImplants
   - UplinkJob
   - UplinkArmor

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -9,8 +9,6 @@
   - UplinkBundles
   - UplinkTools
   - UplinkDeception
-  - UplinkChemicals
-  - UplinkUtility
   - UplinkImplants
   - UplinkJob
   - UplinkArmor

--- a/Resources/Prototypes/Store/presets.yml
+++ b/Resources/Prototypes/Store/presets.yml
@@ -8,7 +8,6 @@
   - UplinkMisc
   - UplinkBundles
   - UplinkTools
-  - UplinkDeception
   - UplinkImplants
   - UplinkJob
   - UplinkArmor


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Moving all chems into Misc where they used to be and Deception into utility where they used to be as well. 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Syndicate uplink misc and ultility trees 
- remove: Removed unused categories that were not set up. 
