### PR TITLE
Senior Uniforms to More Jobs

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/engineering.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/engineering.yml
@@ -37,6 +37,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer
+        - AtmosphericTechnician
+        - ChiefEngineer
     - !type:CharacterPlaytimeRequirement
       tracker: JobAtmosphericTechnician
       min: 21600 # 6 hours
@@ -60,6 +62,8 @@
     - !type:CharacterJobRequirement
       jobs:
         - StationEngineer
+        - AtmosphericTechnician
+        - ChiefEngineer
     - !type:CharacterPlaytimeRequirement
       tracker: JobAtmosphericTechnician
       min: 21600 # 6 hours

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -66,6 +66,9 @@
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
+        - Detective
+        - Warden
+        - HeadOfSecurity
     - !type:CharacterPlaytimeRequirement
       tracker: JobWarden
       min: 21600 # 6 hours
@@ -92,6 +95,9 @@
     - !type:CharacterJobRequirement
       jobs:
         - SecurityOfficer
+        - Detective
+        - Warden
+        - HeadOfSecurity
     - !type:CharacterPlaytimeRequirement
       tracker: JobWarden
       min: 21600 # 6 hours


### PR DESCRIPTION
# Description
Medical department, in its current state, allows senior physician uniform to be worn by all roles excluding the intern role. See below image.

![image](https://github.com/user-attachments/assets/61e8f122-fbd6-42d1-b815-c51f8bb46a98)

This PR expands this logic to both security and engineering department, which in the current state, restricts the senior uniforms to just the basic Security Officer or Station Engineer respectively. This PR allows Atmosians, CE, HoS, Warden, and Detective to equip their departmental senior uniforms in the loadout menu. 

![image](https://github.com/user-attachments/assets/8c53c855-7488-4bd1-b980-9f109724d157)
![image](https://github.com/user-attachments/assets/635e8457-a466-4b6a-bac0-58c7c92a6221)

:cl: Crow
- tweak: Expanded which jobs can wear senior uniforms
