### PR TITLE
Better Vent Critters

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,5 +1,8 @@
-﻿using Content.Server.StationEvents.Events;
+﻿using System.Numerics;
+using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
+using Robust.Shared.Audio;
+
 
 namespace Content.Server.StationEvents.Components;
 
@@ -14,4 +17,32 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
+
+    // Floof section - delayed spawns
+
+    /// <summary>
+    ///     The random per-critter delay between the start of the event and their spawn, in seconds.
+    /// </summary>
+    [DataField]
+    public Vector2 InitialDelay = new(0, 20);
+
+    /// <summary>
+    ///     An optional delay after showing the popup and playing the sound, but before spawning, in seconds.
+    /// </summary>
+    [DataField]
+    public Vector2? CrawlTime = null;
+
+    /// <summary>
+    ///     An optional popup to show after the initial delay.
+    /// </summary>
+    [DataField]
+    public LocId? Popup = null;
+
+    /// <summary>
+    ///     An optional sound to play after the initial delay.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier? Sound = null;
+
+    // Floof section end
 }

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using System.Numerics;
+using System.Threading.Tasks;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Components;
@@ -14,6 +16,10 @@ using Robust.Shared.Prototypes;
 using Content.Server.Announcements.Systems;
 using Robust.Shared.Player;
 using Content.Server.Station.Components;
+using Content.Shared.Popups;
+using Robust.Shared.Audio;
+using Robust.Shared.Timing;
+
 
 namespace Content.Server.StationEvents.Events;
 
@@ -29,6 +35,7 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
     [Dependency] protected readonly StationSystem StationSystem = default!;
     [Dependency] private readonly AnnouncerSystem _announcer = default!;
+    [Dependency] private readonly SharedPopupSystem _popups = default!; // Floof
 
     protected ISawmill Sawmill = default!;
 
@@ -135,6 +142,81 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
     {
         GameTicker.EndGameRule(uid, component);
     }
+
+    // Floof section - a function to delay the appearance of spawned mobs
+
+    /// <summary>
+    ///     A helper function to spawn an entity after a delay while simulatenously showing a popup and/or playing a sound.
+    /// </summary>
+    /// <param name="protoId">The prototype to spawn.</param>
+    /// <param name="coordinates">The coordinates to spawn at.</param>
+    /// <param name="delay">A vector representing the minimum and maximum delay (in seconds). If null, no delay is applied.</param>
+    /// <param name="popup">The popup to show when the delay is started, if any..</param>
+    /// <param name="sound">The sound to play when the delay is started, if any.</param>
+    protected Task<EntityUid> DelayedSpawn(EntProtoId? protoId, EntityCoordinates coordinates, Vector2? delay, LocId? popup, SoundSpecifier? sound)
+    {
+        // Show the popup and play the sound, if any
+        if (popup is {} popupLoc)
+            _popups.PopupCoordinates(Loc.GetString(popupLoc), coordinates, PopupType.MediumCaution);
+        if (sound is {} soundSpecifier)
+            Audio.PlayStatic(soundSpecifier, Filter.Pvs(coordinates), coordinates, true, soundSpecifier.Params);
+
+        // If no delay is specified, just spawn the entity on the current thread and return
+        if (delay == null)
+            return Task.FromResult(Spawn(protoId, coordinates));
+
+        // Otherwise, spawn a new timer that will spawn the entity after the delay, and set the result of this task.
+        var waitTime = (int) RobustRandom.NextFloat(delay.Value.X, delay.Value.Y) * 1000;
+        var tcs = new TaskCompletionSource<EntityUid>();
+
+        Timer.Spawn(waitTime, () =>
+        {
+            // Let's hope this will prevent the timer from being carried across rounds.
+            if (!coordinates.IsValid(EntityManager))
+                return;
+
+            try
+            {
+                var spawned = Spawn(protoId, coordinates);
+                tcs.SetResult(spawned);
+            }
+            catch (Exception e)
+            {
+                tcs.SetException(e);
+            }
+        });
+
+        return tcs.Task;
+    }
+
+    /// <summary>
+    ///     A helper function to delay by a certain random time, then show a popup and play a sound (optionally),
+    ///     and then delay again and finally spawn the mob. Used to make the appearence of entities less sudden and more random at the same time.<br/><br/>
+    ///
+    ///     The resulting delay between the call of this function and the actual spawn is going to be random(initialDelay) + random(afterPopupDelay),
+    ///     with the popup and sound being played after the first of them.
+    /// </summary>
+    /// <see cref="DelayedSpawn(EntProtoId?, EntityCoordinates, Vector2?, LocId?, SoundSpecifier?)"/>
+    protected void DelayedSpawn(
+        EntProtoId? protoId,
+        EntityCoordinates coordinates,
+        Vector2 initialDelay,
+        Vector2? afterPopupDelay,
+        LocId? popup,
+        SoundSpecifier? sound)
+    {
+        // I don't want to make this return the actual uid because it's almost never actually gonna get used, and concurrency is pain.
+        // If you want to get the spawned entity uid (possibly many seconds or minutes after this function has been invoked),
+        // just set up your own function similar to this one.
+        var initialWait = (int) RobustRandom.NextFloat(initialDelay.X, initialDelay.Y) * 1000;
+
+        Timer.Spawn(initialWait, () =>
+        {
+            DelayedSpawn(protoId, coordinates, afterPopupDelay, popup, sound);
+        });
+    }
+
+    // Floof section end
 
     #endregion
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -3,7 +3,9 @@ using Content.Server.StationEvents.Components;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Station.Components;
 using Content.Shared.Storage;
