### PR TITLE
Bionic Changes and Fixes

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -365,6 +365,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       species:
         - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
@@ -403,6 +404,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -426,10 +428,11 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
   components:
     - type: Prying
       speedModifier: 1
-      pryPowered: true
+      pryPowered: false # Floof
 
 - type: trait
   id: PlateletFactories
@@ -440,6 +443,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -469,6 +473,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterSpeciesRequirement
       species:
         - Human
@@ -487,6 +492,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterTraitRequirement
       inverted: true
       traits:
@@ -509,6 +515,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterDepartmentRequirement
       departments:
         - Security
@@ -533,6 +540,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -558,6 +566,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -581,6 +590,7 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator # Floof
     - !type:CharacterDepartmentRequirement
       departments:
         - Security

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -422,7 +422,7 @@
 - type: trait
   id: BionicArm
   category: Physical
-  points: -8
+  points: -6 # Floof - since you can't get free JoL anymore
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -422,7 +422,7 @@
 - type: trait
   id: BionicArm
   category: Physical
-  points: -6 # Floof - since you can't get free JoL anymore
+  points: -3 # Floof - since you can't get free JoL anymore
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
# Description

Makes it so the bionic arm can't open powered doors.
Gladiators can't have bionics.

---

# Changelog

:cl:
- fix: Gladiators can no longer have bionics.
- tweak: Bionic arm cannot opened powered doors. Cost reduced to 6 instead of 8.

