### PR TITLE
Herbals Don't Contain Nicotine

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -77,9 +77,11 @@
       smokable:
         maxVol: 40
         reagents:
-          - ReagentId: Nicotine
-            Quantity: 10
-          - ReagentId: Omnizine
+          - ReagentId: Iron # Floof - Herbals aren't nicotine
+            Quantity: 5
+          - ReagentId: Omnizine # Floof - Herbals aren't nicotine
+            Quantity: 5
+          - ReagentId: Dylovene # Floof - Herbals aren't nicotine
             Quantity: 5
 
 - type: entity


### PR DESCRIPTION
# Description

Per request, this change removes the nicotine from Interdynes but replaces it with Iron and Dylovene.

---

# Changelog

:cl:
- tweak: Removed nicotine from Interdynes and replaced it with iron and dylovene.