+using Content.Shared.Tools.Components;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
@@ -26,14 +28,18 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         var validLocations = new List<EntityCoordinates>();
-        while (locations.MoveNext(out _, out _, out var transform))
+        while (locations.MoveNext(out var ventUid, out _, out var transform))
         {
+            // Floof: do not spawn on welded vents
+            if (TryComp<WeldableComponent>(ventUid, out var weldable) && weldable.IsWelded)
+                continue;
+
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
                 validLocations.Add(transform.Coordinates);
                 foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
                 {
-                    Spawn(spawn, transform.Coordinates);
+                    SpawnCritter(spawn, transform.Coordinates, component); // Floof - changed to delayed spawn
                 }
             }
         }
@@ -46,14 +52,18 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         // guaranteed spawn
         var specialEntry = RobustRandom.Pick(component.SpecialEntries);
         var specialSpawn = RobustRandom.Pick(validLocations);
-        Spawn(specialEntry.PrototypeId, specialSpawn);
+        SpawnCritter(specialEntry.PrototypeId, specialSpawn, component); // Floof - changed to delayed spawn
 
         foreach (var location in validLocations)
         {
             foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
             {
-                Spawn(spawn, location);
+                SpawnCritter(spawn, location, component); // Floof - changed to delayed spawn
             }
         }
     }
+
+    // Floof
+    private void SpawnCritter(EntProtoId? protoId, EntityCoordinates coordinates, VentCrittersRuleComponent rule) =>
+        DelayedSpawn(protoId, coordinates, rule.InitialDelay, rule.CrawlTime, rule.Popup, rule.Sound);
 }

