### PR TITLE
Prescription HUD Construction Crash Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -82,6 +82,7 @@
     tags:
     - HamsterWearable
     - WhitelistChameleon
+    - GlassesNearsight
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -642,6 +642,9 @@
   id: GlassBeaker
 
 - type: Tag
+  id: GlassesNearsight
+
+- type: Tag
   id: GlassShard
 
 - type: Tag


### PR DESCRIPTION
Added the tag "GlassesNearsight" to the tag list in tags.yml and tagged the glasses prototype with it. The crafting graph for prescription HUDs expects this tag.

# Description

The construction graph for the prescription versions of the sec and med HUDs requires an item with the tag "GlassesNearsight". This tag was not on the glasses prototype nor in the list of tags. When attempting to build a prescription HUD with the appropriate HUD, cables, and glasses, but not the glue, the local server would encounter a hard error that closed it. Other combinations were not tested.

---

# TODO

- [ ] Check if this crash can be replicated on others' builds.

---

# Changelog

:cl: sprkl
- fix: Fixed a crash that occurred while trying to build prescription huds.
