### PR TITLE
Even Better Footprints

### DIFF
--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.Footprints.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.Footprints.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Fluids;
+using Content.Shared.FootPrint;
+using Content.Shared.Timing;
+
+
+namespace Content.Server.Fluids.EntitySystems;
+
+
+// Floof-specific
+public sealed partial class AbsorbentSystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+    /// <summary>
+    ///     Tries to clean a number of footprints in a range determined by the component. Returns the number of cleaned footprints.
+    /// </summary>
+    private int TryCleanNearbyFootprints(EntityUid user, EntityUid used, EntityUid target, AbsorbentComponent component,  Entity<SolutionComponent> absorbentSoln)
+    {
+        var footprintQuery = GetEntityQuery<FootPrintComponent>();
+        var targetCoords = Transform(target).Coordinates;
+        var entities = _lookup.GetEntitiesInRange(targetCoords, component.FootprintCleaningRange, LookupFlags.Uncontained);
+
+        // Take up to [MaxCleanedFootprints] footprints closest to the target
+        var cleaned = entities.AsEnumerable()
+            .Where(footprintQuery.HasComp)
+            .Select(uid => (uid, dst: Transform(uid).Coordinates.TryDistance(EntityManager, _transform, targetCoords, out var dst) ? dst : 0f))
+            .Where(ent => ent.dst > 0f)
+            .OrderBy(ent => ent.dst)
+            .Select(ent => (ent.uid, comp: footprintQuery.GetComponent(ent.uid)));
+
+        // And try to interact with each one of them, ignoring useDelay
+        var processed = 0;
+        foreach (var (uid, footprintComp) in cleaned)
+        {
+            if (TryPuddleInteract(user, used, uid, component, useDelay: null, absorbentSoln))
+                processed++;
+
+            if (processed >= component.MaxCleanedFootprints)
+                break;
+        }
+
+        return processed;
+    }
+}

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -18,7 +18,7 @@ using Robust.Shared.Utility;
 namespace Content.Server.Fluids.EntitySystems;
 
 /// <inheritdoc/>
-public sealed class AbsorbentSystem : SharedAbsorbentSystem
+public sealed partial class AbsorbentSystem : SharedAbsorbentSystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
@@ -119,6 +119,8 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
             if (!TryRefillableInteract(user, used, target, component, useDelay, absorberSoln.Value))
                 return;
         }
+
+        TryCleanNearbyFootprints(user, used, target, component, absorberSoln.Value); // Floof
     }
 
     /// <summary>

--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -74,15 +74,18 @@ public sealed class FootPrintsSystem : EntitySystem
         var entities = _lookup.GetEntitiesIntersecting(uid, LookupFlags.All);
         foreach (var entityUid in entities.Where(entityUid => HasComp<PuddleFootPrintsComponent>(entityUid)))
             return; // are we on a puddle? we exit, ideally we would exchange liquid and DNA with the puddle but meh, too lazy to do that now.
+        // Floof section end
 
         component.RightStep = !component.RightStep;
 
         var entity = Spawn(component.StepProtoId, CalcCoords(gridUid, component, transform, dragging));
         var footPrintComponent = EnsureComp<FootPrintComponent>(entity);
 
+        // Floof section
         var forensics = EntityManager.EnsureComponent<ForensicsComponent>(entity);
-        if (TryComp<ForensicsComponent>(uid, out var ownerForensics)) // Floof edit: transfer owner DNA into the footsteps
+        if (TryComp<ForensicsComponent>(uid, out var ownerForensics)) // transfer owner DNA into the footsteps
             forensics.DNAs.UnionWith(ownerForensics.DNAs);
+        // Floof section end
 
         footPrintComponent.PrintOwner = uid;
         Dirty(entity, footPrintComponent);

--- a/Content.Server/FootPrint/FootPrintsSystem.cs
+++ b/Content.Server/FootPrint/FootPrintsSystem.cs
@@ -62,8 +62,10 @@ public sealed class FootPrintsSystem : EntitySystem
             || !_map.TryFindGridAt(_transform.GetMapCoordinates((uid, transform)), out var gridUid, out _))
             return;
 