--- a/Resources/Locale/en-US/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/station-events/events/vent-critters.ftl
@@ -1,15 +1,25 @@
-﻿station-event-cockroach-migration-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-slimes-spawn-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-vent-critters-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-spider-spawn-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-reagentslime-vents-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-meat-vents-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
-station-event-neutral-xeno-vents-announcement = Confirmed sightings of alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to investigate the threat as soon as possible.
-station-event-tick-vents-announcement = Confirmed sightings of hostile alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
-station-event-argocyte-vents-announcement = Confirmed sightings of hostile alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
-station-event-light-vents-announcement = Confirmed sightings of hostile alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
-station-event-carp-vents-announcement = Confirmed sightings of hostile alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
-station-event-space-vents-announcement = Confirmed sightings of hostile wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
+﻿station-event-vent-critters-generic-announcement = Attention. A large influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+station-event-cockroach-migration-announcement = {station-event-vent-critters-generic-announcement}
+station-event-slimes-spawn-announcement = {station-event-vent-critters-generic-announcement}
+station-event-vent-critters-announcement = {station-event-vent-critters-generic-announcement}
+station-event-spider-spawn-announcement = {station-event-vent-critters-generic-announcement}
+station-event-spider-clown-spawn-announcement = {station-event-vent-critters-generic-announcement}
+station-event-reagentslime-vents-announcement = {station-event-vent-critters-generic-announcement}
+station-event-meat-vents-announcement = {station-event-vent-critters-generic-announcement}
+
+station-event-xeno-generic-announcement = Confirmed sightings of alien wildlife on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to investigate the threat as soon as possible.
+station-event-neutral-xeno-vents-announcement = {station-event-xeno-generic-announcement}
+station-event-tick-vents-announcement = {station-event-xeno-generic-announcement}
+station-event-argocyte-vents-announcement = {station-event-xeno-generic-announcement}
+station-event-light-vents-announcement = {station-event-xeno-generic-announcement}
+station-event-carp-vents-announcement = {station-event-xeno-generic-announcement}
+station-event-space-vents-announcement = {station-event-xeno-generic-announcement}
+
 # Weak
 station-event-slimes-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
 station-event-spider-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+
+# Floof - popups
+station-event-generic-vents-popup = Something is squeezing through the ducts...
+station-event-xeno-vents-popup = Something huge is squeezing through the ducts!
+station-event-clown-spiders-popup = Your hear ominous honking coming from down below...

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -32,7 +32,7 @@
     popup: station-event-xeno-vents-popup # Floof
     sound: # Floof
       path: /Audio/Animals/space_dragon_roar.ogg
-      params: {volume: 0.3}
+      params: {volume: 0.5}
 
 # Weaker version of xenos, meant to provide some dangers in low pop.
 - type: entity

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -32,7 +32,7 @@
     popup: station-event-xeno-vents-popup # Floof
     sound: # Floof
       path: /Audio/Animals/space_dragon_roar.ogg
-      params: {volume: 0.5}
+      params: {volume: 0.3}
 
 # Weaker version of xenos, meant to provide some dangers in low pop.
 - type: entity

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -75,9 +75,9 @@
     entries:
     - id: MobMothroach
       prob: 0.05
-      sound: # Floof - mothroach my beloved
-        path: /Audio/Voice/Moth/moth_chitter.ogg
-        params: {volume: 0.5}
+    sound: # Floof - mothroach my beloved
+      path: /Audio/Voice/Moth/moth_chitter.ogg
+      params: {volume: 0.5}
 
 
 - type: entity

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -28,6 +28,11 @@
       prob: 0.005
     - id: MobXenoQueen
       prob: 0.005
+    crawlTime: 3, 4 # Floof
+    popup: station-event-xeno-vents-popup # Floof
+    sound: # Floof
+      path: /Audio/Animals/space_dragon_roar.ogg
+      params: {volume: 0.5}
 
 # Weaker version of xenos, meant to provide some dangers in low pop.
 - type: entity
@@ -70,6 +75,10 @@
     entries:
     - id: MobMothroach
       prob: 0.05
+      sound: # Floof - mothroach my beloved
+        path: /Audio/Voice/Moth/moth_chitter.ogg
+        params: {volume: 0.5}
+
 
 - type: entity
   id: PirateRadioSpawn

--- a/Resources/Prototypes/Floof/Gamerules/Events.yml
+++ b/Resources/Prototypes/Floof/Gamerules/Events.yml
@@ -1,6 +1,6 @@
 # - type: entity
 #   id: ArgocyteVents
