### PR TITLE
Mood Traits Nerf

### DIFF
--- a/Resources/Prototypes/Mood/genericNegativeEffects.yml
+++ b/Resources/Prototypes/Mood/genericNegativeEffects.yml
@@ -38,7 +38,7 @@
 
 - type: moodEffect
   id: TraitSaturnine
-  moodChange: -20
+  moodChange: -12 # Floof - nerfed
 
 - type: moodEffect
   id: Dead

--- a/Resources/Prototypes/Mood/genericPositiveEffects.yml
+++ b/Resources/Prototypes/Mood/genericPositiveEffects.yml
@@ -44,4 +44,4 @@
 
 - type: moodEffect
   id: TraitSanguine
-  moodChange: 15
+  moodChange: 8 # Floof - nerfed


### PR DESCRIPTION
# Description
For ages players with the sanguine trait could completely ignore hunger and dehydration without suffering any negative effects (besides being unable to regenerate blood), while players with saturnine could never escape the hook of depression. This nerfs both of those traits to make them less powergamey and more playable, respectively.

- Sanguine mood buff has been reduced from 15 to 8 (being completely starved and dehydrated at the same time only gives you -14)
- Saturnine mood debuff has been reduced from -20 to -12.

# Changelog
:cl:
- tweak: The effects of the Sanguine and Saturnine traits have been made significantly weaker.
