### PR TITLE
Fix some Species Not Leaving Footprints

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -223,6 +223,7 @@
     - CanPilot
     - FootstepSound
     - DoorBumpOpener
+  - type: FootPrints
 
 - type: entity
   save: false


### PR DESCRIPTION
# Description
*Sighs*. Vulps, felinids, and probably other nyano/floof species lacked the footprints comp.

This adds the footprints comp to the base species proto. I will need to test this later because this was done via github web interface and I cannot guarantee it won't break something immediately.

<details><summary><h1>Media</h1></summary>
<p>

None, needs testing.

</p>
</details>

# Changelog
:cl:
- fix: Vulpkanins and other species should now properly leave footprints.