-#   parent: BaseGameRule
+#   parent: [VentCrittersBase, BaseGameRule]
 #   noSpawn: true
 #   components:
 #   - type: StationEvent
@@ -39,7 +39,7 @@
 
 # - type: entity
 #   id: TickVents
-#   parent: BaseGameRule
+#   parent: [VentCrittersBase, BaseGameRule]
 #   noSpawn: true
 #   components:
 #   - type: StationEvent
@@ -56,7 +56,7 @@
 
 # - type: entity
 #   id: CarpVents
-#   parent: BaseGameRule
+#   parent: [VentCrittersBase, BaseGameRule]
 #   noSpawn: true
 #   components:
 #   - type: StationEvent
@@ -83,7 +83,7 @@
 
 # - type: entity
 #   id: SpaceVents
-#   parent: BaseGameRule
+#   parent: [VentCrittersBase, BaseGameRule]
 #   noSpawn: true
 #   components:
 #   - type: StationEvent

--- a/Resources/Prototypes/GameRules/base.yml
+++ b/Resources/Prototypes/GameRules/base.yml
@@ -1,0 +1,13 @@
+# Floof - base for vent critters. Adds the generic sound and popups.
+- type: entity
+  id: VentCrittersBase
+  abstract: true
+  components:
+  - type: VentCrittersRule
+    crawlTime: 5, 6.5 # The audio itself is 6 seconds long, so we don't want it to be much shorter or longer
+    popup: station-event-generic-vents-popup
+    sound:
+      path: /Audio/Effects/sizzle.ogg
+      params:
+        volume: 0.8
+        pitch: 0.667

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -172,7 +172,7 @@
 
 - type: entity
   id: MouseMigration
-  parent: BaseGameRule
+  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
   noSpawn: true
   components:
   - type: StationEvent
@@ -197,7 +197,7 @@
 
 - type: entity
   id: CockroachMigration
-  parent: BaseGameRule
+  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
   noSpawn: true
   components:
   - type: StationEvent
@@ -281,7 +281,7 @@
 
 - type: entity
   id: SlimesSpawn
-  parent: BaseGameRule
+  parent:  [VentCrittersBase, BaseGameRule] # Floof - reparented
   noSpawn: true
   components:
   - type: StationEvent
@@ -302,7 +302,7 @@
 
 - type: entity
   id: SpiderSpawn
-  parent: BaseGameRule
+  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
   noSpawn: true
   components:
   - type: StationEvent
@@ -319,11 +319,11 @@
 
 - type: entity
   id: SpiderClownSpawn
-  parent: BaseGameRule
+  parent: [VentCrittersBase, BaseGameRule] # Floof - reparented
   noSpawn: true
   components:
   - type: StationEvent
-    startAnnouncement: false
+    startAnnouncement: true
     startDelay: 10
     earliestStart: 20
     minimumPlayers: 20
@@ -333,6 +333,11 @@
     entries:
     - id: MobClownSpider
       prob: 0.05
+    crawlTime: 4, 5 # Floof - God please no...
+    popup: station-event-clown-spiders-popup # Floof
+    sound: # Floof
+      path: /Audio/Items/bikehorn.ogg
+      params: {volume: 0.5}
 
 #- type: entity
 #  id: ZombieOutbreak


### PR DESCRIPTION
# Description
Adds a double random delay to the vent critters rule, as well as optional sounds and popups. Also prevents the gamerule from spawning mobs on welded vents, implements the framework for delayed spawn for use in other entity systems, fixes some ftl problems (including the missing announcement for spider clowns)

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/e31933ea-6c41-488e-8091-58b42e040ee6


</p>
</details>

# Changelog
:cl:
- add: Vent critters will no longer spawn immediately after being announced, and their appearance is now accompanied by audiovisual warnings appearing up to 6 seconds ahead of their spawn.
