### PR TITLE
Event Conditions

### DIFF
--- a/Content.Server/FloofStation/GameTicking/StationEventCondition.cs
+++ b/Content.Server/FloofStation/GameTicking/StationEventCondition.cs
@@ -1,0 +1,140 @@
+using Content.Server.GameTicking;
+using Content.Server.Mind;
+using Content.Server.StationEvents;
+using Content.Server.StationEvents.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Serilog;
+
+
+namespace Content.Server.FloofStation.GameTicking;
+
+/// <summary>
+///     Represents an abstract condition required for a station event to be chosen from the random event pool.
+/// </summary>
+/// <remarks>
+///     Implementations should avoid performing expensive checks.
+///     Any data that may be expensive to compute should instead be precomputed and stored in <see cref="Dependencies"/>
+/// </remarks>
+[Serializable, ImplicitDataDefinitionForInheritors]
+public abstract partial class StationEventCondition
+{
+    /// <summary>
+    ///     If true, the event will only be run if this condition is NOT met.
+    /// </summary>
+    [DataField]
+    public bool Inverted = false;
+
+    public abstract bool IsMet(EntityPrototype proto, StationEventComponent component, Dependencies dependencies);
+
+    /// <summary>
+    ///     Entity system and other dependencies used by station event conditions.
+    ///     GameTicker allocates an instance of this before passing it to all events.
+    /// </summary>
+    public sealed class Dependencies(IEntityManager entMan, GameTicker ticker, EventManagerSystem eventManager)
+    {
+        public ISawmill Log = Logger.GetSawmill("station-event-conditions");
+
+        public IEntityManager EntMan => entMan;
+        public GameTicker Ticker => ticker;
+        public EventManagerSystem EventManager => eventManager;
+
+        public MindSystem Minds = default!;
+        public SharedIdCardSystem IdCard = default!;
+
+        [Dependency] public IPrototypeManager ProtoMan = default!;
+        [Dependency] public IRobustRandom Random = default!;
+        [Dependency] public IPlayerManager PlayerManager = default!;
+
+        /// <summary>
+        ///     List of all players along with their jobs. The dept field may have the default value if it could not be determined.
+        /// </summary>
+        public List<(ICommonSession session, EntityUid uid, ProtoId<JobPrototype> job, ProtoId<DepartmentPrototype> dept)> Players = new();
+        public Dictionary<ProtoId<JobPrototype>, int> JobCounts = new();
+        public Dictionary<ProtoId<DepartmentPrototype>, int> DeptCounts = new();
+
+        // Lookups
+        private readonly Dictionary<string, ProtoId<JobPrototype>> _jobTitleToPrototype = new();
+        private readonly Dictionary<ProtoId<JobPrototype>, ProtoId<DepartmentPrototype>> _jobToDept = new();
+
+        /// <summary>
+        ///     Called once after the instantiation of the class.
+        /// </summary>
+        public void Initialize()
+        {
+            IoCManager.InjectDependencies(this);
+
+            // We cannot use entity system dependencies outside of ESC context.
+            IdCard = EntMan.System<SharedIdCardSystem>();
+            Minds = EntMan.System<MindSystem>();
+
+            // Build the lookups - SharedJobSystem contains methods that iterate over all of those lists each time,
+            // Resulting in an O(n^2 * m) performance cost for each update() call.
+            foreach (var job in ProtoMan.EnumeratePrototypes<JobPrototype>())
+            {
+                _jobTitleToPrototype[job.LocalizedName] = job.ID;
+
+                foreach (var dept in ProtoMan.EnumeratePrototypes<DepartmentPrototype>())
+                {
+                    if (!dept.Primary || !dept.Roles.Contains(job.ID))
+                        continue;
+
+                    _jobToDept[job.ID] = dept.ID;
+                    break;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Called once shortly before passing this object to IsMet() to collect the necessary data about the round.
+        /// </summary>
+        public void Update()
+        {
+            JobCounts.Clear();
+            DeptCounts.Clear();
+
+            // Collect data about the jobs of the players in the round
+            Players.Clear();
+            foreach (var session in PlayerManager.Sessions)
+            {
+                if (session.AttachedEntity is not {} player
+                    || session.Status is SessionStatus.Zombie or SessionStatus.Disconnected
+                    || !Minds.TryGetMind(session, out var mind, out var mindComponent))
+                    continue;
+
+                ProtoId<JobPrototype> job = default;
+                // 1: Try to get the job from the ID the person holds
+                if (IdCard.TryFindIdCard(player, out var idCard) && idCard.Comp.JobTitle is {} jobTitle)
+                    _jobTitleToPrototype.TryGetValue(jobTitle, out job);
+
+                // 2: If failed, try to fetch it from the mind component instead
+                if (job == default
+                    && EntMan.TryGetComponent<JobComponent>(mind, out var jobComp)
+                    && jobComp.Prototype is {} mindJobProto
+                )
+                    job = mindJobProto;
+
+                // If both have failed, skip the player
+                if (job == default)
+                    continue;
+
+                var dept = _jobToDept.GetValueOrDefault(job);
+
+                Players.Add((session, player, job, dept));
+                JobCounts[job] = JobCounts.GetValueOrDefault(job, 0) + 1;
+                DeptCounts[dept] = DeptCounts.GetValueOrDefault(dept, 0) + 1;
+            }
+
+            #if DEBUG
+                Log.Debug($"Event conditions data: Job counts: {string.Join(", ", JobCounts)}");
+                Log.Debug($"Dept counts: {string.Join(", ", DeptCounts)}");
+            #endif
+        }
+    }
+}

--- a/Content.Server/FloofStation/GameTicking/StationEventCondition.cs
+++ b/Content.Server/FloofStation/GameTicking/StationEventCondition.cs
@@ -12,7 +12,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
-
 namespace Content.Server.FloofStation.GameTicking;
 
 /// <summary>

--- a/Content.Server/FloofStation/GameTicking/StationEventConditions.Players.cs
+++ b/Content.Server/FloofStation/GameTicking/StationEventConditions.Players.cs
@@ -1,0 +1,49 @@
+using Content.Server.StationEvents.Components;
+using Content.Shared.InteractionVerbs;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.FloofStation.GameTicking;
+
+/// <summary>
+///     A condition that requires a number of players to be present in a specific department.
+/// </summary>
+/// <example><code>
+///     - !type:DepartmentCountCondition
+///       department: Security
+///       range: {min: 5}
+/// </code></example>
+[Serializable]
+public sealed partial class DepartmentCountCondition : StationEventCondition
+{
+    [DataField(required: true)]
+    public ProtoId<DepartmentPrototype> Department;
+
+    [DataField(required: true)]
+    public InteractionVerbPrototype.RangeSpecifier Range;
+
+    public override bool IsMet(EntityPrototype proto, StationEventComponent component, Dependencies dependencies)
+    {
+        var count = dependencies.DeptCounts.GetValueOrDefault(Department, 0);
+        return Range.IsInRange(count);
+    }
+}
+
+/// <summary>
+///     Same as <see cref="DepartmentCountCondition"/>, but for specific jobs.
+/// </summary>
+[Serializable]
+public sealed partial class JobCountCondition : StationEventCondition
+{
+    [DataField(required: true)]
+    public ProtoId<JobPrototype> Job;
+
+    [DataField(required: true)]
+    public InteractionVerbPrototype.RangeSpecifier Range;
+
+    public override bool IsMet(EntityPrototype proto, StationEventComponent component, Dependencies dependencies)
+    {
+        var count = dependencies.JobCounts.GetValueOrDefault(Job, 0);
+        return Range.IsInRange(count);
+    }
+}

--- a/Content.Server/FloofStation/GameTicking/StationEventConditions.Utility.cs
+++ b/Content.Server/FloofStation/GameTicking/StationEventConditions.Utility.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using Content.Server.StationEvents.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.FloofStation.GameTicking;
+
+/// <summary>
+///     Combines a number of other conditions in a boolean AND or a boolean OR.
+/// </summary>
+/// <example>
+///     <code>
+///         - !type:ComplexCondition
+///           requireAll: true
+///           conditions:
+///           - !type:SomeCondition1
+///             ...
+///           - !type:SomeCondition2
+///             ...
+///     </code>
+/// </example>
+[Serializable]
+public sealed partial class ComplexCondition : StationEventCondition
+{
+    /// <summary>
+    ///     If true, this condition acts as a boolean AND. If false, it acts as a boolean OR.
+    /// </summary>
+    [DataField]
+    public bool RequireAll = false;
+
+    [DataField(required: true)]
+    public List<StationEventCondition> Conditions = new();
+
+    public override bool IsMet(EntityPrototype proto, StationEventComponent component, Dependencies dependencies) =>
+        RequireAll
+            ? Conditions.All(it => it.Inverted ^ it.IsMet(proto, component, dependencies))
+            : Conditions.Any(it => it.Inverted ^ it.IsMet(proto, component, dependencies));
+}

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server.FloofStation.GameTicking;
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -82,4 +83,14 @@ public sealed partial class StationEventComponent : Component
     [DataField("endTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan? EndTime;
+
+    // Floof section - custom conditions
+
+    /// <summary>
+    ///     A list of conditions that must be met for the event to run.
+    /// </summary>
+    [DataField]
+    public List<StationEventCondition>? Conditions;
+
+    // Floof section end
 }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -33,7 +33,7 @@ public sealed class EventManagerSystem : EntitySystem
 
         Subs.CVar(_configurationManager, CCVars.EventsEnabled, SetEnabled, true);
 
-        _eventConditionDeps = new(EntityManager, GameTicker, this);
+        _eventConditionDeps = new(EntityManager, GameTicker, this); // Floof
         _eventConditionDeps.Initialize();
     }
 

--- a/Resources/Prototypes/Floof/Gamerules/base.yml
+++ b/Resources/Prototypes/Floof/Gamerules/base.yml
@@ -1,0 +1,11 @@
+# A game rule base that requires at least 2 security members to be present
+- type: entity
+  id: BaseGameRuleSecurityRequirement
+  parent: BaseGameRule
+  abstract: true
+  components:
+  - type: StationEvent
+    conditions:
+    - !type:DepartmentCountCondition
+      department: Security
+      range: {min: 2}

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -7,6 +7,10 @@
     weight: 8
     startDelay: 30
     duration: 35
+    conditions: # Floof - at least one epi member
+    - !type:DepartmentCountCondition
+      department: Epistemics
+      range: {min: 1}
   - type: AnomalySpawnRule
 
 - type: entity
@@ -80,7 +84,7 @@
     prototype: MobSkeletonCloset
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
   id: DragonSpawn
   noSpawn: true
   components:
@@ -94,7 +98,7 @@
     prototype: SpawnPointGhostDragon
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
   id: NinjaSpawn
   noSpawn: true
   components:
@@ -168,6 +172,10 @@
     endAnnouncement: true
     duration: null #ending is handled by MeteorSwarmRule
     startDelay: 30
+    conditions: # Floof
+    - !type:DepartmentCountCondition
+      department: Engineering
+      range: {min: 2}
   - type: MeteorSwarmRule
 
 - type: entity
@@ -371,7 +379,7 @@
 
 - type: entity
   id: LoneOpsSpawn
-  parent: BaseGameRule
+  parent: BaseGameRuleSecurityRequirement # Floof - changed parent
   noSpawn: true
   components:
   - type: StationEvent


### PR DESCRIPTION
# Description
Implements some basic framework for customizable event conditions (currently featuring 3 types of conditions: job count condition, departament count condition, and complex condition - boolean and/or), and adds:
- A condition for at least 2 security players for most midround antags
- A condition for at least 2 enineering players for meteor swarms
- A condition for at least 1 epistemics player for random anomaly spawn

The existing conditions determine a player's job by first performing an inverse lookup by their ID title, and then, if it fails, checking the job they took when joining the station (dictated by the JobComponent on their mind. It's extremely dumb, I know, but neither ID cards nor player entities actually store your current job)

This needs further testing and adjustments.

<details><summary><h1>Media</h1></summary>
<p>

Something something I'm struggling to test it locally because I can't really run more than 2 clients at once.

![image](https://github.com/user-attachments/assets/f2d2c7e6-f16a-45a3-87d8-edf1788cfbc7)

</p>
</details>

---

# Changelog
:cl:
- add: Station events can now have customizable conditions. This means that the station will no longer have to suffer from midround antags when there is zero security players, and the like.
