### PR TITLE
Glacier Emergency Shuttle Replacement - NTES Delta (Shoko Evac)

### DIFF
--- a/Resources/Prototypes/Maps/glacier.yml
+++ b/Resources/Prototypes/Maps/glacier.yml
@@ -8,6 +8,8 @@
     Glacier:
       stationProto: StandardNanotrasenStation
       components:
+      - type: StationEmergencyShuttle #floofstation
+        emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Delta.yml #floofstation
       - type: StationNameSetup
         mapNameTemplate: '{0} Glacier Station {1}'
         nameGenerator:


### PR DESCRIPTION

# Description

This changes the evac shuttle on glacier from the default, small shuttle, meant for tiny stations; to the emergency shuttle that is used on Shoko, which is way more appropriately sized for the stations population. 

Thats it. 


![image](https://github.com/user-attachments/assets/174b0b5c-f998-4ee3-89ab-8038c02d0b79)
![image](https://github.com/user-attachments/assets/83c15a57-5ee2-4c68-b81e-68b896453a32)


---

# Changelog
:cl: Crow
- tweak: Adjusted Glacier evac shuttle
