### PR TITLE
Mass Bug Fixes

### DIFF
--- a/Content.Client/Effects/ColorFlashEffectSystem.cs
+++ b/Content.Client/Effects/ColorFlashEffectSystem.cs
@@ -45,7 +45,9 @@ public sealed class ColorFlashEffectSystem : SharedColorFlashEffectSystem
             sprite.Color = component.Color;
         }
 
-        RemCompDeferred<ColorFlashEffectComponent>(uid);
+        // Floof - commented this out due to a race condition. It's quite complicated to explain;
+        // in short terms, don't do deferred component removal when dealing with concurrent tasks concerning the same component.
+        // RemCompDeferred<ColorFlashEffectComponent>(uid);
     }
 
     private Animation? GetDamageAnimation(EntityUid uid, Color color, SpriteComponent? sprite = null)
@@ -107,10 +109,11 @@ public sealed class ColorFlashEffectSystem : SharedColorFlashEffectSystem
                 continue;
             }
 
-            if (TryComp<ColorFlashEffectComponent>(ent, out var effect))
-            {
-                sprite.Color = effect.Color;
-            }
+            // Floof - commented out. This is handled by the animation complete event.
+            // if (TryComp<ColorFlashEffectComponent>(ent, out var effect))
+            // {
+            //     sprite.Color = effect.Color;
+            // }
 
             var animation = GetDamageAnimation(ent, color, sprite);
 

--- a/Content.Server/Carrying/CarryingSystem.cs
+++ b/Content.Server/Carrying/CarryingSystem.cs
@@ -273,6 +273,7 @@ namespace Content.Server.Carrying
             if (TryComp<PullableComponent>(carried, out var pullable))
                 _pullingSystem.TryStopPull(carried, pullable);
 
+            EnsureComp<KnockedDownComponent>(carried); // Floof - moved this statement up because some systems can break carrying in response to knockdown
             _transform.AttachToGridOrMap(carrier);
             _transform.AttachToGridOrMap(carried);
             _transform.SetCoordinates(carried, Transform(carrier).Coordinates);
@@ -282,7 +283,6 @@ namespace Content.Server.Carrying
             var carryingComp = EnsureComp<CarryingComponent>(carrier);
             ApplyCarrySlowdown(carrier, carried);
             var carriedComp = EnsureComp<BeingCarriedComponent>(carried);
-            EnsureComp<KnockedDownComponent>(carried);
 
             carryingComp.Carried = carried;
             carriedComp.Carrier = carrier;

--- a/Content.Server/FootPrint/PuddleFootPrintsSystem.cs
+++ b/Content.Server/FootPrint/PuddleFootPrintsSystem.cs
@@ -2,16 +2,20 @@ using System.Linq;
 using Content.Shared.FootPrint;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
 using Content.Shared.Fluids.Components;
 using Content.Shared.Forensics;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Prototypes;
+
 
 namespace Content.Server.FootPrint;
 
+// Floof: this system has been effectively rewritten. DO NOT MERGE UPSTREAM CHANGES.
 public sealed class PuddleFootPrintsSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainer = default!;
 
     public override void Initialize()
