### PR TITLE
Pka Salvage Borg Changes 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -236,7 +236,8 @@
     - state: icon-pka
   - type: ItemBorgModule
     items:
-    - WeaponProtoKineticAccelerator
+    - WeaponProtoKineticAcceleratorborg #Floof
+    - SurvivalKnife # floof they are salavaging they should be able to cut a fish
 
 - type: entity
   id: BorgModuleGrapplingGun

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -1,38 +1,17 @@
 - type: entity
-  name: Borg kinetic Accelerator
-  parent: BaseWeaponBatterySmall
   id: WeaponProtoKineticAcceleratorborg
-  description: borg salvage gun
+  parent: WeaponProtoKineticAccelerator
+  name: proto-kinetic accelerator borg
+  noSpawn: true
   components:
-  - type: Sprite
-    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
-    layers:
-    - state: icon
-      map: ["enum.GunVisualLayers.Base"]
-  - type: Clothing
-    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
   - type: Gun
     fireRate: 0.5
-    availableModes:
-    - SemiAuto
+    selectedMode: SemiAuto
     minAngle: 1
     maxAngle: 3
+    availableModes:
+    - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
-    fireOnDropChance: 0.5
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletKinetic
-    fireCost: 100
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 40
-  - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
-  - type: Appearance
-  - type: Tag
-    tags:
-    - Sidearm
-  - type: StaticPrice
-    price: 750
+    fireOnDropChance: 1
 

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -14,7 +14,3 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
     fireOnDropChance: 1
-  - type: Sprite
-    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
-  - type: Item
-    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -1,16 +1,38 @@
 - type: entity
+  name: Borg kinetic Accelerator
+  parent: BaseWeaponBatterySmall
   id: WeaponProtoKineticAcceleratorborg
-  parent: WeaponProtoKineticAcceleratorBase
-  name: proto-kinetic accelerator borg
-  noSpawn: true
+  description: borg salvage gun
   components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
+    layers:
+    - state: icon
+      map: ["enum.GunVisualLayers.Base"]
+  - type: Clothing
+    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
   - type: Gun
     fireRate: 0.5
-    selectedMode: SemiAuto
-    minAngle: 1
-    maxAngle: 3
     availableModes:
     - SemiAuto
+    minAngle: 1
+    maxAngle: 3
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
-    fireOnDropChance: 1
+    fireOnDropChance: 0.5
+  - type: ProjectileBatteryAmmoProvider
+    proto: BulletKinetic
+    fireCost: 100
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 40
+  - type: Battery
+    maxCharge: 1000
+    startingCharge: 1000
+  - type: Appearance
+  - type: Tag
+    tags:
+    - Sidearm
+  - type: StaticPrice
+    price: 750
+

--- a/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Weapons/borgmodules.yml
@@ -1,0 +1,20 @@
+- type: entity
+  id: WeaponProtoKineticAcceleratorborg
+  parent: WeaponProtoKineticAcceleratorBase
+  name: proto-kinetic accelerator borg
+  noSpawn: true
+  components:
+  - type: Gun
+    fireRate: 0.5
+    selectedMode: SemiAuto
+    minAngle: 1
+    maxAngle: 3
+    availableModes:
+    - SemiAuto
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/kinetic_accel.ogg
+    fireOnDropChance: 1
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
+  - type: Item
+    sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi


### PR DESCRIPTION
commit

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Salvage borg had no melee weapon and couldn't really used the pka due to the weapon angel angel-wielding requirement 
this PR gives them a Survival knife (as told by floor)

---

# Changelog

:cl:
- tweak: SESWC tinkered with the salvage borg PKA module and taped a knife to its other arm.
