### PR TITLE
Fix PirateRadio Heisentest

### DIFF
--- a/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
@@ -8,8 +8,11 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.Salvage;
 using Content.Shared.Random.Helpers;
 using System.Linq;
-using Content.Server.GameTicking.Components;
+using Content.Shared.GameTicking.Components;
 using Content.Shared.CCVar;
+using Robust.Shared.Serialization.Manager;
+using Content.Shared.Parallax.Biomes;
+using Robust.Shared.Map;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -21,25 +24,43 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
     [Dependency] private readonly IConfigurationManager _confMan = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
+    [Dependency] private readonly ISerializationManager _serializationManager = default!;
+    [Dependency] private readonly MapSystem _mapSystem = default!;
 
     protected override void Started(EntityUid uid, PirateRadioSpawnRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, component, gameRule, args);
 
         var stations = _gameTicker.GetSpawnableStations();
-        if (stations is null || stations.Count <= 0)
+        if (stations is null)
+            return;
+
+        // Remove any station from the list that is on a Planet's surface.
+        // We have to do this because if we spawn the listening post 1.5 kilometers from the station on a planet
+        // The server will then attempt to generate 7 billion entities, immediately exceeding the 32bit signed integer limit for EntityUids.
+        var stationsCopy = _serializationManager.CreateCopy(stations, notNullableOverride: true);
+        foreach (var station in stationsCopy)
+            if (HasComp<BiomeComponent>(Transform(station).MapUid))
+                stations.Remove(station);
+
+        // _random forces Test Fails if given an empty list. which is guaranteed to happen during Tests.
+        if (stations.Count <= 0)
             return;
 
         var targetStation = _random.Pick(stations);
-        var randomOffset = _random.NextVector2(component.MinimumDistance, component.MaximumDistance);
+        var targetMapId = Transform(targetStation).MapID;
 
+        if (!_mapSystem.MapExists(targetMapId))
+            return;
+
+        var randomOffset = _random.NextVector2(component.MinimumDistance, component.MaximumDistance);
         var outpostOptions = new MapLoadOptions
         {
             Offset = _xform.GetWorldPosition(targetStation) + randomOffset,
             LoadMap = false,
         };
 
-        if (!_map.TryLoad(GameTicker.DefaultMap, _random.Pick(component.PirateRadioShuttlePath), out var outpostids, outpostOptions))
+        if (!_map.TryLoad(Transform(targetStation).MapID, _random.Pick(component.PirateRadioShuttlePath), out var outpostids, outpostOptions))
             return;
 
         SpawnDebris(component, outpostids);
@@ -55,6 +76,7 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
         {
             var outpostaabb = _xform.GetWorldPosition(id);
             var k = 0;
+
             while (k < component.DebrisCount)
             {
                 var debrisRandomOffset = _random.NextVector2(component.MinimumDebrisDistance, component.MaximumDebrisDistance);
@@ -65,7 +87,16 @@ public sealed class PirateRadioSpawnRule : StationEventSystem<PirateRadioSpawnRu
                     LoadMap = false,
                 };
 
-                var salvageProto = _random.Pick(_prototypeManager.EnumeratePrototypes<SalvageMapPrototype>().ToList());
+                var salvPrototypes = _prototypeManager.EnumeratePrototypes<SalvageMapPrototype>().ToList();
+                var salvageProto = _random.Pick(salvPrototypes);
+
+                if (!_mapSystem.MapExists(GameTicker.DefaultMap))
+                    return;
+
+                // Round didn't start before running this, leading to a null-space test fail.
+                if (GameTicker.DefaultMap == MapId.Nullspace)
+                    return;
+
                 if (!_map.TryLoad(GameTicker.DefaultMap, salvageProto.MapPath.ToString(), out _, debrisOptions))
                     return;
 

--- a/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
+++ b/Content.Server/StationEvents/Events/PirateRadioSpawnRule.cs
@@ -8,7 +8,7 @@ using Content.Server.StationEvents.Components;
 using Content.Shared.Salvage;
 using Content.Shared.Random.Helpers;
 using System.Linq;
-using Content.Shared.GameTicking.Components;
+using Content.Server.GameTicking.Components;
 using Content.Shared.CCVar;
 using Robust.Shared.Serialization.Manager;
 using Content.Shared.Parallax.Biomes;


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

You are now free from the burden of this infamous heisentest.
Also I can PR the engine updates with no issue, if you'd like? Not sure if that's something y'all would want, but it wouldn't be hard. The engine update includes the arrivals visuals PR, so, might be good to get that lmao.
