### PR TITLE
Fix .20 Rifle Rubber Box and Added Rubber .20 Speedloader for Bartenders.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
@@ -51,7 +51,7 @@
   components:
   - type: BallisticAmmoProvider
     capacity: 200
-    proto: CartridgeRiflePractice
+    proto: CartridgeRifleRubber # Floof - Fix the ammo in the .20 Rifle Rubber Box.
   - type: Sprite
     layers:
     - state: base-b

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
@@ -152,6 +152,18 @@
   items:
     - MagazineBoxRifleBigRubber
 
+- type: loadout
+  id: LoadoutServiceBartenderRifleBigRubberSpeedloader
+  category: JobsServiceBartender
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Bartender
+  items:
+    - SpeedLoaderRifleHeavyRubber
+
 #Chef
 - type: loadout
   id: LoadoutClothingHandsChefWarmers


### PR DESCRIPTION
# Description

This PR fixes the ammo in the .20 Rifle Box to be rubbers instead of practice rounds.
It also adds the speedloader for the Argenti to the Bartender's loadout.

Note the speedloader currently can be chosen even without the Argenti. This will be updated later on.

---

# Changelog

:cl:
- add: .20 Rifle Speedloader to Bartenders
- fix: .20 Rubber Rifle Box gives the correct ammo type.
