### PR TITLE
Add .20 Rifle Rubber Box to Bartender Loadout

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/serviceGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/serviceGroups.yml
@@ -104,6 +104,8 @@
       id: LoadoutServiceBartenderBoxLightRifleRubber
     - type: loadout
       id: LoadoutServiceBartenderBoxMagnumRubber # Floofstation
+    - type: loadout
+      id: LoadoutServiceBartenderRifleBigRubber # Floofstation
 
 - type: characterItemGroup
   id: LoadoutBartenderWeapon

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
@@ -138,6 +138,20 @@
   items:
   - ClothingCostumeBunnySuit
 
+- type: loadout
+  id: LoadoutServiceBartenderRifleBigRubber
+  category: JobsServiceBartender
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBartenderAmmo
+    - !type:CharacterJobRequirement
+      jobs:
+        - Bartender
+  items:
+    - MagazineBoxRifleBigRubber
+
 #Chef
 - type: loadout
   id: LoadoutClothingHandsChefWarmers


### PR DESCRIPTION
# Description

Adds the .20 rifle rubber box to the Bartender's loadout for the Argenti.

---

# Changelog

:cl:
- add: .20 Rifle Rubber Ammo Box to Bartender loadout.