@@ -22,22 +26,10 @@ public sealed class PuddleFootPrintsSystem : EntitySystem
 
     private void OnStepTrigger(EntityUid uid, PuddleFootPrintsComponent component, ref EndCollideEvent args)
     {
-        if (!TryComp<AppearanceComponent>(uid, out var appearance)
-            || !TryComp<PuddleComponent>(uid, out var puddle)
-            || !TryComp<FootPrintsComponent>(args.OtherEntity, out var tripper)
-            || !TryComp<SolutionContainerManagerComponent>(uid, out var solutionManager)
-            || !_solutionContainer.ResolveSolution((uid, solutionManager), puddle.SolutionName, ref puddle.Solution, out var solutions))
+        if (!TryComp<PuddleComponent>(uid, out var puddle) || !TryComp<FootPrintsComponent>(args.OtherEntity, out var tripper))
             return;
 
-        var totalSolutionQuantity = solutions.Contents.Sum(sol => (float) sol.Quantity);
-        var waterQuantity = (from sol in solutions.Contents where sol.Reagent.Prototype == "Water" select (float) sol.Quantity).FirstOrDefault();
-
-        if (waterQuantity / (totalSolutionQuantity / 100f) > component.OffPercent || solutions.Contents.Count <= 0)
-            return;
-
-        tripper.ReagentToTransfer =
-            solutions.Contents.Aggregate((l, r) => l.Quantity > r.Quantity ? l : r).Reagent.Prototype;
-
+        // Transfer DNAs from the puddle to the tripper
         if (TryComp<ForensicsComponent>(uid, out var puddleForensics))
         {
             tripper.DNAs.UnionWith(puddleForensics.DNAs);
@@ -45,16 +37,16 @@ public sealed class PuddleFootPrintsSystem : EntitySystem
                 tripperForensics.DNAs.UnionWith(puddleForensics.DNAs);
         }
 
-        if (_appearance.TryGetData(uid, PuddleVisuals.SolutionColor, out var color, appearance)
-            && _appearance.TryGetData(uid, PuddleVisuals.CurrentVolume, out var volume, appearance))
-            AddColor((Color) color, (float) volume * component.SizeRatio, tripper);
+        // Transfer reagents from the puddle to the tripper.
+        // Ideally it should be a two-way process, but that is too hard to simulate and will have very little effect outside of potassium-water spills.
+        var quantity = puddle.Solution?.Comp?.Solution?.Volume ?? 0;
+        var footprintsCapacity = tripper.ContainedSolution.AvailableVolume;
 
-        _solutionContainer.RemoveEachReagent(puddle.Solution.Value, 1);
-    }
+        if (quantity <= 0 || footprintsCapacity <= 0)
+            return;
 
-    private void AddColor(Color col, float quantity, FootPrintsComponent component)
-    {
-        component.PrintsColor = component.ColorQuantity == 0f ? col : Color.InterpolateBetween(component.PrintsColor, col, component.ColorInterpolationFactor);
-        component.ColorQuantity += quantity;
+        var transferAmount = FixedPoint2.Min(footprintsCapacity, quantity * component.SizeRatio);
+        var transferred = _solutionContainer.SplitSolution(puddle.Solution!.Value, transferAmount);
+        tripper.ContainedSolution.AddSolution(transferred, _protoMan);
     }
 }

