### PR TITLE
Footprints Fixes

### DIFF
--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -52,10 +52,10 @@ public sealed class FootPrintsSystem : EntitySystem
     private void OnMove(EntityUid uid, FootPrintsComponent component, ref MoveEvent args)
     {
         // Floof: clear stored DNAs if footprints are now invisible
-        if (component.PrintsColor.A <= .2f)
+        if (component.PrintsColor.A <= .3f)
             component.DNAs.Clear();
 
-        if (component.PrintsColor.A <= .2f // avoid creating footsteps that are invisible
+        if (component.PrintsColor.A <= .3f // avoid creating footsteps that are invisible
             || TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyStatus != BodyStatus.OnGround // Floof: do not create footprints if the entity is flying
             || !_transformQuery.TryComp(uid, out var transform)
             || !_mobThresholdQuery.TryComp(uid, out var mobThreshHolds)

--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Atmos.Components;
+using Content.Server.Gravity;
 using Content.Shared.Inventory;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -9,6 +10,7 @@ using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Forensics;
 using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Random;
 
 namespace Content.Server.FootPrint;
@@ -22,7 +24,7 @@ public sealed class FootPrintsSystem : EntitySystem
     [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!; // Floof
 
     private EntityQuery<TransformComponent> _transformQuery;
     private EntityQuery<MobThresholdsComponent> _mobThresholdQuery;
@@ -49,10 +51,12 @@ public sealed class FootPrintsSystem : EntitySystem
 
     private void OnMove(EntityUid uid, FootPrintsComponent component, ref MoveEvent args)
     {
-        if (component.PrintsColor.A <= .2f) // avoid creating footsteps that are invisible
+        // Floof: clear stored DNAs if footprints are now invisible
+        if (component.PrintsColor.A <= .2f)
             component.DNAs.Clear();
 
-        if (component.PrintsColor.A <= .2f
+        if (component.PrintsColor.A <= .2f // avoid creating footsteps that are invisible
+            || TryComp<PhysicsComponent>(uid, out var physics) && physics.BodyStatus != BodyStatus.OnGround // Floof: do not create footprints if the entity is flying
             || !_transformQuery.TryComp(uid, out var transform)
             || !_mobThresholdQuery.TryComp(uid, out var mobThreshHolds)
             || !_map.TryFindGridAt(_transform.GetMapCoordinates((uid, transform)), out var gridUid, out _))
@@ -66,9 +70,10 @@ public sealed class FootPrintsSystem : EntitySystem
         if (!(distance > stepSize))
             return;
 
+        // Floof section
         var entities = _lookup.GetEntitiesIntersecting(uid, LookupFlags.All);
         foreach (var entityUid in entities.Where(entityUid => HasComp<PuddleFootPrintsComponent>(entityUid)))
-            return; //are we on a puddle? we exit, ideally we would exchange liquid and DNA with the puddle but meh, too lazy to do that now.
+            return; // are we on a puddle? we exit, ideally we would exchange liquid and DNA with the puddle but meh, too lazy to do that now.
 
         component.RightStep = !component.RightStep;
 
@@ -76,7 +81,8 @@ public sealed class FootPrintsSystem : EntitySystem
         var footPrintComponent = EnsureComp<FootPrintComponent>(entity);
 
         var forensics = EntityManager.EnsureComponent<ForensicsComponent>(entity);
-        forensics.DNAs.UnionWith(component.DNAs);
+        if (TryComp<ForensicsComponent>(uid, out var ownerForensics)) // Floof edit: transfer owner DNA into the footsteps
+            forensics.DNAs.UnionWith(ownerForensics.DNAs);
 
         footPrintComponent.PrintOwner = uid;
         Dirty(entity, footPrintComponent);

--- a/Content.Shared/Footprint/FootPrintsComponent.cs
+++ b/Content.Shared/Footprint/FootPrintsComponent.cs
@@ -86,6 +86,7 @@ public sealed partial class FootPrintsComponent : Component
     /// </summary>
     public float ColorInterpolationFactor = 0.2f;
 
+    // Floof
     [DataField]
     public HashSet<string> DNAs = new();
 }


### PR DESCRIPTION
# Description
- Makes it so that CleanTileReaction (space cleaner, water, bleach) clean footprints as well as puddles
- Makes it so that flying (slipping or otherwise) entities do not leave footprints
- Adds some missing floof edit comments

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/7e931986-3789-4240-ba02-03941e66d3f8


</p>
</details>

# Changelog
:cl:
- fix: Space cleaner can now clean footprints, and mobs won't leave footprints while flying.
