### PR TITLE
Prescription HUDs Fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
@@ -11,7 +11,7 @@
   - type: Construction
     graph: PrescriptionMedHud
     node: prescmedhud
-  - type: VisionCorrection
+  - type: VisionCorrection # Floof
   - type: ShowHealthBars
     damageContainers:
     - Biological
@@ -35,7 +35,7 @@
   - type: Construction
     graph: PrescriptionSecHud
     node: prescsechud
-  - type: VisionCorrection
+  - type: VisionCorrection # Floof
   - type: Tag
     tags:
     - HudSecurity

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
@@ -11,6 +11,7 @@
   - type: Construction
     graph: PrescriptionMedHud
     node: prescmedhud
+  - type: VisionCorrection
   - type: ShowHealthBars
     damageContainers:
     - Biological
@@ -34,6 +35,7 @@
   - type: Construction
     graph: PrescriptionSecHud
     node: prescsechud
+  - type: VisionCorrection
   - type: Tag
     tags:
     - HudSecurity


### PR DESCRIPTION
# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds the VisionCorrection component back to prescription HUDs (sechud/medhud)

---

# Changelog

:cl:
- fix: Prescription Lenses re-added to prescription MedHUDs and prescription SecHUDs.