--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -252,7 +252,8 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
             // Maybe a bit expensive but oh well GetBands is queued and has a timer anyway.
             // Make sure the instrument is visible, uses the Opaque collision group so this works across windows etc.
             if (!_interactions.InRangeUnobstructed(uid, entity, MaxInstrumentBandRange,
-                    CollisionGroup.Opaque, e => e == playerUid || e == originPlayer))
+                    CollisionGroup.Opaque,
+                    e => e == playerUid || e == originPlayer || !HasComp<OccluderComponent>(e))) // Floof - added the occluder check.
                 continue;
 
             if (!metadataQuery.TryGetComponent(playerUid, out var playerMetadata)

--- a/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.Storage.cs
+++ b/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.Storage.cs
@@ -80,7 +80,7 @@ public sealed partial class DeepFryerSystem
 
     private void OnInsertItem(EntityUid uid, DeepFryerComponent component, DeepFryerInsertItemMessage args)
     {
-        var user = EntityManager.GetEntity(args.Entity);
+        var user =  args.Actor; // Floof - fix
 
         if (!TryComp<HandsComponent>(user, out var handsComponent) ||
             handsComponent.ActiveHandEntity == null)

--- a/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
+++ b/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
@@ -524,7 +524,7 @@ public sealed partial class DeepFryerSystem : SharedDeepfryerSystem
             if (!_containerSystem.Remove(removedItem, component.Storage))
                 return;
 
-            var user = EntityManager.GetEntity(args.Entity);
+            var user =  args.Actor; // Floof - fix;
 
             _handsSystem.TryPickupAnyHand(user, removedItem);
 
@@ -577,7 +577,7 @@ public sealed partial class DeepFryerSystem : SharedDeepfryerSystem
 
     private void OnScoopVat(EntityUid uid, DeepFryerComponent component, DeepFryerScoopVatMessage args)
     {
-        var user = EntityManager.GetEntity(args.Entity);
+        var user = args.Actor; // Floof - fix
 
         if (!TryGetActiveHandSolutionContainer(uid, user, out var heldItem, out var heldSolution,
                 out var transferAmount))
@@ -598,7 +598,7 @@ public sealed partial class DeepFryerSystem : SharedDeepfryerSystem
 
     private void OnClearSlagStart(EntityUid uid, DeepFryerComponent component, DeepFryerClearSlagMessage args)
     {
-        var user = EntityManager.GetEntity(args.Entity);
+        var user = args.Actor; // Floof - fix
 
         if (!TryGetActiveHandSolutionContainer(uid, user, out var heldItem, out var heldSolution,
                 out var transferAmount))
@@ -639,7 +639,7 @@ public sealed partial class DeepFryerSystem : SharedDeepfryerSystem
 
         _containerSystem.EmptyContainer(component.Storage);
 
-        var user = EntityManager.GetEntity(args.Entity);
+        var user = args.Actor; // Floof - fix
 
         _adminLogManager.Add(LogType.Action, LogImpact.Low,
             $"{ToPrettyString(user)} removed all items from {ToPrettyString(uid)}.");

--- a/Content.Shared/Footprint/FootPrintsComponent.cs
+++ b/Content.Shared/Footprint/FootPrintsComponent.cs
@@ -1,29 +1,26 @@
 using System.Numerics;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.FootPrint;
 
+// Floof: this system has been effectively rewriteen. DO NOT MERGE UPSTREAM CHANGES.
 [RegisterComponent]
 public sealed partial class FootPrintsComponent : Component
 {
-    [ViewVariables(VVAccess.ReadOnly), DataField]
+    [DataField]
     public ResPath RsiPath = new("/Textures/Effects/footprints.rsi");
 
-    // all of those are set as a layer
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public string LeftBarePrint = "footprint-left-bare-human";
+    [DataField]
+    public string
+        LeftBarePrint = "footprint-left-bare-human",
+        RightBarePrint = "footprint-right-bare-human",
+        ShoesPrint = "footprint-shoes",
+        SuitPrint = "footprint-suit";
 
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public string RightBarePrint = "footprint-right-bare-human";
-
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public string ShoesPrint = "footprint-shoes";
-
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public string SuitPrint = "footprint-suit";
-
-    [ViewVariables(VVAccess.ReadOnly), DataField]
+    [DataField]
     public string[] DraggingPrint =
     [
         "dragging-1",
@@ -32,13 +29,9 @@ public sealed partial class FootPrintsComponent : Component
         "dragging-4",
         "dragging-5",
     ];
-    // yea, those
 
-    [ViewVariables(VVAccess.ReadOnly), DataField]
+    [DataField]
     public EntProtoId<FootPrintComponent> StepProtoId = "Footstep";
-
-    [ViewVariables(VVAccess.ReadOnly), DataField]
-    public Color PrintsColor = Color.FromHex("#00000000");
 
     /// <summary>
     ///     The size scaling factor for footprint steps. Must be positive.
@@ -53,20 +46,8 @@ public sealed partial class FootPrintsComponent : Component
     public float DragSize = 0.5f;
 
     /// <summary>
-    ///     The amount of color to transfer from the source (e.g., puddle) to the footprint.
+    ///     Horizontal offset of the created footprints relative to the center.
     /// </summary>
-    [DataField]
-    public float ColorQuantity;
-
-    /// <summary>
-    ///     The factor by which the alpha channel is reduced in subsequent footprints.
-    /// </summary>
-    [DataField]
-    public float ColorReduceAlpha = 0.1f;
-
-    [DataField]
-    public string? ReagentToTransfer;
-
     [DataField]
     public Vector2 OffsetPrint = new(0.1f, 0f);
 
@@ -78,15 +59,21 @@ public sealed partial class FootPrintsComponent : Component
     /// <summary>
     ///     The position of the last footprint in world coordinates.
     /// </summary>
-    public Vector2 StepPos = Vector2.Zero;
-
-    /// <summary>
-    ///     Controls how quickly the footprint color transitions between steps.
-    ///     Value between 0 and 1, where higher values mean faster color changes.
-    /// </summary>
-    public float ColorInterpolationFactor = 0.2f;
+    public Vector2 LastStepPos = Vector2.Zero;
 
     // Floof
     [DataField]
     public HashSet<string> DNAs = new();
+
+    /// <summary>
+    ///     Reagent volume used for footprints.
+    /// </summary>
+    [DataField]
+    public Solution ContainedSolution = new(3) { CanReact = true, MaxVolume = 5f, };
+
+    /// <summary>
+    ///     Amount of reagents used per footprint.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 FootprintVolume = 1f;
 }

--- a/Content.Shared/Footprint/PuddleFootPrintsComponent.cs
+++ b/Content.Shared/Footprint/PuddleFootPrintsComponent.cs
@@ -1,11 +1,15 @@
+using Content.Shared.FixedPoint;
+
+
 namespace Content.Shared.FootPrint;
 
+// Floof: this system has been effectively rewriteen. DO NOT MERGE UPSTREAM CHANGES.
 [RegisterComponent]
 public sealed partial class PuddleFootPrintsComponent : Component
 {
+    /// <summary>
+    ///     Ratio between puddle volume and the amount of reagents that can be transferred from it.
+    /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    public float SizeRatio = 0.2f;
-
-    [ViewVariables(VVAccess.ReadWrite)]
-    public float OffPercent = 80f;
+    public FixedPoint2 SizeRatio = 0.15f;
 }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -154,7 +154,7 @@ public sealed class StandingStateSystem : EntitySystem
 
         var entityDistances = new Dictionary<EntityUid, float>();
 
-        foreach (var entity in _lookup.GetEntitiesInRange(uid, 0.3f))
+        foreach (var entity in _lookup.GetEntitiesIntersecting(uid)) // Floof - changed to GetEntitiesIntersecting to avoid climbing through walls
             if (HasComp<ClimbableComponent>(entity))
                 entityDistances[entity] = (Transform(uid).Coordinates.Position - Transform(entity).Coordinates.Position).LengthSquared();
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -17,6 +17,7 @@ public abstract partial class SharedToolSystem
         SubscribeLocalEvent<WelderComponent, ExaminedEvent>(OnWelderExamine);
         SubscribeLocalEvent<WelderComponent, AfterInteractEvent>(OnWelderAfterInteract);
         SubscribeLocalEvent<WelderComponent, DoAfterAttemptEvent<ToolDoAfterEvent>>(OnWelderToolUseAttempt);
+        SubscribeLocalEvent<WelderComponent, ToolUseAttemptEvent>(OnWelderUseAttempt);
         SubscribeLocalEvent<WelderComponent, ToolDoAfterEvent>(OnWelderDoAfter);
         SubscribeLocalEvent<WelderComponent, ItemToggledEvent>(OnToggle);
         SubscribeLocalEvent<WelderComponent, ItemToggleActivateAttemptEvent>(OnActivateAttempt);
@@ -138,6 +139,16 @@ public abstract partial class SharedToolSystem
             _popup.PopupClient(Loc.GetString("welder-component-cannot-weld-message"), entity, user);
             args.Cancel();
         }
+    }
+
+    // Floof - for some reason, wizden impl lacked this.
+    private void OnWelderUseAttempt(Entity<WelderComponent> entity, ref ToolUseAttemptEvent args)
+    {
+        if (ItemToggle.IsActivated(entity.Owner))
+            return;
+
+        _popup.PopupPredicted(Loc.GetString("welder-component-welder-not-lit-message"), entity, args.User);
+        args.Cancel();
     }
 
     private void OnWelderDoAfter(Entity<WelderComponent> ent, ref ToolDoAfterEvent args)

--- a/Resources/Locale/en-US/Floof/leash/leash.ftl
+++ b/Resources/Locale/en-US/Floof/leash/leash.ftl
@@ -18,3 +18,6 @@ leash-detaching-popup-others = {THE($user)} is trying to remove the leash {$isSe
 }...
 
 leash-snap-popup = {THE($leash)} snaps off!
+leash-set-length-popup = Length set to {$length}m.
+
+leash-length-examine-text = Its current length is {$length}m.

--- a/Resources/Prototypes/Entities/Objects/Decoration/ashtray.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/ashtray.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: Ashtray
-  parent: BaseItem
+  parent: BaseStorageItem # Floof - reparented
   name: ashtray
   description: Proven by scientists to improve the smoking experience by 37%!
   components:
@@ -22,9 +22,6 @@
     maxItemSize: Tiny
     grid:
     - 0,0,9,0
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
   - type: StorageFillVisualizer
     fillBaseName: icon
     maxFillLevels: 10

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -116,6 +116,7 @@
   - type: Tag
     tags:
     - Trash
+    - Burnt # Floof
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/tables.yml
@@ -54,6 +54,7 @@
   - type: Construction
     graph: Table
     node: TableFrame
+  - type: Climbable # Floof - making table frames climbable
 
 - type: entity
   id: CounterWoodFrame
@@ -109,6 +110,7 @@
   - type: Construction
     graph: Table
     node: CounterWoodFrame
+  - type: Climbable # Floof - making table frames climbable
 
 - type: entity
   id: CounterMetalFrame


### PR DESCRIPTION
# Description
Did a pass to fix most bugs known to me.

Codewise changes:
- Rewrote the footprints system, mostly. The system now precisely keeps tracks of reagents collected from puddles, which prevents reagent duping or reagent vanishing (both of which were possible with the old system), and also allows to transfer more than 1 reagent at once, to transfer water with footprints, and (oh god) mix water with potassium on YOUR OWN FEET
- Leash system: fixed the bug that allowed you to set the length of a leash regardless of whether you can interact with it, and added additional examination text and popups.
- Standing state system: Fixed laying down near a table allowing you to bypass any windoors or walls blocking access to the said table.
- Carrying system: carrying an entity standing beside a table should no longer cause carring to enter a broken state.
- Fixed welders being able to weld while not lit
- Fixed instrument bands not being allowed to be created if there are any opaque entities between the band leader and the actor. (note: mobs, water tanks, closets, tables are all considered opaque. Now we are checking for opaque entities that have the occluder component, which actually makes them occlude light)
- Fixed deep fryer UI buttons not working due to it interpreting the deep fryer itself as the "user" instead of the entity interacting with the ui.
- Fixed lingering color flash effects from stamina and regular damage, caused by a race condition due to deferred component removal.

Yaml changes:
- Reparented ashtrays to BaseStorageItem, fixing the bug with them not having an openable storage UI.
- Added the Burnt tag to ash, so it can actually fit into ashtrays.
- Made table and counter frames climbable, so that the next 70 kg human to climb a glass table doesn't have to suffocate inside a wall, unable to climb or destroy the now-shattered table.

TODO (maybe as a follow-up PR):
- try to fix atmos equations to use pressure differential instead of mole count
- fix ActivatableUIRequiresPower allowing to bypass the power requirement for any UI when the maintenance panel is open (perhaps wizden has a fix for that one?)
- Fix linked mood effects (addictions, positive effect followed by a negative one) acting weirdly when a positive mood mood effect is added after the linked negative has taken place, resulting in a mood effect spam.
- Fix the "depressed" mood overlay flickering every few minutes.

<details><summary><h1>Media</h1></summary>
<p>

Footprints:

https://github.com/user-attachments/assets/6201eef0-ee33-46ef-8a1d-9920e091a194

Deep fryer:

https://github.com/user-attachments/assets/23ada0f6-6568-472e-903e-4fc5ab1babeb

Color flash effects:

https://github.com/user-attachments/assets/48a1fe24-9425-47e0-886a-30026b470e6e

Music bands:

![image](https://github.com/user-attachments/assets/63499eb7-894c-4f8f-b4e9-4ea4bd69229f)

</p>
</details>

---

# Changelog
:cl:
- tweak: Improved the footprints system to properly adhere to energy & mass conservation principles.
- fix: Fixed leash length settings and added popups to them.
- fix: Fixed lying down near a table allowing to bypass barriers.
- fix: Deep fryer and music band UIs should now work correctly.
- fix: Fixed lingering color effects from stamina and damage.
- fix: Minor fixes: made table frames climbable, made ashtrays work correctly, made welders require being lit in order to weld glass. See the PR #452 for more details.