-        var dragging = mobThreshHolds.CurrentThresholdState is MobState.Critical or MobState.Dead
-                       || _layingQuery.TryComp(uid, out var laying) && laying.IsCrawlingUnder;
+        // Floof - this is dumb
+        // var dragging = mobThreshHolds.CurrentThresholdState is MobState.Critical or MobState.Dead
+        //                || _layingQuery.TryComp(uid, out var laying) && laying.IsCrawlingUnder;
+        var dragging = TryComp<StandingStateComponent>(uid, out var standing) && standing.CurrentState == StandingState.Lying; // Floof - replaced the above
         var distance = (transform.LocalPosition - component.StepPos).Length();
         var stepSize = dragging ? component.DragSize : component.StepSize;
 

--- a/Content.Shared/Fluids/AbsorbentComponent.cs
+++ b/Content.Shared/Fluids/AbsorbentComponent.cs
@@ -38,4 +38,15 @@ public sealed partial class AbsorbentComponent : Component
         {
             Params = AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(-3f),
         };
+
+    // Floof section
+    [DataField]
+    public float FootprintCleaningRange = 0.2f;
+
+    /// <summary>
+    ///     How many footprints within <see cref="FootprintCleaningRange"/> can be cleaned at once.
+    /// </summary>
+    [DataField]
+    public int MaxCleanedFootprints = 5;
+    // Floof section end
 }

--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -205,3 +205,15 @@
     - type: Puddle
       solution: step
     - type: Appearance
+    # Floof section - components that puddles have and footprints should also have. Why are we not inheriting from Puddle again?
+    - type: Drink
+      delay: 3
+      transferAmount: 1
+      solution: step
+      examinable: false
+    - type: ExaminableSolution
+      solution: step
+    - type: DrawableSolution
+      solution: step
+    - type: BadDrink
+    # Floof section end

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -32,6 +32,8 @@
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
   - type: Absorbent
+    footprintCleaningRange: 0.75 # Floof - to make janitors lives easier, but not too easy.
+    maxCleanedFootprints: 25 # Floof
   - type: SolutionContainerManager
     solutions:
       absorbed:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -86,6 +86,8 @@
       sprite: Objects/Specific/Janitorial/advmop.rsi
     - type: Absorbent
       pickupAmount: 100
+      footprintCleaningRange: 0.9 # Floof - why do advanced mops not inherit from standard ones?
+      maxCleanedFootprints: 25 # Floof
     - type: UseDelay
       delay: 1.0
     - type: SolutionRegeneration

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -32,7 +32,7 @@
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
   - type: Absorbent
-    footprintCleaningRange: 0.75 # Floof - to make janitors lives easier, but not too easy.
+    footprintCleaningRange: 0.45 # Floof - to make janitors lives easier, but not too easy.
     maxCleanedFootprints: 25 # Floof
   - type: SolutionContainerManager
     solutions:
@@ -86,7 +86,7 @@
       sprite: Objects/Specific/Janitorial/advmop.rsi
     - type: Absorbent
       pickupAmount: 100
-      footprintCleaningRange: 0.9 # Floof - why do advanced mops not inherit from standard ones?
+      footprintCleaningRange: 0.75 # Floof - why do advanced mops not inherit from standard ones?
       maxCleanedFootprints: 25 # Floof
     - type: UseDelay
       delay: 1.0


### PR DESCRIPTION
# Description
- Gives absorbents an AOE effect. Regular absorbents (dump rags and cleanbots) clean footprints in a 0.2m radius, up to 25 footprints. Mops clean in a 0.45m radius, and advanced mops - in a 0.75m radius.
- Adds the missing solution components to footprints. They can now be properly examined and can be drawn from with a syringe (potassium footprints my beloathed).
- Makes it so that the "dragging" prints are applied based on whether the entity is laying down rather than whether it's alive.

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/7601f45e-51e9-41dc-b84b-a9273c1ff38a

https://github.com/user-attachments/assets/2674c872-d2d4-489d-9419-767b7eb3dd89

</p>
</details>

# Changelog
:cl:
- add: Mops, damp rags, and cleanbots now have area-of-effect cleaning, allowing them to clean multiple footprints at once.
- fix: Footprints can now be examined and drawn from just like regular puddles.
- fix: Whether an entity leaves the "dragging" or "walking" footprints is now determined by whether it's standing or laying down.
