### PR TITLE
Allows Aranchid to Talk to Spiders

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2314,9 +2314,9 @@
     solution: melee
   - type: LanguageKnowledge
     speaks:
-    - Xeno
+    - Arachnic #change from Xeno  Floofstation
     understands:
-    - Xeno
+    - Arachnic #change from Xeno  Floofstation
   - type: InteractionPopup
     successChance: 0.5
     interactSuccessString: petting-success-tarantula


### PR DESCRIPTION
# Description
Why is it that Slime players can speak to Slimes, Ratania players can speak to Ratkings(In mouse), rats and mice, Moffs can speak to Mothroach BUT YET Aranchid can't speak to spiders at all?  How many Aranchid players do you ever see? (there isn't a lot) This would allow Players to talk to Spider Mobs like  Shiva, Clown spiders, Tarantulas and Space spiders  (and REALLY should be able to talk to Laika and others dogs since Vulpkins are a canine-like being )
---

#  Media

![image](https://github.com/user-attachments/assets/1789226b-d1ad-4e49-a05a-593929ff4b2c)

---

# Changelog

:cl:
- tweak: Aranchids can now speak to shiva and other spiders 