### PR TITLE
Unrevivable Trait

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -6,6 +6,7 @@ using Content.Server.EUI;
 using Content.Server.Ghost;
 using Content.Server.Popups;
 using Content.Server.PowerCell;
+using Content.Server.Traits.Assorted;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
@@ -211,6 +212,11 @@ public sealed class DefibrillatorSystem : EntitySystem
         if (_rotting.IsRotten(target))
         {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
+                InGameICChatType.Speak, true);
+        }
+        else if (HasComp<UnrevivableComponent>(target))
+        {
+            _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"),
                 InGameICChatType.Speak, true);
         }
         else

--- a/Content.Server/Traits/Assorted/UnrevivableComponent.cs
+++ b/Content.Server/Traits/Assorted/UnrevivableComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Server.Traits.Assorted;
+
+/// <summary>
+/// This is used for the urevivable trait.
+/// </summary>
+[RegisterComponent]
+public sealed partial class UnrevivableComponent : Component
+{
+
+}

--- a/Resources/Locale/en-US/medical/components/defibrillator.ftl
+++ b/Resources/Locale/en-US/medical/components/defibrillator.ftl
@@ -1,3 +1,4 @@
 ﻿defibrillator-not-on = The defibrillator isn't turned on.
 defibrillator-no-mind = No intelligence pattern can be detected in patient's brain. Further attempts futile.
 defibrillator-rotten = Body decomposition detected: resuscitation failed.
+defibrillator-unrevivable = This patient is unable to be revived due to a unique body composition.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -43,6 +43,9 @@ trait-description-Hemophilia =
 trait-name-Paracusia = Paracusia
 trait-description-Paracusia = You hear sounds that aren't really there
 
+trait-name-Unrevivable = Unrevivable
+trait-description-Unrevivable = You have a unique body composition that prevents you from being revived by normal means.
+
 trait-name-PirateAccent = Pirate Accent
 trait-description-PirateAccent = You can't stop speaking like a pirate!
 
@@ -321,7 +324,7 @@ trait-description-AddictionNicotine =
 trait-name-AnimalFriend = Animal Friend
 trait-description-AnimalFriend =
     You have a way with animals. You will never be attacked by animals, unless you attack them first.
-    
+
 trait-name-Liar = Pathological liar
 trait-description-Liar = You can hardly bring yourself to tell the truth. Sometimes you lie anyway.
 

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -73,6 +73,26 @@
           sounds:
             collection: Paracusia
 
+# Floofstation-specific trait, for now. EE will probably port it over later, so we keep it here.
+- type: trait
+  id: Unrevivable
+  category: Physical
+  points: 6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Borg # Borgs cannot be revived and don't have the "dead" state, they just gib
+        - MedicalBorg
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC # IPCs use their own system
+  functions:
+    - !type:TraitAddComponent
+      components:
+      - type: Unrevivable
+
 - type: trait
   id: Muted
   category: Mental


### PR DESCRIPTION
# Description
Adds the unrevivable trait, ported from https://github.com/space-wizards/space-station-14/pull/24226

Should preserve compatibility with wizden/ee.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0a6623a0-f9f1-498d-90dd-ded88407ab92)

![image](https://github.com/user-attachments/assets/820b574c-1bcb-4fee-9177-a3b4fb488210)

</p>
</details>

# Changelog
:cl:
- add: Added the "Unrevivable" trait for those who like to live on the edge.