### PR TITLE
Map Reworks Kettle and Rad

### DIFF
--- a/Resources/Maps/Floof/kettle.yml
+++ b/Resources/Maps/Floof/kettle.yml
@@ -12130,7 +12130,7 @@ entities:
       pos: 10.5,32.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -3810.4055
+      secondsUntilStateChange: -3866.0059
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13218,7 +13218,7 @@ entities:
       pos: 30.5,50.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -4227.2954
+      secondsUntilStateChange: -4282.8955
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13982,7 +13982,7 @@ entities:
       pos: -55.5,-23.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -2293.1956
+      secondsUntilStateChange: -2348.796
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -79328,6 +79328,16 @@ entities:
       parent: 26185
     - type: Physics
       canCollide: False
+- proto: EncryptionKeyJustice
+  entities:
+  - uid: 26725
+    components:
+    - type: Transform
+      parent: 25896
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
 - proto: EncryptionKeyMedical
   entities:
   - uid: 26272
@@ -118823,7 +118833,7 @@ entities:
       pos: 29.5,63.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -17096.953
+      secondsUntilStateChange: -17152.553
       state: Opening
 - proto: HospitalCurtainsOpen
   entities:
@@ -147794,6 +147804,7 @@ entities:
           occludes: True
           ents:
           - 26275
+          - 26725
         machine_board: !type:Container
           showEnts: False
           occludes: True

--- a/Resources/Maps/Floof/kettle.yml
+++ b/Resources/Maps/Floof/kettle.yml
@@ -140,7 +140,7 @@ entities:
           version: 6
         3,2:
           ind: 3,2
-          tiles: cAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAABbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAACBwAAAAACbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAACBwAAAAABBwAAAAACBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAAABwAAAAACBwAAAAAABwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAAABwAAAAABBwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: cAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAABbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAACBwAAAAACbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAABBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAACBwAAAAABBwAAAAACBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAAABwAAAAACBwAAAAAABwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAAABwAAAAABBwAAAAACBwAAAAAABwAAAAACbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         3,1:
           ind: 3,1
@@ -164,7 +164,7 @@ entities:
           version: 6
         3,3:
           ind: 3,3
-          tiles: cAAAAAAABwAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAABBwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAAABwAAAAABBwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAACBwAAAAAABwAAAAACBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAAABwAAAAAABwAAAAACBwAAAAABBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAAABwAAAAABBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAAABwAAAAAABwAAAAACBwAAAAABBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACBwAAAAABBwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAAABwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: cAAAAAAABwAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAABBwAAAAABbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAACBwAAAAAABwAAAAABBwAAAAACBwAAAAAABwAAAAACbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAABBwAAAAABBwAAAAACBwAAAAAABwAAAAACBwAAAAACbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAABwAAAAAABwAAAAAABwAAAAACBwAAAAABBwAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAABwAAAAACBwAAAAAABwAAAAAABwAAAAABBwAAAAACbwAAAAAAbwAAAAAAbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAAABwAAAAAABwAAAAACBwAAAAABBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACBwAAAAABBwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAAABwAAAAACBwAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACBwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         2,3:
           ind: 2,3
@@ -7935,10 +7935,11 @@ entities:
           13,10:
             1: 61183
           13,11:
-            1: 3278
+            1: 36046
             0: 16416
           13,12:
             0: 1026
+            1: 51336
           14,8:
             1: 4096
           14,9:
@@ -7946,7 +7947,9 @@ entities:
           14,10:
             1: 4369
           14,11:
-            1: 273
+            1: 4369
+          14,12:
+            1: 4369
           12,4:
             1: 544
           12,-1:
@@ -8151,6 +8154,9 @@ entities:
             0: 1
           13,13:
             0: 4608
+            1: 12
+          14,13:
+            1: 1
           8,13:
             0: 3569
           7,13:
@@ -12124,7 +12130,7 @@ entities:
       pos: 10.5,32.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -373.0967
+      secondsUntilStateChange: -3810.4055
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13212,7 +13218,7 @@ entities:
       pos: 30.5,50.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -789.98676
+      secondsUntilStateChange: -4227.2954
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -13975,6 +13981,12 @@ entities:
     - type: Transform
       pos: -55.5,-23.5
       parent: 82
+    - type: Door
+      secondsUntilStateChange: -2293.1956
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 22635
     components:
     - type: Transform
@@ -14562,17 +14574,23 @@ entities:
       parent: 82
 - proto: AirlockShuttle
   entities:
+  - uid: 20891
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 56.5,45.5
+      parent: 82
+  - uid: 21243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 56.5,44.5
+      parent: 82
   - uid: 26165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 56.5,46.5
-      parent: 82
-  - uid: 26166
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 56.5,43.5
       parent: 82
 - proto: AirlockTheatreLocked
   entities:
@@ -15148,6 +15166,18 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
+- proto: ArrivalsShuttleTimer
+  entities:
+  - uid: 26539
+    components:
+    - type: Transform
+      pos: 74.5,-2.5
+      parent: 82
+  - uid: 26549
+    components:
+    - type: Transform
+      pos: 84.5,-2.5
+      parent: 82
 - proto: Ash
   entities:
   - uid: 21556
@@ -39350,6 +39380,31 @@ entities:
     - type: Transform
       pos: 16.5,33.5
       parent: 82
+  - uid: 26663
+    components:
+    - type: Transform
+      pos: 55.5,47.5
+      parent: 82
+  - uid: 26664
+    components:
+    - type: Transform
+      pos: 55.5,48.5
+      parent: 82
+  - uid: 26665
+    components:
+    - type: Transform
+      pos: 55.5,49.5
+      parent: 82
+  - uid: 26666
+    components:
+    - type: Transform
+      pos: 55.5,50.5
+      parent: 82
+  - uid: 26667
+    components:
+    - type: Transform
+      pos: 55.5,51.5
+      parent: 82
 - proto: CableApcStack
   entities:
   - uid: 4173
@@ -39387,16 +39442,6 @@ entities:
     - type: Transform
       pos: -63.623222,-42.277126
       parent: 82
-  - uid: 26053
-    components:
-    - type: Transform
-      pos: 37.774944,50.637146
-      parent: 82
-    - type: Stack
-      count: 29
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
   - uid: 26513
     components:
     - type: Transform
@@ -43775,6 +43820,36 @@ entities:
     - type: Transform
       pos: -12.5,82.5
       parent: 82
+  - uid: 11665
+    components:
+    - type: Transform
+      pos: -71.5,17.5
+      parent: 82
+  - uid: 11690
+    components:
+    - type: Transform
+      pos: -69.5,15.5
+      parent: 82
+  - uid: 11702
+    components:
+    - type: Transform
+      pos: -65.5,16.5
+      parent: 82
+  - uid: 11707
+    components:
+    - type: Transform
+      pos: -73.5,17.5
+      parent: 82
+  - uid: 11733
+    components:
+    - type: Transform
+      pos: -77.5,-27.5
+      parent: 82
+  - uid: 11746
+    components:
+    - type: Transform
+      pos: -73.5,3.5
+      parent: 82
   - uid: 11752
     components:
     - type: Transform
@@ -43819,11 +43894,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,2.5
-      parent: 82
-  - uid: 11761
-    components:
-    - type: Transform
-      pos: -73.5,3.5
       parent: 82
   - uid: 11762
     components:
@@ -43935,11 +44005,6 @@ entities:
     - type: Transform
       pos: -73.5,18.5
       parent: 82
-  - uid: 11784
-    components:
-    - type: Transform
-      pos: -73.5,17.5
-      parent: 82
   - uid: 11785
     components:
     - type: Transform
@@ -43975,11 +44040,6 @@ entities:
     - type: Transform
       pos: -71.5,18.5
       parent: 82
-  - uid: 11792
-    components:
-    - type: Transform
-      pos: -71.5,17.5
-      parent: 82
   - uid: 11793
     components:
     - type: Transform
@@ -44014,11 +44074,6 @@ entities:
     components:
     - type: Transform
       pos: -69.5,14.5
-      parent: 82
-  - uid: 11800
-    components:
-    - type: Transform
-      pos: -69.5,15.5
       parent: 82
   - uid: 11801
     components:
@@ -45535,11 +45590,6 @@ entities:
     - type: Transform
       pos: -79.5,-19.5
       parent: 82
-  - uid: 20938
-    components:
-    - type: Transform
-      pos: -79.5,-20.5
-      parent: 82
   - uid: 20939
     components:
     - type: Transform
@@ -45610,11 +45660,6 @@ entities:
     - type: Transform
       pos: -75.5,-18.5
       parent: 82
-  - uid: 20953
-    components:
-    - type: Transform
-      pos: -75.5,-19.5
-      parent: 82
   - uid: 20954
     components:
     - type: Transform
@@ -45674,11 +45719,6 @@ entities:
     components:
     - type: Transform
       pos: -82.5,-27.5
-      parent: 82
-  - uid: 20966
-    components:
-    - type: Transform
-      pos: -83.5,-27.5
       parent: 82
   - uid: 20967
     components:
@@ -45795,11 +45835,6 @@ entities:
     - type: Transform
       pos: -79.5,-34.5
       parent: 82
-  - uid: 20990
-    components:
-    - type: Transform
-      pos: -77.5,-27.5
-      parent: 82
   - uid: 20991
     components:
     - type: Transform
@@ -45865,11 +45900,6 @@ entities:
     - type: Transform
       pos: -75.5,-31.5
       parent: 82
-  - uid: 21004
-    components:
-    - type: Transform
-      pos: -75.5,-32.5
-      parent: 82
   - uid: 21005
     components:
     - type: Transform
@@ -45894,11 +45924,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,-29.5
-      parent: 82
-  - uid: 21010
-    components:
-    - type: Transform
-      pos: -73.5,-30.5
       parent: 82
   - uid: 21011
     components:
@@ -45935,11 +45960,6 @@ entities:
     - type: Transform
       pos: -73.5,-22.5
       parent: 82
-  - uid: 21018
-    components:
-    - type: Transform
-      pos: -73.5,-21.5
-      parent: 82
   - uid: 21019
     components:
     - type: Transform
@@ -45954,11 +45974,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,-18.5
-      parent: 82
-  - uid: 21022
-    components:
-    - type: Transform
-      pos: -73.5,-17.5
       parent: 82
   - uid: 21023
     components:
@@ -46040,11 +46055,6 @@ entities:
     - type: Transform
       pos: -33.5,-63.5
       parent: 82
-  - uid: 21265
-    components:
-    - type: Transform
-      pos: -34.5,-63.5
-      parent: 82
   - uid: 21266
     components:
     - type: Transform
@@ -46054,11 +46064,6 @@ entities:
     components:
     - type: Transform
       pos: -36.5,-63.5
-      parent: 82
-  - uid: 21268
-    components:
-    - type: Transform
-      pos: -37.5,-63.5
       parent: 82
   - uid: 21269
     components:
@@ -46074,11 +46079,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,-65.5
-      parent: 82
-  - uid: 21272
-    components:
-    - type: Transform
-      pos: -33.5,-65.5
       parent: 82
   - uid: 21273
     components:
@@ -46135,11 +46135,6 @@ entities:
     - type: Transform
       pos: -36.5,-67.5
       parent: 82
-  - uid: 21284
-    components:
-    - type: Transform
-      pos: -37.5,-67.5
-      parent: 82
   - uid: 21285
     components:
     - type: Transform
@@ -46149,11 +46144,6 @@ entities:
     components:
     - type: Transform
       pos: -39.5,-67.5
-      parent: 82
-  - uid: 21287
-    components:
-    - type: Transform
-      pos: -32.5,-69.5
       parent: 82
   - uid: 21288
     components:
@@ -46219,11 +46209,6 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-71.5
-      parent: 82
-  - uid: 21301
-    components:
-    - type: Transform
-      pos: -38.5,-71.5
       parent: 82
   - uid: 21302
     components:
@@ -46320,11 +46305,6 @@ entities:
     - type: Transform
       pos: -47.5,-69.5
       parent: 82
-  - uid: 21321
-    components:
-    - type: Transform
-      pos: -46.5,-69.5
-      parent: 82
   - uid: 21322
     components:
     - type: Transform
@@ -46354,16 +46334,6 @@ entities:
     components:
     - type: Transform
       pos: -49.5,-67.5
-      parent: 82
-  - uid: 21328
-    components:
-    - type: Transform
-      pos: -48.5,-67.5
-      parent: 82
-  - uid: 21329
-    components:
-    - type: Transform
-      pos: -47.5,-67.5
       parent: 82
   - uid: 21330
     components:
@@ -46494,21 +46464,6 @@ entities:
     components:
     - type: Transform
       pos: -49.5,-63.5
-      parent: 82
-  - uid: 21356
-    components:
-    - type: Transform
-      pos: -48.5,-63.5
-      parent: 82
-  - uid: 21357
-    components:
-    - type: Transform
-      pos: -47.5,-63.5
-      parent: 82
-  - uid: 21358
-    components:
-    - type: Transform
-      pos: -46.5,-63.5
       parent: 82
   - uid: 21359
     components:
@@ -47489,6 +47444,101 @@ entities:
     components:
     - type: Transform
       pos: 1.5,-51.5
+      parent: 82
+  - uid: 26557
+    components:
+    - type: Transform
+      pos: -73.5,-21.5
+      parent: 82
+  - uid: 26558
+    components:
+    - type: Transform
+      pos: -75.5,-19.5
+      parent: 82
+  - uid: 26559
+    components:
+    - type: Transform
+      pos: -73.5,-17.5
+      parent: 82
+  - uid: 26560
+    components:
+    - type: Transform
+      pos: -79.5,-20.5
+      parent: 82
+  - uid: 26561
+    components:
+    - type: Transform
+      pos: -79.5,-30.5
+      parent: 82
+  - uid: 26562
+    components:
+    - type: Transform
+      pos: -75.5,-32.5
+      parent: 82
+  - uid: 26563
+    components:
+    - type: Transform
+      pos: -73.5,-30.5
+      parent: 82
+  - uid: 26564
+    components:
+    - type: Transform
+      pos: -46.5,-69.5
+      parent: 82
+  - uid: 26565
+    components:
+    - type: Transform
+      pos: -48.5,-67.5
+      parent: 82
+  - uid: 26566
+    components:
+    - type: Transform
+      pos: -47.5,-67.5
+      parent: 82
+  - uid: 26567
+    components:
+    - type: Transform
+      pos: -48.5,-63.5
+      parent: 82
+  - uid: 26568
+    components:
+    - type: Transform
+      pos: -47.5,-63.5
+      parent: 82
+  - uid: 26569
+    components:
+    - type: Transform
+      pos: -46.5,-63.5
+      parent: 82
+  - uid: 26570
+    components:
+    - type: Transform
+      pos: -37.5,-63.5
+      parent: 82
+  - uid: 26571
+    components:
+    - type: Transform
+      pos: -34.5,-63.5
+      parent: 82
+  - uid: 26572
+    components:
+    - type: Transform
+      pos: -33.5,-65.5
+      parent: 82
+  - uid: 26573
+    components:
+    - type: Transform
+      pos: -37.5,-67.5
+      parent: 82
+  - uid: 26574
+    components:
+    - type: Transform
+      pos: -32.5,-69.5
+      parent: 82
+  - uid: 26575
+    components:
+    - type: Transform
+      pos: -38.5,-71.5
       parent: 82
 - proto: CableHVStack
   entities:
@@ -60195,6 +60245,84 @@ entities:
     - type: Transform
       pos: -41.5,-72.5
       parent: 82
+  - uid: 21250
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,38.5
+      parent: 82
+  - uid: 21265
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,39.5
+      parent: 82
+  - uid: 21268
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,40.5
+      parent: 82
+  - uid: 21272
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,41.5
+      parent: 82
+  - uid: 21284
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,42.5
+      parent: 82
+  - uid: 21287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,43.5
+      parent: 82
+  - uid: 21301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,38.5
+      parent: 82
+  - uid: 21321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,39.5
+      parent: 82
+  - uid: 21328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,40.5
+      parent: 82
+  - uid: 21329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,41.5
+      parent: 82
+  - uid: 21356
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,42.5
+      parent: 82
+  - uid: 21357
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,43.5
+      parent: 82
+  - uid: 21358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,39.5
+      parent: 82
   - uid: 21405
     components:
     - type: Transform
@@ -60703,6 +60831,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-19.5
       parent: 82
+  - uid: 25008
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,38.5
+      parent: 82
   - uid: 25048
     components:
     - type: Transform
@@ -60868,6 +61002,112 @@ entities:
     components:
     - type: Transform
       pos: 35.5,71.5
+      parent: 82
+  - uid: 26166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 52.5,38.5
+      parent: 82
+  - uid: 26281
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,44.5
+      parent: 82
+  - uid: 26416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,45.5
+      parent: 82
+  - uid: 26535
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,46.5
+      parent: 82
+  - uid: 26536
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,44.5
+      parent: 82
+  - uid: 26537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,45.5
+      parent: 82
+  - uid: 26538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 55.5,46.5
+      parent: 82
+  - uid: 26540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,35.5
+      parent: 82
+  - uid: 26541
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,34.5
+      parent: 82
+  - uid: 26542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,35.5
+      parent: 82
+  - uid: 26543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 54.5,34.5
+      parent: 82
+  - uid: 26668
+    components:
+    - type: Transform
+      pos: 55.5,47.5
+      parent: 82
+  - uid: 26669
+    components:
+    - type: Transform
+      pos: 55.5,48.5
+      parent: 82
+  - uid: 26670
+    components:
+    - type: Transform
+      pos: 55.5,49.5
+      parent: 82
+  - uid: 26671
+    components:
+    - type: Transform
+      pos: 55.5,50.5
+      parent: 82
+  - uid: 26672
+    components:
+    - type: Transform
+      pos: 55.5,51.5
+      parent: 82
+  - uid: 26673
+    components:
+    - type: Transform
+      pos: 55.5,52.5
+      parent: 82
+  - uid: 26674
+    components:
+    - type: Transform
+      pos: 54.5,52.5
+      parent: 82
+  - uid: 26675
+    components:
+    - type: Transform
+      pos: 54.5,51.5
       parent: 82
 - proto: Cautery
   entities:
@@ -68869,6 +69109,11 @@ entities:
         - 0
         - 0
         - 0
+  - uid: 26545
+    components:
+    - type: Transform
+      pos: 37.5,0.5
+      parent: 82
 - proto: CrateServiceJanitorialSupplies
   entities:
   - uid: 12196
@@ -69394,6 +69639,523 @@ entities:
     - type: Transform
       pos: -19.032625,-19.430998
       parent: 82
+- proto: DefaultStationBeacon
+  entities:
+  - uid: 5688
+    components:
+    - type: Transform
+      pos: 60.5,3.5
+      parent: 82
+  - uid: 26053
+    components:
+    - type: Transform
+      pos: 32.5,3.5
+      parent: 82
+  - uid: 26581
+    components:
+    - type: Transform
+      pos: -5.5,-25.5
+      parent: 82
+  - uid: 26582
+    components:
+    - type: Transform
+      pos: 20.5,-24.5
+      parent: 82
+  - uid: 26584
+    components:
+    - type: Transform
+      pos: 28.5,-32.5
+      parent: 82
+  - uid: 26625
+    components:
+    - type: Transform
+      pos: 28.5,-3.5
+      parent: 82
+  - uid: 26626
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 82
+  - uid: 26627
+    components:
+    - type: Transform
+      pos: -22.5,-3.5
+      parent: 82
+  - uid: 26628
+    components:
+    - type: Transform
+      pos: -22.5,9.5
+      parent: 82
+  - uid: 26629
+    components:
+    - type: Transform
+      pos: -41.5,-3.5
+      parent: 82
+  - uid: 26630
+    components:
+    - type: Transform
+      pos: -22.5,30.5
+      parent: 82
+  - uid: 26693
+    components:
+    - type: Transform
+      pos: -50.5,30.5
+      parent: 82
+  - uid: 26694
+    components:
+    - type: Transform
+      pos: -4.5,30.5
+      parent: 82
+  - uid: 26695
+    components:
+    - type: Transform
+      pos: 10.5,30.5
+      parent: 82
+  - uid: 26696
+    components:
+    - type: Transform
+      pos: -4.5,50.5
+      parent: 82
+  - uid: 26697
+    components:
+    - type: Transform
+      pos: 14.5,50.5
+      parent: 82
+  - uid: 26698
+    components:
+    - type: Transform
+      pos: 31.5,50.5
+      parent: 82
+  - uid: 26702
+    components:
+    - type: Transform
+      pos: -5.5,-61.5
+      parent: 82
+  - uid: 26703
+    components:
+    - type: Transform
+      pos: -5.5,-49.5
+      parent: 82
+- proto: DefaultStationBeaconAI
+  entities:
+  - uid: 11681
+    components:
+    - type: Transform
+      pos: 9.5,-88.5
+      parent: 82
+  - uid: 26596
+    components:
+    - type: Transform
+      pos: 20.5,-86.5
+      parent: 82
+  - uid: 26598
+    components:
+    - type: Transform
+      pos: 9.5,-96.5
+      parent: 82
+  - uid: 26599
+    components:
+    - type: Transform
+      pos: 31.5,-96.5
+      parent: 82
+  - uid: 26600
+    components:
+    - type: Transform
+      pos: 31.5,-88.5
+      parent: 82
+- proto: DefaultStationBeaconAICore
+  entities:
+  - uid: 26597
+    components:
+    - type: Transform
+      pos: 20.5,-102.5
+      parent: 82
+- proto: DefaultStationBeaconAISatellite
+  entities:
+  - uid: 26595
+    components:
+    - type: Transform
+      pos: 20.5,-62.5
+      parent: 82
+- proto: DefaultStationBeaconAME
+  entities:
+  - uid: 26601
+    components:
+    - type: Transform
+      pos: -12.5,50.5
+      parent: 82
+- proto: DefaultStationBeaconAnomalyGenerator
+  entities:
+  - uid: 26602
+    components:
+    - type: Transform
+      pos: 16.5,73.5
+      parent: 82
+- proto: DefaultStationBeaconArmory
+  entities:
+  - uid: 26604
+    components:
+    - type: Transform
+      pos: 50.5,-15.5
+      parent: 82
+  - uid: 26605
+    components:
+    - type: Transform
+      pos: 50.5,-19.5
+      parent: 82
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 26550
+    components:
+    - type: Transform
+      pos: 72.5,-8.5
+      parent: 82
+  - uid: 26551
+    components:
+    - type: Transform
+      pos: 86.5,-8.5
+      parent: 82
+  - uid: 26552
+    components:
+    - type: Transform
+      pos: 79.5,2.5
+      parent: 82
+- proto: DefaultStationBeaconArtifactLab
+  entities:
+  - uid: 26603
+    components:
+    - type: Transform
+      pos: 27.5,75.5
+      parent: 82
+- proto: DefaultStationBeaconAtmospherics
+  entities:
+  - uid: 26606
+    components:
+    - type: Transform
+      pos: 28.5,8.5
+      parent: 82
+  - uid: 26607
+    components:
+    - type: Transform
+      pos: 26.5,14.5
+      parent: 82
+  - uid: 26608
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 82
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 26594
+    components:
+    - type: Transform
+      pos: -21.5,-14.5
+      parent: 82
+- proto: DefaultStationBeaconBridge
+  entities:
+  - uid: 26592
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 82
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 26588
+    components:
+    - type: Transform
+      pos: 37.5,-18.5
+      parent: 82
+  - uid: 26589
+    components:
+    - type: Transform
+      pos: 40.5,-18.5
+      parent: 82
+  - uid: 26590
+    components:
+    - type: Transform
+      pos: 43.5,-18.5
+      parent: 82
+  - uid: 26591
+    components:
+    - type: Transform
+      pos: 46.5,-18.5
+      parent: 82
+- proto: DefaultStationBeaconCameraServerRoom
+  entities:
+  - uid: 26611
+    components:
+    - type: Transform
+      pos: 2.5,44.5
+      parent: 82
+- proto: DefaultStationBeaconCaptainsQuarters
+  entities:
+  - uid: 26613
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 82
+- proto: DefaultStationBeaconCargoReception
+  entities:
+  - uid: 26642
+    components:
+    - type: Transform
+      pos: 36.5,27.5
+      parent: 82
+- proto: DefaultStationBeaconCERoom
+  entities:
+  - uid: 26610
+    components:
+    - type: Transform
+      pos: -8.5,34.5
+      parent: 82
+- proto: DefaultStationBeaconChapel
+  entities:
+  - uid: 26615
+    components:
+    - type: Transform
+      pos: -14.5,16.5
+      parent: 82
+  - uid: 26616
+    components:
+    - type: Transform
+      pos: -16.5,9.5
+      parent: 82
+- proto: DefaultStationBeaconChemistry
+  entities:
+  - uid: 26576
+    components:
+    - type: Transform
+      pos: -33.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconCMORoom
+  entities:
+  - uid: 26612
+    components:
+    - type: Transform
+      pos: -42.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconCommand
+  entities:
+  - uid: 26617
+    components:
+    - type: Transform
+      pos: 22.5,0.5
+      parent: 82
+- proto: DefaultStationBeaconConferenceRoom
+  entities:
+  - uid: 26593
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 82
+- proto: DefaultStationBeaconCorpsman
+  entities:
+  - uid: 26618
+    components:
+    - type: Transform
+      pos: 51.5,-12.5
+      parent: 82
+- proto: DefaultStationBeaconCourtroom
+  entities:
+  - uid: 26585
+    components:
+    - type: Transform
+      pos: 26.5,-20.5
+      parent: 82
+- proto: DefaultStationBeaconCryonics
+  entities:
+  - uid: 26578
+    components:
+    - type: Transform
+      pos: -42.5,-42.5
+      parent: 82
+- proto: DefaultStationBeaconCryosleep
+  entities:
+  - uid: 26619
+    components:
+    - type: Transform
+      pos: 16.5,-43.5
+      parent: 82
+- proto: DefaultStationBeaconDetectiveRoom
+  entities:
+  - uid: 26620
+    components:
+    - type: Transform
+      pos: -53.5,0.5
+      parent: 82
+- proto: DefaultStationBeaconDisposals
+  entities:
+  - uid: 26579
+    components:
+    - type: Transform
+      pos: -63.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconDorms
+  entities:
+  - uid: 26583
+    components:
+    - type: Transform
+      pos: 7.5,-35.5
+      parent: 82
+  - uid: 26706
+    components:
+    - type: Transform
+      pos: -1.5,-38.5
+      parent: 82
+  - uid: 26707
+    components:
+    - type: Transform
+      pos: 3.5,-38.5
+      parent: 82
+  - uid: 26708
+    components:
+    - type: Transform
+      pos: 1.5,-31.5
+      parent: 82
+  - uid: 26709
+    components:
+    - type: Transform
+      pos: 7.5,-31.5
+      parent: 82
+  - uid: 26710
+    components:
+    - type: Transform
+      pos: 13.5,-31.5
+      parent: 82
+  - uid: 26711
+    components:
+    - type: Transform
+      pos: 11.5,-38.5
+      parent: 82
+  - uid: 26712
+    components:
+    - type: Transform
+      pos: 16.5,-38.5
+      parent: 82
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 26699
+    components:
+    - type: Transform
+      pos: -12.5,44.5
+      parent: 82
+  - uid: 26700
+    components:
+    - type: Transform
+      pos: -24.5,38.5
+      parent: 82
+  - uid: 26701
+    components:
+    - type: Transform
+      pos: -13.5,38.5
+      parent: 82
+- proto: DefaultStationBeaconEscapePod
+  entities:
+  - uid: 26624
+    components:
+    - type: Transform
+      pos: 88.5,3.5
+      parent: 82
+  - uid: 26713
+    components:
+    - type: Transform
+      pos: -53.5,47.5
+      parent: 82
+  - uid: 26714
+    components:
+    - type: Transform
+      pos: -53.5,38.5
+      parent: 82
+- proto: DefaultStationBeaconEvac
+  entities:
+  - uid: 26689
+    components:
+    - type: Transform
+      pos: -56.5,36.5
+      parent: 82
+  - uid: 26690
+    components:
+    - type: Transform
+      pos: -57.5,49.5
+      parent: 82
+  - uid: 26691
+    components:
+    - type: Transform
+      pos: -59.5,54.5
+      parent: 82
+- proto: DefaultStationBeaconEVAStorage
+  entities:
+  - uid: 26621
+    components:
+    - type: Transform
+      pos: -39.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconExam
+  entities:
+  - uid: 26580
+    components:
+    - type: Transform
+      pos: -34.5,-36.5
+      parent: 82
+- proto: DefaultStationBeaconGravGen
+  entities:
+  - uid: 26631
+    components:
+    - type: Transform
+      pos: 0.5,56.5
+      parent: 82
+- proto: DefaultStationBeaconHOPOffice
+  entities:
+  - uid: 26633
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 82
+  - uid: 26634
+    components:
+    - type: Transform
+      pos: -11.5,1.5
+      parent: 82
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 26635
+    components:
+    - type: Transform
+      pos: 59.5,-9.5
+      parent: 82
+  - uid: 26636
+    components:
+    - type: Transform
+      pos: 61.5,-15.5
+      parent: 82
+- proto: DefaultStationBeaconJanitorsCloset
+  entities:
+  - uid: 26632
+    components:
+    - type: Transform
+      pos: -0.5,37.5
+      parent: 82
+- proto: DefaultStationBeaconKitchen
+  entities:
+  - uid: 26637
+    components:
+    - type: Transform
+      pos: -32.5,-12.5
+      parent: 82
+- proto: DefaultStationBeaconLawOffice
+  entities:
+  - uid: 26639
+    components:
+    - type: Transform
+      pos: 28.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 26640
+    components:
+    - type: Transform
+      pos: 26.5,26.5
+      parent: 82
 - proto: DefaultStationBeaconMailroom
   entities:
   - uid: 11625
@@ -69403,17 +70165,110 @@ entities:
       parent: 82
 - proto: DefaultStationBeaconMantis
   entities:
-  - uid: 5688
+  - uid: 26644
     components:
     - type: Transform
       pos: 36.5,50.5
       parent: 82
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 26645
+    components:
+    - type: Transform
+      pos: -24.5,-29.5
+      parent: 82
+  - uid: 26646
+    components:
+    - type: Transform
+      pos: -37.5,-31.5
+      parent: 82
+  - uid: 26647
+    components:
+    - type: Transform
+      pos: -50.5,-31.5
+      parent: 82
+- proto: DefaultStationBeaconMetempsychosis
+  entities:
+  - uid: 26577
+    components:
+    - type: Transform
+      pos: -49.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconMorgue
+  entities:
+  - uid: 26648
+    components:
+    - type: Transform
+      pos: -55.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconPark
+  entities:
+  - uid: 26649
+    components:
+    - type: Transform
+      pos: -11.5,-34.5
+      parent: 82
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 26651
+    components:
+    - type: Transform
+      pos: 57.5,-41.5
+      parent: 82
+  - uid: 26652
+    components:
+    - type: Transform
+      pos: 49.5,-42.5
+      parent: 82
+  - uid: 26653
+    components:
+    - type: Transform
+      pos: 44.5,-48.5
+      parent: 82
+  - uid: 26654
+    components:
+    - type: Transform
+      pos: 48.5,-48.5
+      parent: 82
+  - uid: 26655
+    components:
+    - type: Transform
+      pos: 52.5,-48.5
+      parent: 82
+  - uid: 26656
+    components:
+    - type: Transform
+      pos: 44.5,-42.5
+      parent: 82
+- proto: DefaultStationBeaconPowerBank
+  entities:
+  - uid: 26660
+    components:
+    - type: Transform
+      pos: -25.5,42.5
+      parent: 82
 - proto: DefaultStationBeaconPsychologist
   entities:
-  - uid: 26416
+  - uid: 26544
     components:
     - type: Transform
       pos: -0.5,-55.5
+      parent: 82
+    - type: NavMapBeacon
+      text: Psych
+- proto: DefaultStationBeaconQMRoom
+  entities:
+  - uid: 26638
+    components:
+    - type: Transform
+      pos: 46.5,12.5
+      parent: 82
+- proto: DefaultStationBeaconRDRoom
+  entities:
+  - uid: 26643
+    components:
+    - type: Transform
+      pos: 28.5,64.5
       parent: 82
 - proto: DefaultStationBeaconReporter
   entities:
@@ -69421,6 +70276,177 @@ entities:
     components:
     - type: Transform
       pos: -10.5,-56.5
+      parent: 82
+    - type: NavMapBeacon
+      text: Reporter
+- proto: DefaultStationBeaconRobotics
+  entities:
+  - uid: 26658
+    components:
+    - type: Transform
+      pos: 14.5,55.5
+      parent: 82
+- proto: DefaultStationBeaconSalvage
+  entities:
+  - uid: 26659
+    components:
+    - type: Transform
+      pos: 43.5,33.5
+      parent: 82
+  - uid: 26661
+    components:
+    - type: Transform
+      pos: 50.5,36.5
+      parent: 82
+  - uid: 26662
+    components:
+    - type: Transform
+      pos: 54.5,37.5
+      parent: 82
+- proto: DefaultStationBeaconScience
+  entities:
+  - uid: 26622
+    components:
+    - type: Transform
+      pos: 26.5,60.5
+      parent: 82
+  - uid: 26623
+    components:
+    - type: Transform
+      pos: 21.5,66.5
+      parent: 82
+- proto: DefaultStationBeaconSecurityCheckpoint
+  entities:
+  - uid: 11678
+    components:
+    - type: Transform
+      pos: -24.5,-38.5
+      parent: 82
+  - uid: 26679
+    components:
+    - type: Transform
+      pos: -28.5,26.5
+      parent: 82
+  - uid: 26692
+    components:
+    - type: Transform
+      pos: -62.5,49.5
+      parent: 82
+- proto: DefaultStationBeaconServerRoom
+  entities:
+  - uid: 26657
+    components:
+    - type: Transform
+      pos: 12.5,64.5
+      parent: 82
+- proto: DefaultStationBeaconService
+  entities:
+  - uid: 26680
+    components:
+    - type: Transform
+      pos: 15.5,-49.5
+      parent: 82
+  - uid: 26681
+    components:
+    - type: Transform
+      pos: -16.5,25.5
+      parent: 82
+  - uid: 26704
+    components:
+    - type: Transform
+      pos: -10.5,-48.5
+      parent: 82
+  - uid: 26705
+    components:
+    - type: Transform
+      pos: -10.5,-52.5
+      parent: 82
+- proto: DefaultStationBeaconSingularity
+  entities:
+  - uid: 26650
+    components:
+    - type: Transform
+      pos: -26.5,54.5
+      parent: 82
+- proto: DefaultStationBeaconSolars
+  entities:
+  - uid: 20854
+    components:
+    - type: Transform
+      pos: -64.5,-25.5
+      parent: 82
+  - uid: 21238
+    components:
+    - type: Transform
+      pos: -41.5,-50.5
+      parent: 82
+- proto: DefaultStationBeaconSupply
+  entities:
+  - uid: 26609
+    components:
+    - type: Transform
+      pos: 37.5,13.5
+      parent: 82
+    - type: NavMapBeacon
+      text: Cargo Bay
+  - uid: 26614
+    components:
+    - type: Transform
+      pos: 43.5,22.5
+      parent: 82
+  - uid: 26641
+    components:
+    - type: Transform
+      pos: 36.5,8.5
+      parent: 82
+    - type: NavMapBeacon
+      text: Mailroom
+- proto: DefaultStationBeaconTechVault
+  entities:
+  - uid: 26682
+    components:
+    - type: Transform
+      pos: 9.5,36.5
+      parent: 82
+  - uid: 26683
+    components:
+    - type: Transform
+      pos: 12.5,38.5
+      parent: 82
+- proto: DefaultStationBeaconTelecoms
+  entities:
+  - uid: 26685
+    components:
+    - type: Transform
+      pos: -31.5,18.5
+      parent: 82
+- proto: DefaultStationBeaconToolRoom
+  entities:
+  - uid: 26684
+    components:
+    - type: Transform
+      pos: -29.5,3.5
+      parent: 82
+- proto: DefaultStationBeaconVault
+  entities:
+  - uid: 26686
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 82
+- proto: DefaultStationBeaconVirology
+  entities:
+  - uid: 26687
+    components:
+    - type: Transform
+      pos: -44.5,-25.5
+      parent: 82
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 26688
+    components:
+    - type: Transform
+      pos: 41.5,-8.5
       parent: 82
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -82765,6 +83791,8 @@ entities:
   entities:
   - uid: 754
     components:
+    - type: MetaData
+      name: Distro Gas Mixer
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 12.5,14.5
@@ -101460,6 +102488,13 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 21246
+    components:
+    - type: Transform
+      pos: -41.5,-42.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 22443
     components:
     - type: Transform
@@ -104441,16 +105476,22 @@ entities:
       parent: 82
   - uid: 710
     components:
+    - type: MetaData
+      name: N2 Pump
     - type: Transform
       pos: 11.5,17.5
       parent: 82
   - uid: 711
     components:
+    - type: MetaData
+      name: O2 Pump
     - type: Transform
       pos: 9.5,17.5
       parent: 82
   - uid: 719
     components:
+    - type: MetaData
+      name: Distro Pump
     - type: Transform
       pos: 18.5,15.5
       parent: 82
@@ -104576,6 +105617,8 @@ entities:
       color: '#0055CCFF'
   - uid: 15518
     components:
+    - type: MetaData
+      name: Cryo Distro Pump
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-40.5
@@ -104584,6 +105627,8 @@ entities:
       color: '#0055CCFF'
   - uid: 18739
     components:
+    - type: MetaData
+      name: Cryo Waste Pump
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -40.5,-42.5
@@ -106964,6 +108009,8 @@ entities:
   entities:
   - uid: 901
     components:
+    - type: MetaData
+      name: Waste Pump
     - type: Transform
       pos: -5.5,17.5
       parent: 82
@@ -117776,7 +118823,7 @@ entities:
       pos: 29.5,63.5
       parent: 82
     - type: Door
-      secondsUntilStateChange: -13659.644
+      secondsUntilStateChange: -17096.953
       state: Opening
 - proto: HospitalCurtainsOpen
   entities:
@@ -126482,17 +127529,26 @@ entities:
       parent: 82
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 26281
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 56.5,44.5
-      parent: 82
   - uid: 26282
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 55.5,35.5
+      parent: 82
+  - uid: 26676
+    components:
+    - type: Transform
+      pos: 53.5,45.5
+      parent: 82
+  - uid: 26677
+    components:
+    - type: Transform
+      pos: 54.5,50.5
+      parent: 82
+  - uid: 26678
+    components:
+    - type: Transform
+      pos: 54.5,47.5
       parent: 82
 - proto: PoweredlightSodium
   entities:
@@ -129898,11 +130954,6 @@ entities:
     - type: Transform
       pos: 13.5,-37.5
       parent: 82
-  - uid: 13935
-    components:
-    - type: Transform
-      pos: -63.5,41.5
-      parent: 82
   - uid: 24744
     components:
     - type: Transform
@@ -130198,11 +131249,6 @@ entities:
     - type: Transform
       pos: -27.5,32.5
       parent: 82
-  - uid: 25008
-    components:
-    - type: Transform
-      pos: -63.5,45.5
-      parent: 82
   - uid: 25020
     components:
     - type: Transform
@@ -130273,6 +131319,16 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -43.5,-12.5
+      parent: 82
+  - uid: 26554
+    components:
+    - type: Transform
+      pos: -64.5,41.5
+      parent: 82
+  - uid: 26555
+    components:
+    - type: Transform
+      pos: -64.5,45.5
       parent: 82
 - proto: RandomSnacks
   entities:
@@ -136277,6 +137333,18 @@ entities:
     - type: Transform
       pos: 59.497196,-36.45737
       parent: 82
+- proto: Screen
+  entities:
+  - uid: 20895
+    components:
+    - type: Transform
+      pos: -63.5,41.5
+      parent: 82
+  - uid: 20899
+    components:
+    - type: Transform
+      pos: -63.5,45.5
+      parent: 82
 - proto: Screwdriver
   entities:
   - uid: 10906
@@ -136378,8 +137446,11 @@ entities:
   - uid: 26288
     components:
     - type: Transform
-      pos: 17.477987,74.5598
+      pos: 17.385406,74.58083
       parent: 82
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: SheetPlasteel
   entities:
   - uid: 6439
@@ -138426,6 +139497,18 @@ entities:
     - type: Transform
       pos: 4.5,-12.5
       parent: 82
+- proto: SignCourt
+  entities:
+  - uid: 26586
+    components:
+    - type: Transform
+      pos: 23.5,-22.5
+      parent: 82
+  - uid: 26587
+    components:
+    - type: Transform
+      pos: 23.5,-17.5
+      parent: 82
 - proto: SignCryogenicsMed
   entities:
   - uid: 18570
@@ -140160,6 +141243,8 @@ entities:
       parent: 82
   - uid: 8060
     components:
+    - type: MetaData
+      name: Telecom SMES
     - type: Transform
       pos: -27.5,20.5
       parent: 82
@@ -140242,13 +141327,155 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -16.5,-14.5
       parent: 82
-- proto: SolarPanel
+- proto: SolarAssembly
   entities:
-  - uid: 10804
+  - uid: 11667
     components:
     - type: Transform
-      pos: -75.5,18.5
+      pos: -65.5,16.5
       parent: 82
+  - uid: 11672
+    components:
+    - type: Transform
+      pos: -69.5,15.5
+      parent: 82
+  - uid: 11674
+    components:
+    - type: Transform
+      pos: -75.5,-32.5
+      parent: 82
+  - uid: 11727
+    components:
+    - type: Transform
+      pos: -73.5,17.5
+      parent: 82
+  - uid: 11736
+    components:
+    - type: Transform
+      pos: -73.5,3.5
+      parent: 82
+  - uid: 11749
+    components:
+    - type: Transform
+      pos: -71.5,4.5
+      parent: 82
+  - uid: 20822
+    components:
+    - type: Transform
+      pos: -73.5,-21.5
+      parent: 82
+  - uid: 20828
+    components:
+    - type: Transform
+      pos: -75.5,-19.5
+      parent: 82
+  - uid: 20832
+    components:
+    - type: Transform
+      pos: -77.5,-27.5
+      parent: 82
+  - uid: 20839
+    components:
+    - type: Transform
+      pos: -79.5,-20.5
+      parent: 82
+  - uid: 20860
+    components:
+    - type: Transform
+      pos: -37.5,-67.5
+      parent: 82
+  - uid: 20864
+    components:
+    - type: Transform
+      pos: -34.5,-63.5
+      parent: 82
+  - uid: 20867
+    components:
+    - type: Transform
+      pos: -32.5,-69.5
+      parent: 82
+  - uid: 20871
+    components:
+    - type: Transform
+      pos: -46.5,-69.5
+      parent: 82
+  - uid: 20872
+    components:
+    - type: Transform
+      pos: -48.5,-67.5
+      parent: 82
+  - uid: 20904
+    components:
+    - type: Transform
+      pos: -73.5,-17.5
+      parent: 82
+  - uid: 20907
+    components:
+    - type: Transform
+      pos: -77.5,-18.5
+      parent: 82
+  - uid: 20953
+    components:
+    - type: Transform
+      pos: -73.5,-30.5
+      parent: 82
+  - uid: 20966
+    components:
+    - type: Transform
+      pos: -65.5,6.5
+      parent: 82
+  - uid: 20990
+    components:
+    - type: Transform
+      pos: -79.5,-30.5
+      parent: 82
+  - uid: 21018
+    components:
+    - type: Transform
+      pos: -75.5,-33.5
+      parent: 82
+  - uid: 21177
+    components:
+    - type: Transform
+      pos: -33.5,-65.5
+      parent: 82
+  - uid: 21191
+    components:
+    - type: Transform
+      pos: -47.5,-67.5
+      parent: 82
+  - uid: 21192
+    components:
+    - type: Transform
+      pos: -38.5,-71.5
+      parent: 82
+  - uid: 21214
+    components:
+    - type: Transform
+      pos: -46.5,-63.5
+      parent: 82
+  - uid: 21224
+    components:
+    - type: Transform
+      pos: -47.5,-63.5
+      parent: 82
+  - uid: 21229
+    components:
+    - type: Transform
+      pos: -37.5,-63.5
+      parent: 82
+  - uid: 21233
+    components:
+    - type: Transform
+      pos: -48.5,-63.5
+      parent: 82
+  - uid: 26556
+    components:
+    - type: Transform
+      pos: -71.5,17.5
+      parent: 82
+- proto: SolarPanel
+  entities:
   - uid: 10805
     components:
     - type: Transform
@@ -140294,20 +141521,10 @@ entities:
     - type: Transform
       pos: -73.5,14.5
       parent: 82
-  - uid: 11665
-    components:
-    - type: Transform
-      pos: -73.5,15.5
-      parent: 82
   - uid: 11666
     components:
     - type: Transform
       pos: -73.5,16.5
-      parent: 82
-  - uid: 11667
-    components:
-    - type: Transform
-      pos: -73.5,17.5
       parent: 82
   - uid: 11668
     components:
@@ -140329,20 +141546,10 @@ entities:
     - type: Transform
       pos: -71.5,20.5
       parent: 82
-  - uid: 11672
-    components:
-    - type: Transform
-      pos: -71.5,19.5
-      parent: 82
   - uid: 11673
     components:
     - type: Transform
       pos: -71.5,18.5
-      parent: 82
-  - uid: 11674
-    components:
-    - type: Transform
-      pos: -71.5,17.5
       parent: 82
   - uid: 11675
     components:
@@ -140359,11 +141566,6 @@ entities:
     - type: Transform
       pos: -71.5,14.5
       parent: 82
-  - uid: 11678
-    components:
-    - type: Transform
-      pos: -71.5,13.5
-      parent: 82
   - uid: 11679
     components:
     - type: Transform
@@ -140373,16 +141575,6 @@ entities:
     components:
     - type: Transform
       pos: -69.5,14.5
-      parent: 82
-  - uid: 11681
-    components:
-    - type: Transform
-      pos: -69.5,15.5
-      parent: 82
-  - uid: 11682
-    components:
-    - type: Transform
-      pos: -69.5,16.5
       parent: 82
   - uid: 11683
     components:
@@ -140399,11 +141591,6 @@ entities:
     - type: Transform
       pos: -69.5,19.5
       parent: 82
-  - uid: 11686
-    components:
-    - type: Transform
-      pos: -69.5,20.5
-      parent: 82
   - uid: 11687
     components:
     - type: Transform
@@ -140418,11 +141605,6 @@ entities:
     components:
     - type: Transform
       pos: -67.5,18.5
-      parent: 82
-  - uid: 11690
-    components:
-    - type: Transform
-      pos: -67.5,17.5
       parent: 82
   - uid: 11691
     components:
@@ -140464,11 +141646,6 @@ entities:
     - type: Transform
       pos: -65.5,17.5
       parent: 82
-  - uid: 11699
-    components:
-    - type: Transform
-      pos: -65.5,16.5
-      parent: 82
   - uid: 11700
     components:
     - type: Transform
@@ -140478,11 +141655,6 @@ entities:
     components:
     - type: Transform
       pos: -65.5,14.5
-      parent: 82
-  - uid: 11702
-    components:
-    - type: Transform
-      pos: -65.5,13.5
       parent: 82
   - uid: 11703
     components:
@@ -140498,16 +141670,6 @@ entities:
     components:
     - type: Transform
       pos: -75.5,7.5
-      parent: 82
-  - uid: 11706
-    components:
-    - type: Transform
-      pos: -75.5,6.5
-      parent: 82
-  - uid: 11707
-    components:
-    - type: Transform
-      pos: -75.5,5.5
       parent: 82
   - uid: 11708
     components:
@@ -140554,11 +141716,6 @@ entities:
     - type: Transform
       pos: -73.5,4.5
       parent: 82
-  - uid: 11717
-    components:
-    - type: Transform
-      pos: -73.5,3.5
-      parent: 82
   - uid: 11718
     components:
     - type: Transform
@@ -140579,20 +141736,10 @@ entities:
     - type: Transform
       pos: -71.5,7.5
       parent: 82
-  - uid: 11722
-    components:
-    - type: Transform
-      pos: -71.5,6.5
-      parent: 82
   - uid: 11723
     components:
     - type: Transform
       pos: -71.5,5.5
-      parent: 82
-  - uid: 11724
-    components:
-    - type: Transform
-      pos: -71.5,4.5
       parent: 82
   - uid: 11725
     components:
@@ -140603,16 +141750,6 @@ entities:
     components:
     - type: Transform
       pos: -71.5,2.5
-      parent: 82
-  - uid: 11727
-    components:
-    - type: Transform
-      pos: -69.5,9.5
-      parent: 82
-  - uid: 11728
-    components:
-    - type: Transform
-      pos: -69.5,8.5
       parent: 82
   - uid: 11729
     components:
@@ -140634,11 +141771,6 @@ entities:
     - type: Transform
       pos: -69.5,4.5
       parent: 82
-  - uid: 11733
-    components:
-    - type: Transform
-      pos: -69.5,3.5
-      parent: 82
   - uid: 11734
     components:
     - type: Transform
@@ -140648,11 +141780,6 @@ entities:
     components:
     - type: Transform
       pos: -67.5,9.5
-      parent: 82
-  - uid: 11736
-    components:
-    - type: Transform
-      pos: -67.5,8.5
       parent: 82
   - uid: 11737
     components:
@@ -140669,11 +141796,6 @@ entities:
     - type: Transform
       pos: -67.5,5.5
       parent: 82
-  - uid: 11740
-    components:
-    - type: Transform
-      pos: -67.5,4.5
-      parent: 82
   - uid: 11741
     components:
     - type: Transform
@@ -140683,11 +141805,6 @@ entities:
     components:
     - type: Transform
       pos: -67.5,2.5
-      parent: 82
-  - uid: 11743
-    components:
-    - type: Transform
-      pos: -65.5,9.5
       parent: 82
   - uid: 11744
     components:
@@ -140699,11 +141816,6 @@ entities:
     - type: Transform
       pos: -65.5,7.5
       parent: 82
-  - uid: 11746
-    components:
-    - type: Transform
-      pos: -65.5,6.5
-      parent: 82
   - uid: 11747
     components:
     - type: Transform
@@ -140713,11 +141825,6 @@ entities:
     components:
     - type: Transform
       pos: -65.5,4.5
-      parent: 82
-  - uid: 11749
-    components:
-    - type: Transform
-      pos: -65.5,3.5
       parent: 82
   - uid: 11750
     components:
@@ -140738,11 +141845,6 @@ entities:
     components:
     - type: Transform
       pos: -75.5,-18.5
-      parent: 82
-  - uid: 20822
-    components:
-    - type: Transform
-      pos: -75.5,-19.5
       parent: 82
   - uid: 20823
     components:
@@ -140769,30 +141871,15 @@ entities:
     - type: Transform
       pos: -73.5,-16.5
       parent: 82
-  - uid: 20828
-    components:
-    - type: Transform
-      pos: -73.5,-17.5
-      parent: 82
   - uid: 20829
     components:
     - type: Transform
       pos: -73.5,-18.5
       parent: 82
-  - uid: 20830
-    components:
-    - type: Transform
-      pos: -73.5,-19.5
-      parent: 82
   - uid: 20831
     components:
     - type: Transform
       pos: -73.5,-20.5
-      parent: 82
-  - uid: 20832
-    components:
-    - type: Transform
-      pos: -73.5,-21.5
       parent: 82
   - uid: 20833
     components:
@@ -140803,11 +141890,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,-23.5
-      parent: 82
-  - uid: 20835
-    components:
-    - type: Transform
-      pos: -79.5,-16.5
       parent: 82
   - uid: 20836
     components:
@@ -140823,11 +141905,6 @@ entities:
     components:
     - type: Transform
       pos: -79.5,-19.5
-      parent: 82
-  - uid: 20839
-    components:
-    - type: Transform
-      pos: -79.5,-20.5
       parent: 82
   - uid: 20840
     components:
@@ -140853,11 +141930,6 @@ entities:
     components:
     - type: Transform
       pos: -77.5,-17.5
-      parent: 82
-  - uid: 20845
-    components:
-    - type: Transform
-      pos: -77.5,-18.5
       parent: 82
   - uid: 20846
     components:
@@ -140899,11 +141971,6 @@ entities:
     - type: Transform
       pos: -81.5,-18.5
       parent: 82
-  - uid: 20854
-    components:
-    - type: Transform
-      pos: -81.5,-19.5
-      parent: 82
   - uid: 20855
     components:
     - type: Transform
@@ -140929,11 +141996,6 @@ entities:
     - type: Transform
       pos: -83.5,-16.5
       parent: 82
-  - uid: 20860
-    components:
-    - type: Transform
-      pos: -83.5,-17.5
-      parent: 82
   - uid: 20861
     components:
     - type: Transform
@@ -140949,11 +142011,6 @@ entities:
     - type: Transform
       pos: -83.5,-20.5
       parent: 82
-  - uid: 20864
-    components:
-    - type: Transform
-      pos: -83.5,-21.5
-      parent: 82
   - uid: 20865
     components:
     - type: Transform
@@ -140963,11 +142020,6 @@ entities:
     components:
     - type: Transform
       pos: -83.5,-23.5
-      parent: 82
-  - uid: 20867
-    components:
-    - type: Transform
-      pos: -83.5,-27.5
       parent: 82
   - uid: 20868
     components:
@@ -140983,16 +142035,6 @@ entities:
     components:
     - type: Transform
       pos: -83.5,-30.5
-      parent: 82
-  - uid: 20871
-    components:
-    - type: Transform
-      pos: -83.5,-31.5
-      parent: 82
-  - uid: 20872
-    components:
-    - type: Transform
-      pos: -83.5,-32.5
       parent: 82
   - uid: 20873
     components:
@@ -141013,11 +142055,6 @@ entities:
     components:
     - type: Transform
       pos: -81.5,-28.5
-      parent: 82
-  - uid: 20877
-    components:
-    - type: Transform
-      pos: -81.5,-29.5
       parent: 82
   - uid: 20878
     components:
@@ -141044,11 +142081,6 @@ entities:
     - type: Transform
       pos: -81.5,-34.5
       parent: 82
-  - uid: 20883
-    components:
-    - type: Transform
-      pos: -79.5,-27.5
-      parent: 82
   - uid: 20884
     components:
     - type: Transform
@@ -141058,11 +142090,6 @@ entities:
     components:
     - type: Transform
       pos: -79.5,-29.5
-      parent: 82
-  - uid: 20886
-    components:
-    - type: Transform
-      pos: -79.5,-30.5
       parent: 82
   - uid: 20887
     components:
@@ -141074,20 +142101,10 @@ entities:
     - type: Transform
       pos: -79.5,-32.5
       parent: 82
-  - uid: 20889
-    components:
-    - type: Transform
-      pos: -79.5,-33.5
-      parent: 82
   - uid: 20890
     components:
     - type: Transform
       pos: -79.5,-34.5
-      parent: 82
-  - uid: 20891
-    components:
-    - type: Transform
-      pos: -77.5,-27.5
       parent: 82
   - uid: 20892
     components:
@@ -141104,11 +142121,6 @@ entities:
     - type: Transform
       pos: -77.5,-30.5
       parent: 82
-  - uid: 20895
-    components:
-    - type: Transform
-      pos: -77.5,-31.5
-      parent: 82
   - uid: 20896
     components:
     - type: Transform
@@ -141123,11 +142135,6 @@ entities:
     components:
     - type: Transform
       pos: -77.5,-34.5
-      parent: 82
-  - uid: 20899
-    components:
-    - type: Transform
-      pos: -75.5,-27.5
       parent: 82
   - uid: 20900
     components:
@@ -141149,25 +142156,10 @@ entities:
     - type: Transform
       pos: -75.5,-31.5
       parent: 82
-  - uid: 20904
-    components:
-    - type: Transform
-      pos: -75.5,-32.5
-      parent: 82
-  - uid: 20905
-    components:
-    - type: Transform
-      pos: -75.5,-33.5
-      parent: 82
   - uid: 20906
     components:
     - type: Transform
       pos: -75.5,-34.5
-      parent: 82
-  - uid: 20907
-    components:
-    - type: Transform
-      pos: -73.5,-27.5
       parent: 82
   - uid: 20908
     components:
@@ -141178,11 +142170,6 @@ entities:
     components:
     - type: Transform
       pos: -73.5,-29.5
-      parent: 82
-  - uid: 20910
-    components:
-    - type: Transform
-      pos: -73.5,-30.5
       parent: 82
   - uid: 20911
     components:
@@ -141213,11 +142200,6 @@ entities:
     components:
     - type: Transform
       pos: -44.5,-71.5
-      parent: 82
-  - uid: 21158
-    components:
-    - type: Transform
-      pos: -45.5,-71.5
       parent: 82
   - uid: 21159
     components:
@@ -141259,11 +142241,6 @@ entities:
     - type: Transform
       pos: -45.5,-69.5
       parent: 82
-  - uid: 21167
-    components:
-    - type: Transform
-      pos: -46.5,-69.5
-      parent: 82
   - uid: 21168
     components:
     - type: Transform
@@ -141273,11 +142250,6 @@ entities:
     components:
     - type: Transform
       pos: -48.5,-69.5
-      parent: 82
-  - uid: 21170
-    components:
-    - type: Transform
-      pos: -49.5,-69.5
       parent: 82
   - uid: 21171
     components:
@@ -141294,25 +142266,10 @@ entities:
     - type: Transform
       pos: -44.5,-67.5
       parent: 82
-  - uid: 21174
-    components:
-    - type: Transform
-      pos: -45.5,-67.5
-      parent: 82
   - uid: 21175
     components:
     - type: Transform
       pos: -46.5,-67.5
-      parent: 82
-  - uid: 21176
-    components:
-    - type: Transform
-      pos: -47.5,-67.5
-      parent: 82
-  - uid: 21177
-    components:
-    - type: Transform
-      pos: -48.5,-67.5
       parent: 82
   - uid: 21178
     components:
@@ -141333,11 +142290,6 @@ entities:
     components:
     - type: Transform
       pos: -49.5,-65.5
-      parent: 82
-  - uid: 21182
-    components:
-    - type: Transform
-      pos: -48.5,-65.5
       parent: 82
   - uid: 21183
     components:
@@ -141369,30 +142321,10 @@ entities:
     - type: Transform
       pos: -43.5,-63.5
       parent: 82
-  - uid: 21189
-    components:
-    - type: Transform
-      pos: -44.5,-63.5
-      parent: 82
   - uid: 21190
     components:
     - type: Transform
       pos: -45.5,-63.5
-      parent: 82
-  - uid: 21191
-    components:
-    - type: Transform
-      pos: -46.5,-63.5
-      parent: 82
-  - uid: 21192
-    components:
-    - type: Transform
-      pos: -47.5,-63.5
-      parent: 82
-  - uid: 21193
-    components:
-    - type: Transform
-      pos: -48.5,-63.5
       parent: 82
   - uid: 21194
     components:
@@ -141408,11 +142340,6 @@ entities:
     components:
     - type: Transform
       pos: -50.5,-61.5
-      parent: 82
-  - uid: 21197
-    components:
-    - type: Transform
-      pos: -49.5,-61.5
       parent: 82
   - uid: 21198
     components:
@@ -141434,11 +142361,6 @@ entities:
     - type: Transform
       pos: -45.5,-61.5
       parent: 82
-  - uid: 21202
-    components:
-    - type: Transform
-      pos: -44.5,-61.5
-      parent: 82
   - uid: 21203
     components:
     - type: Transform
@@ -141453,11 +142375,6 @@ entities:
     components:
     - type: Transform
       pos: -38.5,-61.5
-      parent: 82
-  - uid: 21206
-    components:
-    - type: Transform
-      pos: -37.5,-61.5
       parent: 82
   - uid: 21207
     components:
@@ -141484,20 +142401,10 @@ entities:
     - type: Transform
       pos: -32.5,-61.5
       parent: 82
-  - uid: 21212
-    components:
-    - type: Transform
-      pos: -32.5,-63.5
-      parent: 82
   - uid: 21213
     components:
     - type: Transform
       pos: -33.5,-63.5
-      parent: 82
-  - uid: 21214
-    components:
-    - type: Transform
-      pos: -34.5,-63.5
       parent: 82
   - uid: 21215
     components:
@@ -141508,11 +142415,6 @@ entities:
     components:
     - type: Transform
       pos: -36.5,-63.5
-      parent: 82
-  - uid: 21217
-    components:
-    - type: Transform
-      pos: -37.5,-63.5
       parent: 82
   - uid: 21218
     components:
@@ -141544,20 +142446,10 @@ entities:
     - type: Transform
       pos: -36.5,-65.5
       parent: 82
-  - uid: 21224
-    components:
-    - type: Transform
-      pos: -35.5,-65.5
-      parent: 82
   - uid: 21225
     components:
     - type: Transform
       pos: -34.5,-65.5
-      parent: 82
-  - uid: 21226
-    components:
-    - type: Transform
-      pos: -33.5,-65.5
       parent: 82
   - uid: 21227
     components:
@@ -141568,11 +142460,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,-67.5
-      parent: 82
-  - uid: 21229
-    components:
-    - type: Transform
-      pos: -33.5,-67.5
       parent: 82
   - uid: 21230
     components:
@@ -141588,11 +142475,6 @@ entities:
     components:
     - type: Transform
       pos: -36.5,-67.5
-      parent: 82
-  - uid: 21233
-    components:
-    - type: Transform
-      pos: -37.5,-67.5
       parent: 82
   - uid: 21234
     components:
@@ -141614,11 +142496,6 @@ entities:
     - type: Transform
       pos: -38.5,-69.5
       parent: 82
-  - uid: 21238
-    components:
-    - type: Transform
-      pos: -37.5,-69.5
-      parent: 82
   - uid: 21239
     components:
     - type: Transform
@@ -141639,11 +142516,6 @@ entities:
     - type: Transform
       pos: -33.5,-69.5
       parent: 82
-  - uid: 21243
-    components:
-    - type: Transform
-      pos: -32.5,-69.5
-      parent: 82
   - uid: 21244
     components:
     - type: Transform
@@ -141653,11 +142525,6 @@ entities:
     components:
     - type: Transform
       pos: -33.5,-71.5
-      parent: 82
-  - uid: 21246
-    components:
-    - type: Transform
-      pos: -34.5,-71.5
       parent: 82
   - uid: 21247
     components:
@@ -141674,15 +142541,239 @@ entities:
     - type: Transform
       pos: -37.5,-71.5
       parent: 82
-  - uid: 21250
-    components:
-    - type: Transform
-      pos: -38.5,-71.5
-      parent: 82
   - uid: 21251
     components:
     - type: Transform
       pos: -39.5,-71.5
+      parent: 82
+- proto: SolarPanelBroken
+  entities:
+  - uid: 10804
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -71.5,6.5
+      parent: 82
+  - uid: 11682
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -69.5,16.5
+      parent: 82
+  - uid: 11686
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -71.5,13.5
+      parent: 82
+  - uid: 11699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -69.5,20.5
+      parent: 82
+  - uid: 11706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -73.5,15.5
+      parent: 82
+  - uid: 11717
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -65.5,13.5
+      parent: 82
+  - uid: 11722
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -75.5,18.5
+      parent: 82
+  - uid: 11724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -67.5,17.5
+      parent: 82
+  - uid: 11728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -71.5,19.5
+      parent: 82
+  - uid: 11740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -69.5,8.5
+      parent: 82
+  - uid: 11743
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -67.5,8.5
+      parent: 82
+  - uid: 11761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -65.5,9.5
+      parent: 82
+  - uid: 11784
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -65.5,3.5
+      parent: 82
+  - uid: 11792
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -69.5,3.5
+      parent: 82
+  - uid: 11800
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -67.5,4.5
+      parent: 82
+  - uid: 13935
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -75.5,5.5
+      parent: 82
+  - uid: 20830
+    components:
+    - type: Transform
+      pos: -73.5,-27.5
+      parent: 82
+  - uid: 20835
+    components:
+    - type: Transform
+      pos: -83.5,-32.5
+      parent: 82
+  - uid: 20845
+    components:
+    - type: Transform
+      pos: -83.5,-21.5
+      parent: 82
+  - uid: 20877
+    components:
+    - type: Transform
+      pos: -49.5,-69.5
+      parent: 82
+  - uid: 20883
+    components:
+    - type: Transform
+      pos: -48.5,-65.5
+      parent: 82
+  - uid: 20886
+    components:
+    - type: Transform
+      pos: -45.5,-67.5
+      parent: 82
+  - uid: 20905
+    components:
+    - type: Transform
+      pos: -81.5,-19.5
+      parent: 82
+  - uid: 20910
+    components:
+    - type: Transform
+      pos: -73.5,-19.5
+      parent: 82
+  - uid: 20938
+    components:
+    - type: Transform
+      pos: -75.5,-27.5
+      parent: 82
+  - uid: 21004
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -75.5,6.5
+      parent: 82
+  - uid: 21010
+    components:
+    - type: Transform
+      pos: -79.5,-27.5
+      parent: 82
+  - uid: 21022
+    components:
+    - type: Transform
+      pos: -77.5,-31.5
+      parent: 82
+  - uid: 21158
+    components:
+    - type: Transform
+      pos: -83.5,-31.5
+      parent: 82
+  - uid: 21167
+    components:
+    - type: Transform
+      pos: -83.5,-27.5
+      parent: 82
+  - uid: 21170
+    components:
+    - type: Transform
+      pos: -79.5,-33.5
+      parent: 82
+  - uid: 21174
+    components:
+    - type: Transform
+      pos: -81.5,-29.5
+      parent: 82
+  - uid: 21176
+    components:
+    - type: Transform
+      pos: -37.5,-61.5
+      parent: 82
+  - uid: 21182
+    components:
+    - type: Transform
+      pos: -32.5,-63.5
+      parent: 82
+  - uid: 21189
+    components:
+    - type: Transform
+      pos: -35.5,-65.5
+      parent: 82
+  - uid: 21193
+    components:
+    - type: Transform
+      pos: -33.5,-67.5
+      parent: 82
+  - uid: 21197
+    components:
+    - type: Transform
+      pos: -34.5,-71.5
+      parent: 82
+  - uid: 21202
+    components:
+    - type: Transform
+      pos: -37.5,-69.5
+      parent: 82
+  - uid: 21206
+    components:
+    - type: Transform
+      pos: -45.5,-71.5
+      parent: 82
+  - uid: 21212
+    components:
+    - type: Transform
+      pos: -49.5,-61.5
+      parent: 82
+  - uid: 21217
+    components:
+    - type: Transform
+      pos: -44.5,-61.5
+      parent: 82
+  - uid: 21226
+    components:
+    - type: Transform
+      pos: -44.5,-63.5
       parent: 82
 - proto: SolarTracker
   entities:
@@ -142727,6 +143818,63 @@ entities:
     - type: Transform
       pos: -7.5,-48.5
       parent: 82
+  - uid: 26715
+    components:
+    - type: Transform
+      pos: -24.5,33.5
+      parent: 82
+  - uid: 26716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-28.5
+      parent: 82
+  - uid: 26717
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-52.5
+      parent: 82
+  - uid: 26718
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-46.5
+      parent: 82
+  - uid: 26719
+    components:
+    - type: Transform
+      pos: 21.5,-15.5
+      parent: 82
+  - uid: 26720
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-2.5
+      parent: 82
+  - uid: 26721
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 83.5,1.5
+      parent: 82
+  - uid: 26722
+    components:
+    - type: Transform
+      pos: 24.5,52.5
+      parent: 82
+  - uid: 26723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,48.5
+      parent: 82
+  - uid: 26724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -44.5,28.5
+      parent: 82
 - proto: Stool
   entities:
   - uid: 4351
@@ -142927,6 +144075,8 @@ entities:
   entities:
   - uid: 1264
     components:
+    - type: MetaData
+      name: Atmos Substation
     - type: Transform
       pos: 19.5,5.5
       parent: 82
@@ -142942,11 +144092,15 @@ entities:
       parent: 82
   - uid: 7942
     components:
+    - type: MetaData
+      name: Telecom Substation
     - type: Transform
       pos: -28.5,15.5
       parent: 82
   - uid: 12038
     components:
+    - type: MetaData
+      name: Dorms Substation
     - type: Transform
       pos: 13.5,-41.5
       parent: 82
@@ -142964,6 +144118,8 @@ entities:
       parent: 82
   - uid: 15682
     components:
+    - type: MetaData
+      name: substation
     - type: Transform
       pos: -4.5,5.5
       parent: 82
@@ -142979,11 +144135,15 @@ entities:
       parent: 82
   - uid: 16880
     components:
+    - type: MetaData
+      name: Epistemics Substation
     - type: Transform
       pos: 7.5,44.5
       parent: 82
   - uid: 17128
     components:
+    - type: MetaData
+      name: substation
     - type: Transform
       pos: 40.5,37.5
       parent: 82
@@ -143001,13 +144161,15 @@ entities:
       parent: 82
   - uid: 18370
     components:
+    - type: MetaData
+      name: Medical Substation
     - type: Transform
       pos: -25.5,-46.5
       parent: 82
   - uid: 26361
     components:
     - type: MetaData
-      name: Service Substation
+      name: Service & Psych Substation
     - type: Transform
       pos: 1.5,-51.5
       parent: 82
@@ -165823,6 +166985,13 @@ entities:
       parent: 82
     - type: WarpPoint
       location: Security
+  - uid: 20889
+    components:
+    - type: Transform
+      pos: -0.5,-55.5
+      parent: 82
+    - type: WarpPoint
+      location: Psychologist
   - uid: 25245
     components:
     - type: Transform
@@ -165843,7 +167012,7 @@ entities:
       pos: 19.5,65.5
       parent: 82
     - type: WarpPoint
-      location: Science
+      location: Epistemics
   - uid: 25248
     components:
     - type: Transform
@@ -165902,6 +167071,34 @@ entities:
       parent: 82
     - type: WarpPoint
       location: Evac
+  - uid: 26546
+    components:
+    - type: Transform
+      pos: 26.5,-19.5
+      parent: 82
+    - type: WarpPoint
+      location: Court House
+  - uid: 26547
+    components:
+    - type: Transform
+      pos: 0.5,59.5
+      parent: 82
+    - type: WarpPoint
+      location: Gravity Generator
+  - uid: 26548
+    components:
+    - type: Transform
+      pos: -25.5,64.5
+      parent: 82
+    - type: WarpPoint
+      location: Tesla
+  - uid: 26553
+    components:
+    - type: Transform
+      pos: -31.5,17.5
+      parent: 82
+    - type: WarpPoint
+      location: Telecoms
 - proto: WarpPointLibrary
   entities:
   - uid: 26505

--- a/Resources/Maps/Floof/lighthouse.yml
+++ b/Resources/Maps/Floof/lighthouse.yml
@@ -127,7 +127,7 @@ entities:
           version: 6
         1,-2:
           ind: 1,-2
-          tiles: MAAAAAADXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAXgAAAAABXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAABXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMgAAAAAAXgAAAAABXgAAAAADfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMgAAAAAAXgAAAAACXgAAAAABfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAADXgAAAAADXgAAAAABXgAAAAABXgAAAAADXgAAAAADXgAAAAADXgAAAAADXgAAAAABXgAAAAADXgAAAAABMgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAADMAAAAAACMAAAAAABMAAAAAAAMAAAAAADMAAAAAAAXgAAAAACXgAAAAABXgAAAAADMgAAAAAAXgAAAAADXgAAAAABUAAAAAAAXgAAAAADXgAAAAACXgAAAAAAXgAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAADMAAAAAABXgAAAAACXgAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAAAXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAACXgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABfwAAAAAAewAAAAABfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAABXgAAAAABUAAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAAAXgAAAAADXgAAAAAAUAAAAAAAXgAAAAACXgAAAAACXgAAAAABXgAAAAABXgAAAAADfwAAAAAAfwAAAAAAewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAMAAAAAAAXgAAAAADXgAAAAAAXgAAAAAAMAAAAAABMAAAAAADXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABewAAAAADewAAAAABewAAAAADewAAAAABewAAAAAA
+          tiles: MAAAAAADXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAAAXgAAAAABXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAABXgAAAAACXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXgAAAAACXgAAAAAAXgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMgAAAAAAXgAAAAABXgAAAAADfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMgAAAAAAXgAAAAACXgAAAAABfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACwAAAAAAXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAADXgAAAAADXgAAAAABXgAAAAABXgAAAAADUAAAAAAAXgAAAAADXgAAAAADXgAAAAABXgAAAAADXgAAAAABMgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAADMAAAAAACMAAAAAABMAAAAAAAMAAAAAADMAAAAAAAXgAAAAACXgAAAAABXgAAAAADMgAAAAAAXgAAAAADXgAAAAABUAAAAAAAXgAAAAADXgAAAAACXgAAAAAAXgAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAMAAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAADMAAAAAABXgAAAAACXgAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAAAXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAACXgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABfwAAAAAAewAAAAABfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAABXgAAAAABUAAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAAAXgAAAAADXgAAAAAAUAAAAAAAXgAAAAACXgAAAAACXgAAAAABXgAAAAABXgAAAAADfwAAAAAAfwAAAAAAewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAMAAAAAAAXgAAAAADXgAAAAAAXgAAAAAAMAAAAAABMAAAAAADXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABewAAAAADewAAAAABewAAAAADewAAAAABewAAAAAA
           version: 6
         -2,0:
           ind: -2,0
@@ -9411,7 +9411,7 @@ entities:
       pos: -49.5,31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -2518.374
+      secondsUntilStateChange: -2933.9045
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9986,6 +9986,30 @@ entities:
       linkedPorts:
         13203:
         - DoorStatus: InputA
+- proto: AirlockExternalGlassShuttleArrivals
+  entities:
+  - uid: 18633
+    components:
+    - type: Transform
+      pos: 26.5,-25.5
+      parent: 2
+  - uid: 19270
+    components:
+    - type: Transform
+      pos: 33.5,-25.5
+      parent: 2
+  - uid: 19271
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 33.5,-35.5
+      parent: 2
+  - uid: 19383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-35.5
+      parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
   - uid: 256
@@ -10889,28 +10913,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -58.5,-18.5
-      parent: 2
-  - uid: 11363
-    components:
-    - type: Transform
-      pos: 26.5,-25.5
-      parent: 2
-  - uid: 14643
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 26.5,-35.5
-      parent: 2
-  - uid: 14776
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,-35.5
-      parent: 2
-  - uid: 15555
-    components:
-    - type: Transform
-      pos: 33.5,-25.5
       parent: 2
 - proto: AirlockHeadOfPersonnelGlassLocked
   entities:
@@ -12793,6 +12795,18 @@ entities:
     components:
     - type: Transform
       pos: -27.753727,33.79231
+      parent: 2
+- proto: ArrivalsShuttleTimer
+  entities:
+  - uid: 11363
+    components:
+    - type: Transform
+      pos: 19.5,-33.5
+      parent: 2
+  - uid: 15555
+    components:
+    - type: Transform
+      pos: 19.5,-27.5
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
@@ -27391,6 +27405,21 @@ entities:
     components:
     - type: Transform
       pos: -46.5,48.5
+      parent: 2
+  - uid: 19384
+    components:
+    - type: Transform
+      pos: 35.5,-37.5
+      parent: 2
+  - uid: 19385
+    components:
+    - type: Transform
+      pos: 36.5,-37.5
+      parent: 2
+  - uid: 19386
+    components:
+    - type: Transform
+      pos: 37.5,-37.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -45953,6 +45982,18 @@ entities:
     - type: Transform
       pos: 16.5,51.5
       parent: 2
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 14643
+    components:
+    - type: Transform
+      pos: 31.5,-24.5
+      parent: 2
+  - uid: 18595
+    components:
+    - type: Transform
+      pos: 33.5,-37.5
+      parent: 2
 - proto: DefaultStationBeaconArtifactLab
   entities:
   - uid: 6865
@@ -52027,21 +52068,6 @@ entities:
       parent: 2
 - proto: filingCabinet
   entities:
-  - uid: 7870
-    components:
-    - type: Transform
-      pos: -22.5,50.5
-      parent: 2
-  - uid: 7871
-    components:
-    - type: Transform
-      pos: 7.5,51.5
-      parent: 2
-  - uid: 7872
-    components:
-    - type: Transform
-      pos: 23.5,6.5
-      parent: 2
   - uid: 7873
     components:
     - type: Transform
@@ -52069,11 +52095,6 @@ entities:
     - type: Transform
       pos: -38.5,-1.5
       parent: 2
-  - uid: 7878
-    components:
-    - type: Transform
-      pos: -38.5,-2.5
-      parent: 2
   - uid: 7879
     components:
     - type: Transform
@@ -52099,11 +52120,6 @@ entities:
     - type: Transform
       pos: -4.5,-18.5
       parent: 2
-  - uid: 7884
-    components:
-    - type: Transform
-      pos: -7.5,-41.5
-      parent: 2
   - uid: 7885
     components:
     - type: Transform
@@ -52113,6 +52129,68 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-5.5
+      parent: 2
+- proto: filingCabinetDrawerRandom
+  entities:
+  - uid: 7870
+    components:
+    - type: Transform
+      pos: -22.5,50.5
+      parent: 2
+  - uid: 7871
+    components:
+    - type: Transform
+      pos: 7.5,51.5
+      parent: 2
+  - uid: 7872
+    components:
+    - type: Transform
+      pos: 23.5,6.5
+      parent: 2
+  - uid: 7878
+    components:
+    - type: Transform
+      pos: -38.5,-2.5
+      parent: 2
+  - uid: 7884
+    components:
+    - type: Transform
+      pos: -7.5,-41.5
+      parent: 2
+  - uid: 18038
+    components:
+    - type: Transform
+      pos: -15.5,-13.5
+      parent: 2
+  - uid: 18042
+    components:
+    - type: Transform
+      pos: -5.5,73.5
+      parent: 2
+  - uid: 18057
+    components:
+    - type: Transform
+      pos: -15.5,73.5
+      parent: 2
+  - uid: 18060
+    components:
+    - type: Transform
+      pos: 12.5,36.5
+      parent: 2
+  - uid: 18306
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 18558
+    components:
+    - type: Transform
+      pos: -22.5,40.5
+      parent: 2
+  - uid: 18571
+    components:
+    - type: Transform
+      pos: -14.5,-28.5
       parent: 2
 - proto: FireAlarm
   entities:
@@ -131276,6 +131354,13 @@ entities:
       parent: 2
     - type: WarpPoint
       location: laser tag arena
+- proto: WarpPointArrivals
+  entities:
+  - uid: 14776
+    components:
+    - type: Transform
+      pos: 33.5,-38.5
+      parent: 2
 - proto: WarpPointBombing
   entities:
   - uid: 20503

--- a/Resources/Maps/Floof/lighthouse.yml
+++ b/Resources/Maps/Floof/lighthouse.yml
@@ -9411,7 +9411,7 @@ entities:
       pos: -49.5,31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -2933.9045
+      secondsUntilStateChange: -3128.9094
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -27420,6 +27420,11 @@ entities:
     components:
     - type: Transform
       pos: 37.5,-37.5
+      parent: 2
+  - uid: 19388
+    components:
+    - type: Transform
+      pos: -46.5,47.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -131796,14 +131801,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -26.5,36.5
       parent: 2
-- proto: WindoorMailLocked
-  entities:
-  - uid: 20571
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-1.5
-      parent: 2
 - proto: WindoorSecure
   entities:
   - uid: 20572
@@ -131928,6 +131925,12 @@ entities:
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:
+  - uid: 19387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-1.5
+      parent: 2
   - uid: 20587
     components:
     - type: MetaData

--- a/Resources/Maps/Floof/radstation.yml
+++ b/Resources/Maps/Floof/radstation.yml
@@ -14977,7 +14977,7 @@ entities:
       pos: -23.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -4105.455
+      secondsUntilStateChange: -4124.439
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15011,7 +15011,7 @@ entities:
       pos: 34.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -68724.65
+      secondsUntilStateChange: -68743.63
       state: Opening
   - uid: 386
     components:
@@ -15337,7 +15337,7 @@ entities:
       pos: -35.5,-8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -4507.487
+      secondsUntilStateChange: -4526.4707
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -37068,6 +37068,11 @@ entities:
     components:
     - type: Transform
       pos: -14.5,-26.5
+      parent: 2
+  - uid: 24281
+    components:
+    - type: Transform
+      pos: 11.5,-56.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -158350,7 +158355,7 @@ entities:
       links:
       - 20116
     - type: Door
-      secondsUntilStateChange: -205016.92
+      secondsUntilStateChange: -205035.9
       state: Opening
   - uid: 23498
     components:

--- a/Resources/Maps/Floof/radstation.yml
+++ b/Resources/Maps/Floof/radstation.yml
@@ -83,7 +83,7 @@ entities:
           version: 6
         -2,-1:
           ind: -2,-1
-          tiles: cQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAGwAAAAAAGwAAAAABGwAAAAAAGwAAAAABGwAAAAABcQAAAAAAcQAAAAAAVAAAAAADJgAAAAAAcQAAAAAAVAAAAAACcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAABGwAAAAABGwAAAAAAGwAAAAACcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAVAAAAAADcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABGwAAAAADGwAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAVAAAAAACVAAAAAADVAAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAABYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABcQAAAAAAVAAAAAADVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAADGwAAAAABVAAAAAACVAAAAAACVAAAAAAAVAAAAAABGwAAAAACGwAAAAADcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAACVAAAAAACVAAAAAADVAAAAAACVAAAAAABVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAACVAAAAAAAVAAAAAACcQAAAAAAVAAAAAACcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAADVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAACVAAAAAADGwAAAAADGwAAAAAAGwAAAAADGwAAAAACGwAAAAADGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAADVAAAAAACVAAAAAABVAAAAAABVAAAAAABVAAAAAADVAAAAAABVAAAAAADVAAAAAAC
+          tiles: cQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAANAAAAAAANAAAAAAANAAAAAAANAAAAAAANAAAAAAAcQAAAAAAcQAAAAAAVAAAAAADJgAAAAAAcQAAAAAAVAAAAAACcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAGwAAAAADNAAAAAAASAAAAAAASAAAAAAASAAAAAAANAAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAVAAAAAADcQAAAAAAGwAAAAADNAAAAAAASAAAAAAANAAAAAAASAAAAAAANAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABNAAAAAAASAAAAAAASAAAAAAASAAAAAAANAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAVAAAAAACVAAAAAADVAAAAAAAVAAAAAAAcQAAAAAAcQAAAAAANAAAAAAANAAAAAAANAAAAAAANAAAAAAANAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABcQAAAAAAVAAAAAADVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAADGwAAAAABVAAAAAACVAAAAAACVAAAAAAAVAAAAAABGwAAAAACGwAAAAADcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAACVAAAAAACVAAAAAADVAAAAAACVAAAAAABVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAACVAAAAAAAVAAAAAACcQAAAAAAVAAAAAACcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAADVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAGwAAAAACVAAAAAADGwAAAAADGwAAAAAAGwAAAAADGwAAAAACGwAAAAADGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAABAAAAAAABAAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAADVAAAAAACVAAAAAABVAAAAAABVAAAAAABVAAAAAADVAAAAAABVAAAAAADVAAAAAAC
           version: 6
         -1,1:
           ind: -1,1
@@ -119,11 +119,11 @@ entities:
           version: 6
         -3,0:
           ind: -3,0
-          tiles: AAAAAAAAAAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAACGwAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAACAAAAAAAAAAAAAAAAGwAAAAADGwAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAACGwAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAADcQAAAAAAVAAAAAABVAAAAAABVAAAAAACVAAAAAADVAAAAAACVAAAAAADGwAAAAABcQAAAAAAVAAAAAABVAAAAAACVAAAAAADAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAADcQAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAABVAAAAAACVAAAAAACGwAAAAABcQAAAAAAVAAAAAACVAAAAAAAVAAAAAADAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACGwAAAAADGwAAAAABGwAAAAAAYQAAAAAAVAAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAVAAAAAABVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAADVAAAAAABVAAAAAADVAAAAAAAVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAADVAAAAAABVAAAAAABbQAAAAABbQAAAAAAbQAAAAACbQAAAAACVAAAAAADVAAAAAAAVAAAAAACVAAAAAACVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAACJAAAAAAAVAAAAAAAbQAAAAADVAAAAAAAVAAAAAADbQAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAADVAAAAAADVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAADJAAAAAAAVAAAAAAAbQAAAAAAbQAAAAACbQAAAAABbQAAAAABVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAAAVAAAAAADcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAABJAAAAAABVAAAAAADVAAAAAABVAAAAAABVAAAAAABVAAAAAABVAAAAAACVAAAAAABVAAAAAACVAAAAAACVAAAAAACVAAAAAADcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAAAJAAAAAACVAAAAAACVAAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAAAcQAAAAAAGwAAAAACVAAAAAABVAAAAAABVAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAACJAAAAAABJAAAAAADJAAAAAACJAAAAAABJAAAAAAAJAAAAAABJAAAAAACJAAAAAADGwAAAAAAVAAAAAADVAAAAAACVAAAAAABcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADSAAAAAAASAAAAAAASAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADSAAAAAAANAAAAAAASAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAACGwAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAACAAAAAAAAAAAAAAAAGwAAAAADGwAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAACGwAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAADcQAAAAAAVAAAAAABVAAAAAABVAAAAAACVAAAAAADVAAAAAACVAAAAAADGwAAAAABcQAAAAAAVAAAAAABVAAAAAACVAAAAAADAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAADcQAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAABVAAAAAACVAAAAAACGwAAAAABcQAAAAAAVAAAAAACVAAAAAAAVAAAAAADAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACGwAAAAADGwAAAAABGwAAAAAAYQAAAAAAVAAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAVAAAAAABVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAADVAAAAAABVAAAAAADVAAAAAAAVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAADVAAAAAABVAAAAAABbQAAAAABbQAAAAAAbQAAAAACbQAAAAACVAAAAAADVAAAAAAAVAAAAAACVAAAAAACVAAAAAACVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAACJAAAAAAAVAAAAAAAbQAAAAADVAAAAAAAVAAAAAADbQAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAADVAAAAAADVAAAAAACAAAAAAAAAAAAAAAAcQAAAAAAJAAAAAADJAAAAAAAVAAAAAAAbQAAAAAAbQAAAAACbQAAAAABbQAAAAABVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAAAVAAAAAADcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAABJAAAAAABVAAAAAADVAAAAAABVAAAAAABVAAAAAABVAAAAAABVAAAAAACVAAAAAABVAAAAAACVAAAAAACVAAAAAACVAAAAAADcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAAAJAAAAAACVAAAAAACVAAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAAAcQAAAAAAGwAAAAACVAAAAAABVAAAAAABVAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAJAAAAAACJAAAAAABJAAAAAADJAAAAAACJAAAAAABJAAAAAAAJAAAAAABJAAAAAACJAAAAAADGwAAAAAAVAAAAAADVAAAAAACVAAAAAABcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAGwAAAAAAVAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAAAGwAAAAADVAAAAAAAGwAAAAAAVAAAAAAAcAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAAAGwAAAAADVAAAAAAAGwAAAAAAVAAAAAAA
           version: 6
         -3,1:
           ind: -3,1
-          tiles: cAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADSAAAAAAASAAAAAAASAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAANAAAAAAANAAAAAAANAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAADcQAAAAAAcQAAAAAAVAAAAAABAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAABGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABGwAAAAACGwAAAAABcQAAAAAAGwAAAAAAGwAAAAABAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAACVAAAAAABcQAAAAAAGwAAAAABGwAAAAABGwAAAAADGwAAAAACGwAAAAADGwAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAVAAAAAACVAAAAAACVAAAAAABVAAAAAADcQAAAAAAGwAAAAADGwAAAAADGwAAAAADcQAAAAAAGwAAAAAAGwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAACGwAAAAADGwAAAAADGwAAAAADGwAAAAABGwAAAAACGwAAAAACGwAAAAACcQAAAAAAGwAAAAAAGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAACGwAAAAABcQAAAAAAGwAAAAACGwAAAAACGwAAAAADcQAAAAAAVAAAAAACVAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACGwAAAAAAGwAAAAABGwAAAAACGwAAAAAAGwAAAAABGwAAAAACGwAAAAADGwAAAAABVAAAAAACVAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAACGwAAAAACGwAAAAACcQAAAAAAGwAAAAABGwAAAAAAGwAAAAACcQAAAAAAVAAAAAABVAAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACSgAAAAAASgAAAAAASgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAA
+          tiles: cAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAAAGwAAAAADVAAAAAAAGwAAAAAAVAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAAAGwAAAAAAVAAAAAAAGwAAAAAAVAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADGwAAAAADcQAAAAAAcQAAAAAAVAAAAAABAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAABGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABGwAAAAACGwAAAAABcQAAAAAAGwAAAAAAGwAAAAABAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAACVAAAAAABcQAAAAAAGwAAAAABGwAAAAABGwAAAAADGwAAAAACGwAAAAADGwAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAVAAAAAACVAAAAAACVAAAAAABVAAAAAADcQAAAAAAGwAAAAADGwAAAAADGwAAAAADcQAAAAAAGwAAAAAAGwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGwAAAAAAGwAAAAACGwAAAAADGwAAAAADGwAAAAADGwAAAAABGwAAAAACGwAAAAACGwAAAAACcQAAAAAAGwAAAAAAGwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAABGwAAAAABGwAAAAACGwAAAAABcQAAAAAAGwAAAAACGwAAAAACGwAAAAADcQAAAAAAVAAAAAACVAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcQAAAAAAGwAAAAACGwAAAAAAGwAAAAABGwAAAAACGwAAAAAAGwAAAAABGwAAAAACGwAAAAADGwAAAAABVAAAAAACVAAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACGwAAAAACGwAAAAACGwAAAAACcQAAAAAAGwAAAAABGwAAAAAAGwAAAAACcQAAAAAAVAAAAAABVAAAAAABcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcQAAAAAAGwAAAAACSgAAAAAASgAAAAAASgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAA
           version: 6
         -2,1:
           ind: -2,1
@@ -425,81 +425,81 @@ entities:
             color: '#EFB34196'
             id: 1
           decals:
-            4074: -9,24
+            4049: -9,24
         - node:
             color: '#EFB341FF'
             id: 1
           decals:
-            1330: -46,-27
-            5353: 44,-34
+            1305: -46,-27
+            5328: 44,-34
         - node:
             color: '#EFB34196'
             id: 2
           decals:
-            4075: -9,23
+            4050: -9,23
         - node:
             color: '#EFB341FF'
             id: 2
           decals:
-            1365: -39,-33
-            5354: 45,-34
+            1340: -39,-33
+            5329: 45,-34
         - node:
             color: '#EFB34196'
             id: 3
           decals:
-            4076: -9,22
-            7163: -21,-46
+            4051: -9,22
+            7138: -21,-46
         - node:
             color: '#EFB341FF'
             id: 3
           decals:
-            5355: 46,-34
+            5330: 46,-34
         - node:
             color: '#EFB341FF'
             id: 4
           decals:
-            5356: 47,-34
+            5331: 47,-34
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7480: -5,-69
-            7481: -6,-69
-            7492: 2,-63
-            7493: 3,-63
+            7455: -5,-69
+            7456: -6,-69
+            7467: 2,-63
+            7468: 3,-63
         - node:
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7483: -5,-72
-            7484: -5,-73
-            7491: 1,-63
+            7458: -5,-72
+            7459: -5,-73
+            7466: 1,-63
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            7482: -6,-71
-            7490: 8,-75
+            7457: -6,-71
+            7465: 8,-75
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Arrows
           decals:
-            4990: 1,52
-            4991: 0,52
-            7485: 5,-73
-            7486: 5,-72
-            7487: 5,-71
-            7488: 5,-70
-            7489: 5,-69
+            4965: 1,52
+            4966: 0,52
+            7460: 5,-73
+            7461: 5,-72
+            7462: 5,-71
+            7463: 5,-70
+            7464: 5,-69
         - node:
             color: '#FFFFFFFF'
             id: Basalt1
           decals:
             347: -5,-2
-            6016: 3,47
+            5991: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Basalt2
@@ -507,9 +507,9 @@ entities:
             346: -7,-3
             360: 6,-2
             362: 6,-4
-            3669: 35,-8
-            3670: 40,-8
-            3675: 32,-4
+            3644: 35,-8
+            3645: 40,-8
+            3650: 32,-4
         - node:
             color: '#FFFFFFFF'
             id: Basalt3
@@ -519,15 +519,15 @@ entities:
             374: -6,3
             375: -5,6
             376: -3,7
-            3674: 32,-4
-            6006: 14,-27
+            3649: 32,-4
+            5981: 14,-27
         - node:
             color: '#FFFFFFFF'
             id: Basalt4
           decals:
             359: 5,-6
-            3668: 37,-8
-            6014: 3,48
+            3643: 37,-8
+            5989: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Basalt5
@@ -540,10 +540,10 @@ entities:
             381: 6,4
             382: 4,7
             383: 4,8
-            3666: 41,-9
-            3667: 34,-10
-            6007: 14,-26
-            6015: 3,49
+            3641: 41,-9
+            3642: 34,-10
+            5982: 14,-26
+            5990: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Basalt6
@@ -567,15 +567,15 @@ entities:
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            3125: 32,14
-            3126: 32,13
-            3127: 37,13
-            3128: 38,13
-            3129: 38,19
-            3130: 36,19
-            3131: 35,19
-            3132: 34,19
-            3133: 34,20
+            3100: 32,14
+            3101: 32,13
+            3102: 37,13
+            3103: 38,13
+            3104: 38,19
+            3105: 36,19
+            3106: 35,19
+            3107: 34,19
+            3108: 34,20
         - node:
             color: '#FFFFFFFF'
             id: Bot
@@ -616,582 +616,583 @@ entities:
             529: 5,19
             530: 4,19
             882: -31,4
-            1057: -44,8
-            1058: -44,9
-            1059: -44,10
-            1060: -44,11
-            1130: -42,-4
-            1131: -42,-3
-            1132: -41,-3
-            1133: -41,-4
-            1134: -40,-4
-            1135: -40,-3
-            1136: -39,-3
-            1137: -39,-4
-            1138: -42,1
-            1139: -42,2
-            1140: -41,2
-            1141: -41,1
-            1142: -40,1
-            1143: -40,2
-            1144: -39,2
-            1145: -39,1
-            1156: -43,-1
-            1187: -38,-8
-            1188: -43,-14
-            1189: -45,-14
-            1267: -37,-21
-            1268: -39,-21
-            1269: -37,-16
-            1270: -37,-17
-            1271: -37,-18
-            1395: -29,-21
-            1410: -37,-29
-            1411: -37,-27
-            1516: -31,-36
-            1517: -28,-36
-            1518: -28,-35
-            1519: -36,-39
-            1520: -36,-40
-            1531: -31,-40
-            1532: -31,-39
-            1533: -31,-38
-            1543: -31,-42
-            1544: -30,-42
-            1545: -29,-42
-            1546: -28,-42
-            1626: -26,-34
-            1650: -24,-22
-            1651: -24,-24
-            1652: -22,-24
-            1653: -22,-22
-            1654: -25,-25
-            1655: -21,-19
-            1783: -21,-31
-            1784: -21,-32
-            1785: -21,-34
-            1786: -23,-34
-            1787: -23,-33
-            1853: -9,-33
-            1854: -9,-32
-            1855: -9,-31
-            1856: -3,-34
-            1857: -4,-34
-            1858: -3,-31
-            1859: -4,-31
-            1860: -5,-31
-            1957: -14,-50
-            1958: -14,-47
-            1959: -14,-44
-            1960: -14,-41
-            1961: -14,-38
-            1962: -13,-35
-            1963: -12,-50
-            2067: -9,-22
-            2068: -37,-42
-            2099: -42,-39
-            2237: -35,-46
-            2238: -33,-46
-            2239: -32,-46
-            2240: -40,-53
-            2241: -40,-52
-            2647: -36,6
-            2648: -33,8
-            2744: 28,-5
-            2745: 27,-5
-            2746: 27,-5
-            2747: 28,-3
-            2748: 30,-3
-            3002: 21,12
-            3003: 32,11
-            3004: 15,16
-            3005: 19,17
-            3006: 19,18
-            3007: 21,19
-            3008: 23,19
-            3009: 24,19
-            3010: 24,17
-            3011: 21,21
-            3012: 24,23
-            3013: 25,23
-            3014: 26,23
-            3015: 26,21
-            3016: 25,21
-            3017: 22,23
-            3165: 40,17
-            3166: 41,17
-            3167: 42,17
-            3168: 43,17
-            3192: 43,9
-            3207: 37,24
-            3208: 36,24
-            3209: 36,22
-            3210: 36,21
-            3634: 27,29
-            3635: 27,33
-            3636: 30,39
-            3637: 31,30
-            3638: 32,30
-            3639: 33,30
-            3640: 35,30
-            3641: 36,30
-            3642: 37,30
-            3643: 39,30
-            3644: 31,26
-            3645: 32,26
-            3646: 33,26
-            3647: 35,26
-            3648: 36,26
-            3649: 37,26
-            3650: 42,39
-            3651: 42,43
-            3652: 42,44
-            3653: 42,45
-            3817: 32,-13
-            3818: 33,-13
-            3819: 34,-13
-            3820: 35,-13
-            3821: 39,-13
-            3822: 40,-13
-            3823: 41,-13
-            3824: 42,-13
-            3825: 43,-13
-            3826: 44,-12
-            3827: 41,-4
-            3828: 42,-4
-            3829: 43,-4
-            3830: 44,-5
-            3881: 46,-17
-            3882: 45,-17
-            3883: 45,-19
-            3884: 46,-19
-            4045: -3,18
-            4069: -13,24
-            4070: -10,24
-            4071: -10,23
-            4072: -10,22
-            4073: -4,24
-            4227: -12,34
-            4228: -11,34
-            4229: -11,35
-            4230: -12,35
-            4231: -12,36
-            4232: -9,34
-            4233: -8,34
-            4234: -8,32
-            4235: -10,31
-            4236: -11,31
-            4237: -12,31
-            4263: -17,31
-            4264: -18,31
-            4265: -18,33
-            4266: -18,34
-            4267: -18,35
-            4268: -18,36
-            4269: -15,36
-            4270: -15,33
-            4273: -17,40
-            4274: -16,40
-            4275: -15,40
-            4276: -14,40
-            4277: -13,40
-            4278: -14,38
-            4279: -15,38
-            4280: -16,38
-            4300: -21,31
-            4301: -21,33
-            4302: -21,34
-            4303: -21,35
-            4304: -21,36
-            4323: -21,40
-            4324: -21,39
-            4325: -21,38
-            4326: -27,40
-            4327: -27,39
-            4328: -27,38
-            4344: -27,36
-            4345: -28,36
-            4346: -29,38
-            4378: -43,28
-            4379: -42,28
-            4380: -41,28
-            4381: -40,28
-            4382: -41,30
-            4383: -42,30
-            4384: -43,30
-            4385: -37,39
-            4418: -36,20
-            4419: -36,21
-            4420: -36,22
-            4512: -27,30
-            4544: -3,40
-            4548: -3,28
-            4549: -6,30
-            4550: -7,30
-            4601: 7,30
-            4602: 8,31
-            4603: 7,32
-            4604: 6,31
-            4745: 13,50
-            4746: 13,49
-            4747: 8,56
-            4748: 7,56
-            4749: 4,56
-            4750: 4,55
-            4789: 4,46
-            4790: 4,48
-            4791: 4,49
-            4792: 4,50
-            4961: -3,58
-            4962: -6,58
-            4963: -6,59
-            4964: -6,60
-            4965: 7,58
-            4966: 7,59
-            4967: 7,60
-            4968: 3,61
-            4969: 3,60
-            4970: -2,61
-            4971: -2,60
-            4972: -3,61
-            4973: 4,61
-            4974: 1,62
-            4975: -1,62
-            4976: 0,62
-            4977: 2,62
-            5089: 6,69
-            5090: -5,69
-            5091: -5,61
-            5092: 6,61
-            5141: 12,-15
-            5142: 12,-16
-            5143: 12,-17
-            5144: 15,-14
-            5145: 17,-14
-            5153: 20,-19
-            5154: 20,-20
-            5155: 20,-21
-            5156: 17,-21
-            5204: 26,-22
-            5205: 26,-21
-            5206: 22,-20
-            5207: 25,-18
-            5208: 26,-18
-            5291: 34,-22
-            5336: 38,-33
-            5337: 42,-33
-            5338: 42,-35
-            5339: 41,-31
-            5340: 41,-28
-            5345: 39,-27
-            5423: 28,-28
-            5424: 28,-29
-            5425: 28,-30
-            5426: 25,-31
-            5427: 25,-30
-            5428: 25,-28
-            5429: 30,-28
-            5430: 31,-28
-            5431: 32,-28
-            5432: 32,-32
-            5433: 30,-30
-            5454: 10,-33
-            5455: 8,-33
-            5456: 7,-33
-            5457: 9,-33
-            5458: 10,-30
-            5459: 9,-30
-            5460: 8,-30
-            5461: 4,-30
-            5462: 4,-31
-            5463: 4,-32
-            5547: 10,-28
-            5857: 11,-31
-            5861: 41,-21
-            5862: 40,-21
-            5863: 39,-21
-            5864: 15,-23
-            5865: 16,-23
-            5866: 20,-23
-            5867: 21,-23
-            5868: 22,-23
-            5869: 23,-23
-            6140: -2,-45
-            6141: 8,-46
-            6185: 2,-49
-            6186: 3,-49
-            6187: 4,-49
-            6269: 4,-57
-            6270: 4,-58
-            6271: 4,-59
-            6272: 4,-60
-            6273: 4,-61
-            6274: 2,-57
-            6275: 2,-56
-            6276: 2,-55
-            6403: -16,-62
-            6404: -19,-60
-            6478: 4,25
-            6486: 11,-66
-            6487: 12,-66
-            6488: 13,-66
-            6504: 10,-63
-            6535: -4,-67
-            6536: -3,-67
-            6537: 3,-67
-            6538: 4,-67
-            6539: 0,-70
-            6540: -5,-63
-            6541: -4,-65
-            6542: 5,-65
-            6543: 3,-75
-            6544: 3,-76
-            6545: -8,-71
-            6546: -8,-69
-            6547: -5,-71
-            6661: 7,-77
-            6662: -7,-77
-            6793: 16,-50
-            6794: 16,-51
-            6795: 16,-52
-            6796: 17,-52
-            6797: 17,-51
-            6798: 17,-50
-            6799: 18,-50
-            6800: 18,-51
-            6801: 18,-52
-            6802: 19,-52
-            6803: 19,-51
-            6804: 19,-50
-            6836: 28,-60
-            6837: 27,-60
-            6838: 27,-59
-            6839: 27,-58
-            6840: 28,-58
-            6841: 30,-58
-            6842: 30,-59
-            6843: 30,-60
-            6975: 22,-49
-            6976: 21,-49
-            6977: 20,-49
-            6997: 35,-52
-            6998: 36,-52
-            6999: 37,-52
-            7000: 38,-52
-            7001: 38,-51
-            7002: 38,-50
-            7003: 38,-49
-            7004: 36,-49
-            7005: 37,-49
-            7006: 35,-49
-            7007: 35,-50
-            7008: 35,-51
-            7009: 36,-51
-            7010: 37,-51
-            7011: 37,-50
-            7012: 36,-50
-            7013: 35,-42
-            7014: 38,-45
-            7038: 22,-40
-            7039: 26,-40
-            7040: 27,-40
-            7041: 28,-40
-            7075: 14,-44
-            7076: 14,-46
-            7116: 10,-49
-            7117: 11,-49
-            7118: 12,-49
-            7119: 13,-49
-            7120: 14,-49
-            7259: 15,23
-            7260: 15,22
-            7261: 24,-59
-            7288: 8,-55
-            7289: 41,-15
-            7416: -7,-59
-            7417: -7,-58
-            7418: -7,-57
-            7419: -6,-57
-            7420: -6,-58
-            7421: -6,-59
-            7422: -5,-59
-            7423: -5,-58
-            7424: -5,-57
-            7425: -4,-57
-            7426: -4,-58
-            7427: -4,-59
-            7428: -3,-59
-            7429: -3,-58
-            7430: -3,-57
-            7431: -2,-57
-            7432: -2,-58
-            7433: -2,-59
-            7434: -1,-59
-            7435: -1,-58
-            7436: -1,-57
-            7495: 6,56
-            7496: -38,22
-            7497: -38,21
+            1056: -44,8
+            1057: -44,9
+            1058: -44,10
+            1059: -44,11
+            1129: -42,-4
+            1130: -42,-3
+            1131: -41,-3
+            1132: -41,-4
+            1133: -40,-4
+            1134: -40,-3
+            1135: -39,-3
+            1136: -39,-4
+            1137: -42,1
+            1138: -42,2
+            1139: -41,2
+            1140: -41,1
+            1141: -40,1
+            1142: -40,2
+            1143: -39,2
+            1144: -39,1
+            1155: -43,-1
+            1186: -38,-8
+            1187: -43,-14
+            1188: -45,-14
+            1242: -37,-21
+            1243: -39,-21
+            1244: -37,-16
+            1245: -37,-17
+            1246: -37,-18
+            1370: -29,-21
+            1385: -37,-29
+            1386: -37,-27
+            1491: -31,-36
+            1492: -28,-36
+            1493: -28,-35
+            1494: -36,-39
+            1495: -36,-40
+            1506: -31,-40
+            1507: -31,-39
+            1508: -31,-38
+            1518: -31,-42
+            1519: -30,-42
+            1520: -29,-42
+            1521: -28,-42
+            1601: -26,-34
+            1625: -24,-22
+            1626: -24,-24
+            1627: -22,-24
+            1628: -22,-22
+            1629: -25,-25
+            1630: -21,-19
+            1758: -21,-31
+            1759: -21,-32
+            1760: -21,-34
+            1761: -23,-34
+            1762: -23,-33
+            1828: -9,-33
+            1829: -9,-32
+            1830: -9,-31
+            1831: -3,-34
+            1832: -4,-34
+            1833: -3,-31
+            1834: -4,-31
+            1835: -5,-31
+            1932: -14,-50
+            1933: -14,-47
+            1934: -14,-44
+            1935: -14,-41
+            1936: -14,-38
+            1937: -13,-35
+            1938: -12,-50
+            2042: -9,-22
+            2043: -37,-42
+            2074: -42,-39
+            2212: -35,-46
+            2213: -33,-46
+            2214: -32,-46
+            2215: -40,-53
+            2216: -40,-52
+            2622: -36,6
+            2623: -33,8
+            2719: 28,-5
+            2720: 27,-5
+            2721: 27,-5
+            2722: 28,-3
+            2723: 30,-3
+            2977: 21,12
+            2978: 32,11
+            2979: 15,16
+            2980: 19,17
+            2981: 19,18
+            2982: 21,19
+            2983: 23,19
+            2984: 24,19
+            2985: 24,17
+            2986: 21,21
+            2987: 24,23
+            2988: 25,23
+            2989: 26,23
+            2990: 26,21
+            2991: 25,21
+            2992: 22,23
+            3140: 40,17
+            3141: 41,17
+            3142: 42,17
+            3143: 43,17
+            3167: 43,9
+            3182: 37,24
+            3183: 36,24
+            3184: 36,22
+            3185: 36,21
+            3609: 27,29
+            3610: 27,33
+            3611: 30,39
+            3612: 31,30
+            3613: 32,30
+            3614: 33,30
+            3615: 35,30
+            3616: 36,30
+            3617: 37,30
+            3618: 39,30
+            3619: 31,26
+            3620: 32,26
+            3621: 33,26
+            3622: 35,26
+            3623: 36,26
+            3624: 37,26
+            3625: 42,39
+            3626: 42,43
+            3627: 42,44
+            3628: 42,45
+            3792: 32,-13
+            3793: 33,-13
+            3794: 34,-13
+            3795: 35,-13
+            3796: 39,-13
+            3797: 40,-13
+            3798: 41,-13
+            3799: 42,-13
+            3800: 43,-13
+            3801: 44,-12
+            3802: 41,-4
+            3803: 42,-4
+            3804: 43,-4
+            3805: 44,-5
+            3856: 46,-17
+            3857: 45,-17
+            3858: 45,-19
+            3859: 46,-19
+            4020: -3,18
+            4044: -13,24
+            4045: -10,24
+            4046: -10,23
+            4047: -10,22
+            4048: -4,24
+            4202: -12,34
+            4203: -11,34
+            4204: -11,35
+            4205: -12,35
+            4206: -12,36
+            4207: -9,34
+            4208: -8,34
+            4209: -8,32
+            4210: -10,31
+            4211: -11,31
+            4212: -12,31
+            4238: -17,31
+            4239: -18,31
+            4240: -18,33
+            4241: -18,34
+            4242: -18,35
+            4243: -18,36
+            4244: -15,36
+            4245: -15,33
+            4248: -17,40
+            4249: -16,40
+            4250: -15,40
+            4251: -14,40
+            4252: -13,40
+            4253: -14,38
+            4254: -15,38
+            4255: -16,38
+            4275: -21,31
+            4276: -21,33
+            4277: -21,34
+            4278: -21,35
+            4279: -21,36
+            4298: -21,40
+            4299: -21,39
+            4300: -21,38
+            4301: -27,40
+            4302: -27,39
+            4303: -27,38
+            4319: -27,36
+            4320: -28,36
+            4321: -29,38
+            4353: -43,28
+            4354: -42,28
+            4355: -41,28
+            4356: -40,28
+            4357: -41,30
+            4358: -42,30
+            4359: -43,30
+            4360: -37,39
+            4393: -36,20
+            4394: -36,21
+            4395: -36,22
+            4487: -27,30
+            4519: -3,40
+            4523: -3,28
+            4524: -6,30
+            4525: -7,30
+            4576: 7,30
+            4577: 8,31
+            4578: 7,32
+            4579: 6,31
+            4720: 13,50
+            4721: 13,49
+            4722: 8,56
+            4723: 7,56
+            4724: 4,56
+            4725: 4,55
+            4764: 4,46
+            4765: 4,48
+            4766: 4,49
+            4767: 4,50
+            4936: -3,58
+            4937: -6,58
+            4938: -6,59
+            4939: -6,60
+            4940: 7,58
+            4941: 7,59
+            4942: 7,60
+            4943: 3,61
+            4944: 3,60
+            4945: -2,61
+            4946: -2,60
+            4947: -3,61
+            4948: 4,61
+            4949: 1,62
+            4950: -1,62
+            4951: 0,62
+            4952: 2,62
+            5064: 6,69
+            5065: -5,69
+            5066: -5,61
+            5067: 6,61
+            5116: 12,-15
+            5117: 12,-16
+            5118: 12,-17
+            5119: 15,-14
+            5120: 17,-14
+            5128: 20,-19
+            5129: 20,-20
+            5130: 20,-21
+            5131: 17,-21
+            5179: 26,-22
+            5180: 26,-21
+            5181: 22,-20
+            5182: 25,-18
+            5183: 26,-18
+            5266: 34,-22
+            5311: 38,-33
+            5312: 42,-33
+            5313: 42,-35
+            5314: 41,-31
+            5315: 41,-28
+            5320: 39,-27
+            5398: 28,-28
+            5399: 28,-29
+            5400: 28,-30
+            5401: 25,-31
+            5402: 25,-30
+            5403: 25,-28
+            5404: 30,-28
+            5405: 31,-28
+            5406: 32,-28
+            5407: 32,-32
+            5408: 30,-30
+            5429: 10,-33
+            5430: 8,-33
+            5431: 7,-33
+            5432: 9,-33
+            5433: 10,-30
+            5434: 9,-30
+            5435: 8,-30
+            5436: 4,-30
+            5437: 4,-31
+            5438: 4,-32
+            5522: 10,-28
+            5832: 11,-31
+            5836: 41,-21
+            5837: 40,-21
+            5838: 39,-21
+            5839: 15,-23
+            5840: 16,-23
+            5841: 20,-23
+            5842: 21,-23
+            5843: 22,-23
+            5844: 23,-23
+            6115: -2,-45
+            6116: 8,-46
+            6160: 2,-49
+            6161: 3,-49
+            6162: 4,-49
+            6244: 4,-57
+            6245: 4,-58
+            6246: 4,-59
+            6247: 4,-60
+            6248: 4,-61
+            6249: 2,-57
+            6250: 2,-56
+            6251: 2,-55
+            6378: -16,-62
+            6379: -19,-60
+            6453: 4,25
+            6461: 11,-66
+            6462: 12,-66
+            6463: 13,-66
+            6479: 10,-63
+            6510: -4,-67
+            6511: -3,-67
+            6512: 3,-67
+            6513: 4,-67
+            6514: 0,-70
+            6515: -5,-63
+            6516: -4,-65
+            6517: 5,-65
+            6518: 3,-75
+            6519: 3,-76
+            6520: -8,-71
+            6521: -8,-69
+            6522: -5,-71
+            6636: 7,-77
+            6637: -7,-77
+            6768: 16,-50
+            6769: 16,-51
+            6770: 16,-52
+            6771: 17,-52
+            6772: 17,-51
+            6773: 17,-50
+            6774: 18,-50
+            6775: 18,-51
+            6776: 18,-52
+            6777: 19,-52
+            6778: 19,-51
+            6779: 19,-50
+            6811: 28,-60
+            6812: 27,-60
+            6813: 27,-59
+            6814: 27,-58
+            6815: 28,-58
+            6816: 30,-58
+            6817: 30,-59
+            6818: 30,-60
+            6950: 22,-49
+            6951: 21,-49
+            6952: 20,-49
+            6972: 35,-52
+            6973: 36,-52
+            6974: 37,-52
+            6975: 38,-52
+            6976: 38,-51
+            6977: 38,-50
+            6978: 38,-49
+            6979: 36,-49
+            6980: 37,-49
+            6981: 35,-49
+            6982: 35,-50
+            6983: 35,-51
+            6984: 36,-51
+            6985: 37,-51
+            6986: 37,-50
+            6987: 36,-50
+            6988: 35,-42
+            6989: 38,-45
+            7013: 22,-40
+            7014: 26,-40
+            7015: 27,-40
+            7016: 28,-40
+            7050: 14,-44
+            7051: 14,-46
+            7091: 10,-49
+            7092: 11,-49
+            7093: 12,-49
+            7094: 13,-49
+            7095: 14,-49
+            7234: 15,23
+            7235: 15,22
+            7236: 24,-59
+            7263: 8,-55
+            7264: 41,-15
+            7391: -7,-59
+            7392: -7,-58
+            7393: -7,-57
+            7394: -6,-57
+            7395: -6,-58
+            7396: -6,-59
+            7397: -5,-59
+            7398: -5,-58
+            7399: -5,-57
+            7400: -4,-57
+            7401: -4,-58
+            7402: -4,-59
+            7403: -3,-59
+            7404: -3,-58
+            7405: -3,-57
+            7406: -2,-57
+            7407: -2,-58
+            7408: -2,-59
+            7409: -1,-59
+            7410: -1,-58
+            7411: -1,-57
+            7470: 6,56
+            7471: -38,22
+            7472: -38,21
+            7554: 20,-12
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            2111: -48,-30
+            2086: -48,-30
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Bot
           decals:
-            5099: 14,-9
-            5100: 14,-10
-            5101: 14,-11
-            5102: 17,-9
-            5103: 17,-10
-            5104: 17,-11
-            5105: 19,-9
-            5106: 19,-10
-            5107: 19,-11
+            5074: 14,-9
+            5075: 14,-10
+            5076: 14,-11
+            5077: 17,-9
+            5078: 17,-10
+            5079: 17,-11
+            5080: 19,-9
+            5081: 19,-10
+            5082: 19,-11
         - node:
             color: '#D4D4D4D9'
             id: BotGreyscale
           decals:
-            4376: -41,31
-            4377: -42,31
+            4351: -41,31
+            4352: -42,31
         - node:
             color: '#FFFFFFFF'
             id: BotLeft
           decals:
-            4597: 8,32
-            4599: 6,30
+            4572: 8,32
+            4574: 6,30
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: BotLeft
           decals:
-            4598: 6,32
-            4600: 8,30
+            4573: 6,32
+            4575: 8,30
         - node:
             color: '#DE3A3AFF'
             id: Box
           decals:
-            2256: -25,-48
+            2231: -25,-48
         - node:
             color: '#EFB34196'
             id: Box
           decals:
-            7164: -21,-46
+            7139: -21,-46
         - node:
             color: '#EFB341FF'
             id: Box
           decals:
-            1329: -46,-27
-            1364: -39,-33
+            1304: -46,-27
+            1339: -39,-33
         - node:
             color: '#FFFFFFFF'
             id: Box
           decals:
-            1157: -40,-1
-            1852: -4,-33
-            5209: 30,-23
-            5210: 32,-23
-            5341: 38,-28
-            5342: 38,-29
-            5343: 38,-30
-            5344: 38,-31
-            5548: 6,-28
-            5549: 8,-22
-            5851: 32,-23
-            5852: 30,-23
+            1156: -40,-1
+            1827: -4,-33
+            5184: 30,-23
+            5185: 32,-23
+            5316: 38,-28
+            5317: 38,-29
+            5318: 38,-30
+            5319: 38,-31
+            5523: 6,-28
+            5524: 8,-22
+            5826: 32,-23
+            5827: 30,-23
         - node:
             color: '#DE3A3AFF'
             id: BoxGreyscale
           decals:
-            4305: -21,32
+            4280: -21,32
         - node:
             color: '#FFFFFFFF'
             id: BoxGreyscale
           decals:
-            4436: -31,26
-            5146: 16,-15
+            4411: -31,26
+            5121: 16,-15
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
           decals:
-            3384: 23,30
-            3394: 19,34
+            3359: 23,30
+            3369: 19,34
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNw
           decals:
-            3379: 25,30
-            3387: 21,30
-            3392: 21,36
-            3400: 17,33
+            3354: 25,30
+            3362: 21,30
+            3367: 21,36
+            3375: 17,33
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSe
           decals:
-            3385: 23,32
-            3399: 19,29
-            4715: -5,56
+            3360: 23,32
+            3374: 19,29
+            4690: -5,56
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSw
           decals:
-            3378: 25,32
-            3386: 21,32
-            3401: 17,29
-            4714: -7,56
-            6466: 6,25
+            3353: 25,32
+            3361: 21,32
+            3376: 17,29
+            4689: -7,56
+            6441: 6,25
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkEndE
           decals:
-            3393: 19,36
+            3368: 19,36
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineE
           decals:
-            3382: 23,33
-            3383: 23,29
-            3395: 19,33
-            3396: 19,32
-            3397: 19,31
-            3398: 19,30
+            3357: 23,33
+            3358: 23,29
+            3370: 19,33
+            3371: 19,32
+            3372: 19,31
+            3373: 19,30
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineN
           decals:
-            2458: -35,-65
-            2459: -36,-65
-            2460: -37,-65
-            3406: 22,30
+            2433: -35,-65
+            2434: -36,-65
+            2435: -37,-65
+            3381: 22,30
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineS
           decals:
-            3402: 18,29
-            3407: 22,32
-            4716: -6,56
-            6461: 8,25
-            6463: 7,25
+            3377: 18,29
+            3382: 22,32
+            4691: -6,56
+            6436: 8,25
+            6438: 7,25
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineW
           decals:
-            3380: 25,29
-            3381: 25,33
-            3388: 21,29
-            3389: 21,33
-            3390: 21,34
-            3391: 21,35
-            3403: 17,30
-            3404: 17,31
-            3405: 17,32
-            4713: -7,57
-            6468: 6,26
-            6469: 6,27
+            3355: 25,29
+            3356: 25,33
+            3363: 21,29
+            3364: 21,33
+            3365: 21,34
+            3366: 21,35
+            3378: 17,30
+            3379: 17,31
+            3380: 17,32
+            4688: -7,57
+            6443: 6,26
+            6444: 6,27
         - node:
             color: '#FFFFFFFF'
             id: Bushf1
@@ -1225,13 +1226,13 @@ entities:
             400: 7,3
             401: 9,3
             402: 7,4
-            3654: 34,-10
-            3655: 35,-8
-            3656: 37,-9
-            3657: 40,-9
-            3658: 41,-8
-            6002: 14,-26
-            6008: 3,49
+            3629: 34,-10
+            3630: 35,-8
+            3631: 37,-9
+            3632: 40,-9
+            3633: 41,-8
+            5977: 14,-26
+            5983: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Bushf2
@@ -1242,9 +1243,9 @@ entities:
             414: -4,6
             415: -5,7
             422: 5,5
-            3672: 32,-3
-            6003: 14,-27
-            6010: 3,47
+            3647: 32,-3
+            5978: 14,-27
+            5985: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Bushf3
@@ -1257,11 +1258,11 @@ entities:
             419: 5,7
             420: 6,7
             421: 8,4
-            3659: 41,-10
-            3660: 40,-8
-            3661: 34,-8
-            3671: 32,-4
-            6009: 3,48
+            3634: 41,-10
+            3635: 40,-8
+            3636: 34,-8
+            3646: 32,-4
+            5984: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Bushl1
@@ -1271,140 +1272,140 @@ entities:
             color: '#FFFFFFFF'
             id: Bushl2
           decals:
-            3662: 34,-9
+            3637: 34,-9
         - node:
             color: '#FFFFFFFF'
             id: Bushl4
           decals:
             410: -2,6
-            3663: 41,-9
+            3638: 41,-9
         - node:
             angle: -3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            4128: -3,26
-            4129: -3,26
-            4130: -4,26
-            4131: -6,26
-            4132: -7,26
-            4133: -9,26
-            4134: -10,26
-            4135: -12,26
-            4136: -13,26
-            4137: -13,26
-            4138: -21,26
-            4139: -21,26
-            4140: -20,26
+            4103: -3,26
+            4104: -3,26
+            4105: -4,26
+            4106: -6,26
+            4107: -7,26
+            4108: -9,26
+            4109: -10,26
+            4110: -12,26
+            4111: -13,26
+            4112: -13,26
+            4113: -21,26
+            4114: -21,26
+            4115: -20,26
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            5346: 46,-32
-            5347: 46,-32
-            5348: 46,-32
-            5349: 46,-32
-            5350: 46,-32
-            5351: 46,-32
-            7022: 38,-47
+            5321: 46,-32
+            5322: 46,-32
+            5323: 46,-32
+            5324: 46,-32
+            5325: 46,-32
+            5326: 46,-32
+            6997: 38,-47
         - node:
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            4984: 2,53
-            4985: -1,53
-            6531: 4,-71
-            6532: -4,-71
+            4959: 2,53
+            4960: -1,53
+            6506: 4,-71
+            6507: -4,-71
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            2106: -43,-44
+            2081: -43,-44
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Caution
           decals:
-            4986: 2,58
-            4987: -1,58
-            6533: 4,-69
-            6534: -4,-69
+            4961: 2,58
+            4962: -1,58
+            6508: 4,-69
+            6509: -4,-69
         - node:
             color: '#52B4E996'
             id: CheckerNESW
           decals:
-            3213: 37,21
-            3214: 38,21
-            3215: 38,22
-            3216: 37,22
-            3217: 37,23
-            3218: 38,23
-            3219: 36,23
-            3220: 38,24
-            5182: 25,-22
-            5183: 26,-22
-            5184: 26,-21
-            5185: 25,-21
-            5186: 24,-21
-            5187: 23,-21
-            5188: 22,-21
-            5189: 22,-20
-            5190: 23,-20
-            5191: 24,-20
-            5192: 25,-20
-            5193: 26,-20
-            5194: 26,-19
-            5195: 25,-19
-            5196: 24,-19
-            5197: 23,-19
-            5198: 22,-19
-            5199: 22,-18
-            5200: 23,-18
-            5201: 24,-18
-            5202: 25,-18
-            5203: 26,-18
+            3188: 37,21
+            3189: 38,21
+            3190: 38,22
+            3191: 37,22
+            3192: 37,23
+            3193: 38,23
+            3194: 36,23
+            3195: 38,24
+            5157: 25,-22
+            5158: 26,-22
+            5159: 26,-21
+            5160: 25,-21
+            5161: 24,-21
+            5162: 23,-21
+            5163: 22,-21
+            5164: 22,-20
+            5165: 23,-20
+            5166: 24,-20
+            5167: 25,-20
+            5168: 26,-20
+            5169: 26,-19
+            5170: 25,-19
+            5171: 24,-19
+            5172: 23,-19
+            5173: 22,-19
+            5174: 22,-18
+            5175: 23,-18
+            5176: 24,-18
+            5177: 25,-18
+            5178: 26,-18
         - node:
             color: '#6C6C6C92'
             id: CheckerNESW
           decals:
-            2461: -26,-65
-            2462: -25,-65
-            2463: -25,-64
-            2464: -24,-64
-            2465: -23,-65
-            2466: -23,-63
-            2467: -26,-63
-            2468: -27,-63
-            2469: -27,-64
+            2436: -26,-65
+            2437: -25,-65
+            2438: -25,-64
+            2439: -24,-64
+            2440: -23,-65
+            2441: -23,-63
+            2442: -26,-63
+            2443: -27,-63
+            2444: -27,-64
         - node:
             color: '#DE3A3A96'
             id: CheckerNESW
           decals:
             886: -20,12
-            2865: 15,6
-            2866: 15,7
-            2867: 15,8
-            2868: 15,9
-            2869: 15,10
-            2870: 15,11
-            2871: 16,11
-            2872: 17,11
-            2873: 18,11
-            2874: 19,11
-            2875: 20,11
-            2876: 21,11
-            2877: 21,10
-            2878: 21,9
-            2879: 22,8
-            2880: 23,8
-            2881: 24,8
-            2882: 25,8
-            2883: 26,8
-            2884: 27,9
-            2885: 27,10
-            2886: 27,11
+            2840: 15,6
+            2841: 15,7
+            2842: 15,8
+            2843: 15,9
+            2844: 15,10
+            2845: 15,11
+            2846: 16,11
+            2847: 17,11
+            2848: 18,11
+            2849: 19,11
+            2850: 20,11
+            2851: 21,11
+            2852: 21,10
+            2853: 21,9
+            2854: 22,8
+            2855: 23,8
+            2856: 24,8
+            2857: 25,8
+            2858: 26,8
+            2859: 27,9
+            2860: 27,10
+            2861: 27,11
         - node:
             color: '#EFB34196'
             id: CheckerNESW
@@ -1414,120 +1415,120 @@ entities:
             color: '#52B4E996'
             id: CheckerNWSE
           decals:
-            2790: 26,-14
+            2765: 26,-14
         - node:
             color: '#6C6C6C93'
             id: CheckerNWSE
           decals:
-            2917: 23,10
-            2918: 24,10
-            2919: 25,10
-            2920: 25,11
-            2921: 24,11
-            2922: 23,11
-            2923: 23,12
-            2924: 24,12
-            2925: 25,12
-            2926: 22,13
-            2927: 22,14
-            2928: 23,14
-            2929: 23,13
-            2930: 24,13
-            2931: 24,14
-            2932: 25,13
-            2933: 26,13
-            2934: 26,14
-            2935: 25,14
-            2936: 27,14
-            2937: 26,15
-            2938: 25,15
-            2939: 24,15
-            2940: 23,15
-            2941: 21,15
-            2942: 20,15
+            2892: 23,10
+            2893: 24,10
+            2894: 25,10
+            2895: 25,11
+            2896: 24,11
+            2897: 23,11
+            2898: 23,12
+            2899: 24,12
+            2900: 25,12
+            2901: 22,13
+            2902: 22,14
+            2903: 23,14
+            2904: 23,13
+            2905: 24,13
+            2906: 24,14
+            2907: 25,13
+            2908: 26,13
+            2909: 26,14
+            2910: 25,14
+            2911: 27,14
+            2912: 26,15
+            2913: 25,15
+            2914: 24,15
+            2915: 23,15
+            2916: 21,15
+            2917: 20,15
         - node:
             color: '#79150096'
             id: CheckerNWSE
           decals:
-            2887: 16,12
-            2888: 17,12
-            2889: 18,12
-            2890: 19,12
-            2891: 20,12
-            2892: 21,12
-            2893: 21,13
-            2894: 20,13
-            2895: 19,13
-            2896: 18,13
-            2897: 17,13
-            2898: 16,13
-            2899: 15,13
-            2900: 15,14
-            2901: 16,14
-            2902: 17,14
-            2903: 18,14
-            2904: 19,14
-            2905: 20,14
-            2906: 21,14
-            2907: 16,15
-            2908: 16,16
-            2909: 15,16
-            2910: 15,17
-            2911: 16,17
-            2912: 17,17
-            2913: 17,16
-            2914: 17,18
-            2915: 16,18
-            2916: 15,18
+            2862: 16,12
+            2863: 17,12
+            2864: 18,12
+            2865: 19,12
+            2866: 20,12
+            2867: 21,12
+            2868: 21,13
+            2869: 20,13
+            2870: 19,13
+            2871: 18,13
+            2872: 17,13
+            2873: 16,13
+            2874: 15,13
+            2875: 15,14
+            2876: 16,14
+            2877: 17,14
+            2878: 18,14
+            2879: 19,14
+            2880: 20,14
+            2881: 21,14
+            2882: 16,15
+            2883: 16,16
+            2884: 15,16
+            2885: 15,17
+            2886: 16,17
+            2887: 17,17
+            2888: 17,16
+            2889: 17,18
+            2890: 16,18
+            2891: 15,18
         - node:
             color: '#EFB34196'
             id: CheckerNWSE
           decals:
-            2505: -12,-54
-            6215: -1,-54
+            2480: -12,-54
+            6190: -1,-54
         - node:
             color: '#F9801D87'
             id: CheckerNWSE
           decals:
-            7398: 5,-30
-            7399: 5,-31
-            7400: 5,-32
-            7401: 6,-32
-            7402: 6,-31
-            7403: 6,-30
-            7404: 6,-29
-            7405: 5,-29
-            7406: 7,-31
-            7407: 7,-32
-            7408: 8,-32
-            7409: 8,-31
-            7410: 9,-31
-            7411: 9,-32
-            7412: 10,-32
-            7413: 10,-31
-            7414: 11,-31
-            7415: 11,-32
+            7373: 5,-30
+            7374: 5,-31
+            7375: 5,-32
+            7376: 6,-32
+            7377: 6,-31
+            7378: 6,-30
+            7379: 6,-29
+            7380: 5,-29
+            7381: 7,-31
+            7382: 7,-32
+            7383: 8,-32
+            7384: 8,-31
+            7385: 9,-31
+            7386: 9,-32
+            7387: 10,-32
+            7388: 10,-31
+            7389: 11,-31
+            7390: 11,-32
         - node:
             color: '#DE3A3A96'
             id: Delivery
           decals:
-            1193: -44,-8
-            1194: -45,-8
+            1192: -44,-8
+            1193: -45,-8
         - node:
             color: '#FF0000FF'
             id: Delivery
           decals:
-            7438: -4,-60
-            7439: -4,-60
-            7440: -4,-60
-            7441: -4,-60
-            7442: -4,-60
+            7413: -4,-60
+            7414: -4,-60
+            7415: -4,-60
+            7416: -4,-60
+            7417: -4,-60
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            3134: 37,19
+            3109: 37,19
         - node:
             color: '#FFFFFFFF'
             id: Delivery
@@ -1535,269 +1536,272 @@ entities:
             494: -9,15
             495: -15,15
             838: -24,-7
-            995: -34,3
-            1052: -38,11
-            1053: -39,11
-            1054: -40,11
-            1055: -41,11
-            1056: -42,11
-            1146: -40,-6
-            1190: -41,-14
-            1191: -40,-14
-            1192: -39,-14
-            1215: -35,-15
-            1216: -34,-15
-            1217: -33,-15
-            1231: -32,15
-            1232: -36,15
-            1233: -35,17
-            1234: -33,17
-            1412: -36,-34
-            1487: -31,-28
-            1488: -31,-27
-            1521: -36,-38
-            1534: -30,-40
-            1535: -29,-40
-            1536: -28,-40
-            1537: -28,-39
-            1538: -29,-39
-            1539: -30,-39
-            1540: -30,-38
-            1541: -29,-38
-            1542: -28,-38
-            1625: -26,-35
-            1796: -20,-33
-            1955: -11,-40
-            1956: -11,-46
-            2065: -3,-29
-            2066: -4,-29
-            2252: -42,-52
-            2571: -3,-41
-            2572: -3,-40
-            2573: -5,-40
-            2574: -5,-41
-            2575: -5,-38
-            2576: -5,-37
-            2577: -5,-36
-            2578: -4,-36
-            2579: -3,-36
-            2580: -3,-38
-            2649: -33,3
-            2650: -35,3
-            2651: -36,8
-            2652: -36,9
-            2653: -36,10
-            2749: 29,-2
-            3169: 43,19
-            3211: 40,21
-            3212: 40,22
-            3831: 44,-4
-            3832: 44,-6
-            3833: 44,-7
-            3834: 44,-8
-            3835: 44,-9
-            3836: 44,-10
-            3837: 44,-11
-            3838: 44,-13
-            4066: -8,25
-            4067: -3,25
-            4068: -12,25
-            4272: -13,38
-            4310: -12,43
-            4311: -10,41
-            4312: -10,42
-            4313: -10,37
-            4314: -10,38
-            4347: -27,32
-            4415: -43,22
-            4416: -43,26
-            4417: -40,26
-            4513: -28,27
-            4545: -4,37
-            4546: -5,37
-            4547: -6,37
-            4605: 7,31
-            4742: 11,48
-            4743: 12,49
-            4744: 12,50
-            4788: 4,47
-            4829: 1,53
-            4830: 0,53
-            5073: -7,76
-            5550: 7,-28
-            5551: 7,-22
-            5571: 12,-33
-            5572: 19,-27
-            5573: 19,-26
-            5574: 17,-26
-            5575: 17,-27
-            5576: 15,-27
-            5577: 15,-26
-            6188: 5,-50
-            6189: 0,-44
-            6190: -1,-44
-            6400: -18,-62
-            6401: -20,-63
-            6402: -20,-58
-            6489: 14,-66
-            6490: 10,-66
-            6548: -7,-71
-            6549: -7,-69
-            6550: -5,-70
-            6551: -3,-74
-            6552: -1,-74
-            6553: 1,-74
-            6554: 3,-74
-            6555: -3,-76
-            6556: -2,-77
-            6557: -1,-77
-            6558: 1,-77
-            6559: 2,-77
-            6560: 4,-76
-            6561: 0,-65
-            6562: -4,-66
-            6563: -3,-66
-            6564: 3,-66
-            6565: 4,-66
-            6566: -1,-67
-            6567: 1,-67
-            6568: -5,-64
-            6569: -3,-65
-            6822: 23,-64
-            6823: 23,-63
-            6824: 23,-62
-            6825: 27,-61
-            6826: 31,-62
-            6827: 28,-59
-            6828: 30,-56
-            6829: 24,-53
-            6830: 24,-52
-            6831: 24,-51
-            6832: 26,-53
-            6833: 23,-58
-            6834: 20,-51
-            6835: 20,-52
-            6968: 22,-60
-            6969: 28,-65
-            6970: 32,-64
-            6971: 32,-62
-            6972: 32,-60
-            6973: 32,-58
-            6974: 32,-56
-            6993: 34,-49
-            6994: 34,-50
-            6995: 34,-51
-            6996: 34,-52
-            7015: 38,-46
-            7016: 35,-47
-            7023: 16,-39
-            7077: 13,-43
-            7078: 13,-47
-            7262: 26,-57
-            7263: 28,-56
-            7264: 28,-62
-            7265: 29,-62
-            7266: 22,-57
-            7267: 26,-65
-            7271: 30,-55
-            7273: 28,-53
-            7274: 31,-54
-            7276: 30,-61
-            7277: 25,-61
-            7282: 31,-58
-            7283: 24,-64
-            7284: 32,-54
-            7437: -4,-60
-            7443: -6,-59
-            7444: -6,-58
-            7445: -6,-57
-            7446: -5,-57
-            7447: -5,-58
-            7448: -5,-59
-            7449: -4,-59
-            7450: -4,-58
-            7451: -4,-57
-            7452: -3,-57
-            7453: -3,-58
-            7454: -3,-59
-            7455: -2,-59
-            7456: -2,-58
-            7457: -2,-57
-            7471: 32,24
-            7472: 34,24
-            7473: 34,22
-            7474: 32,22
+            994: -34,3
+            1051: -38,11
+            1052: -39,11
+            1053: -40,11
+            1054: -41,11
+            1055: -42,11
+            1145: -40,-6
+            1189: -41,-14
+            1190: -40,-14
+            1191: -39,-14
+            1214: -35,-15
+            1215: -34,-15
+            1216: -33,-15
+            1387: -36,-34
+            1462: -31,-28
+            1463: -31,-27
+            1496: -36,-38
+            1509: -30,-40
+            1510: -29,-40
+            1511: -28,-40
+            1512: -28,-39
+            1513: -29,-39
+            1514: -30,-39
+            1515: -30,-38
+            1516: -29,-38
+            1517: -28,-38
+            1600: -26,-35
+            1771: -20,-33
+            1930: -11,-40
+            1931: -11,-46
+            2040: -3,-29
+            2041: -4,-29
+            2227: -42,-52
+            2546: -3,-41
+            2547: -3,-40
+            2548: -5,-40
+            2549: -5,-41
+            2550: -5,-38
+            2551: -5,-37
+            2552: -5,-36
+            2553: -4,-36
+            2554: -3,-36
+            2555: -3,-38
+            2624: -33,3
+            2625: -35,3
+            2626: -36,8
+            2627: -36,9
+            2628: -36,10
+            2724: 29,-2
+            3144: 43,19
+            3186: 40,21
+            3187: 40,22
+            3806: 44,-4
+            3807: 44,-6
+            3808: 44,-7
+            3809: 44,-8
+            3810: 44,-9
+            3811: 44,-10
+            3812: 44,-11
+            3813: 44,-13
+            4041: -8,25
+            4042: -3,25
+            4043: -12,25
+            4247: -13,38
+            4285: -12,43
+            4286: -10,41
+            4287: -10,42
+            4288: -10,37
+            4289: -10,38
+            4322: -27,32
+            4390: -43,22
+            4391: -43,26
+            4392: -40,26
+            4488: -28,27
+            4520: -4,37
+            4521: -5,37
+            4522: -6,37
+            4580: 7,31
+            4717: 11,48
+            4718: 12,49
+            4719: 12,50
+            4763: 4,47
+            4804: 1,53
+            4805: 0,53
+            5048: -7,76
+            5525: 7,-28
+            5526: 7,-22
+            5546: 12,-33
+            5547: 19,-27
+            5548: 19,-26
+            5549: 17,-26
+            5550: 17,-27
+            5551: 15,-27
+            5552: 15,-26
+            6163: 5,-50
+            6164: 0,-44
+            6165: -1,-44
+            6375: -18,-62
+            6376: -20,-63
+            6377: -20,-58
+            6464: 14,-66
+            6465: 10,-66
+            6523: -7,-71
+            6524: -7,-69
+            6525: -5,-70
+            6526: -3,-74
+            6527: -1,-74
+            6528: 1,-74
+            6529: 3,-74
+            6530: -3,-76
+            6531: -2,-77
+            6532: -1,-77
+            6533: 1,-77
+            6534: 2,-77
+            6535: 4,-76
+            6536: 0,-65
+            6537: -4,-66
+            6538: -3,-66
+            6539: 3,-66
+            6540: 4,-66
+            6541: -1,-67
+            6542: 1,-67
+            6543: -5,-64
+            6544: -3,-65
+            6797: 23,-64
+            6798: 23,-63
+            6799: 23,-62
+            6800: 27,-61
+            6801: 31,-62
+            6802: 28,-59
+            6803: 30,-56
+            6804: 24,-53
+            6805: 24,-52
+            6806: 24,-51
+            6807: 26,-53
+            6808: 23,-58
+            6809: 20,-51
+            6810: 20,-52
+            6943: 22,-60
+            6944: 28,-65
+            6945: 32,-64
+            6946: 32,-62
+            6947: 32,-60
+            6948: 32,-58
+            6949: 32,-56
+            6968: 34,-49
+            6969: 34,-50
+            6970: 34,-51
+            6971: 34,-52
+            6990: 38,-46
+            6991: 35,-47
+            6998: 16,-39
+            7052: 13,-43
+            7053: 13,-47
+            7237: 26,-57
+            7238: 28,-56
+            7239: 28,-62
+            7240: 29,-62
+            7241: 22,-57
+            7242: 26,-65
+            7246: 30,-55
+            7248: 28,-53
+            7249: 31,-54
+            7251: 30,-61
+            7252: 25,-61
+            7257: 31,-58
+            7258: 24,-64
+            7259: 32,-54
+            7412: -4,-60
+            7418: -6,-59
+            7419: -6,-58
+            7420: -6,-57
+            7421: -5,-57
+            7422: -5,-58
+            7423: -5,-59
+            7424: -4,-59
+            7425: -4,-58
+            7426: -4,-57
+            7427: -3,-57
+            7428: -3,-58
+            7429: -3,-59
+            7430: -2,-59
+            7431: -2,-58
+            7432: -2,-57
+            7446: 32,24
+            7447: 34,24
+            7448: 34,22
+            7449: 32,22
+            7547: -31,-11
+            7548: -27,-11
+            7549: -27,-15
+            7550: -30,-15
+            7551: -35,13
+            7552: -34,13
+            7553: -33,13
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            2107: -45,-44
-            2109: -48,-35
+            2082: -45,-44
+            2084: -48,-35
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            4515: -33,26
+            4490: -33,26
         - node:
             color: '#EFB341FF'
             id: DeliveryGreyscale
           decals:
-            6257: 6,-61
-            6258: 7,-61
-            6259: 8,-61
+            6232: 6,-61
+            6233: 7,-61
+            6234: 8,-61
         - node:
             color: '#52B4E996'
             id: DiagonalOverlay
           decals:
-            6786: 12,-43
-            6787: 12,-44
-            6788: 13,-44
-            6789: 14,-43
-            7073: 14,-44
-            7074: 13,-43
+            6761: 12,-43
+            6762: 12,-44
+            6763: 13,-44
+            6764: 14,-43
+            7048: 14,-44
+            7049: 13,-43
         - node:
             color: '#DE3A3A96'
             id: DiagonalOverlay
           decals:
-            6790: 12,-47
-            6791: 12,-46
-            6792: 14,-47
-            7070: 13,-47
-            7071: 13,-46
-            7072: 14,-46
+            6765: 12,-47
+            6766: 12,-46
+            6767: 14,-47
+            7045: 13,-47
+            7046: 13,-46
+            7047: 14,-46
         - node:
             color: '#FFFFFFFF'
             id: Dirt
           decals:
-            7323: -42,-23
-            7324: -44,-24
-            7325: -48,-17
-            7326: -48,-20
-            7327: -45,-22
-            7328: -45,-19
-            7329: -46,-18
-            7330: -42,-16
-            7331: -41,-18
-            7332: -48,-22
-            7333: -49,-20
-            7334: -49,-17
-            7335: -47,-24
-            7384: -41,-21
-            7385: -42,-20
-            7386: -43,-18
-            7387: -44,-18
-            7388: -42,-17
-            7389: -47,-18
-            7390: -49,-16
-            7391: -49,-22
-            7392: -49,-23
-            7393: -47,-23
-            7394: -47,-23
-            7395: -45,-24
-            7396: -45,-23
-            7397: -41,-24
+            7298: -42,-23
+            7299: -44,-24
+            7300: -48,-17
+            7301: -48,-20
+            7302: -45,-22
+            7303: -45,-19
+            7304: -46,-18
+            7305: -42,-16
+            7306: -41,-18
+            7307: -48,-22
+            7308: -49,-20
+            7309: -49,-17
+            7310: -47,-24
+            7359: -41,-21
+            7360: -42,-20
+            7361: -43,-18
+            7362: -44,-18
+            7363: -42,-17
+            7364: -47,-18
+            7365: -49,-16
+            7366: -49,-22
+            7367: -49,-23
+            7368: -47,-23
+            7369: -47,-23
+            7370: -45,-24
+            7371: -45,-23
+            7372: -41,-24
         - node:
             color: '#A4610696'
             id: DirtHeavy
@@ -2133,1508 +2137,1508 @@ entities:
             977: -26,11
             978: -26,10
             979: -26,9
-            1278: -39,-25
-            1279: -38,-25
-            1280: -37,-25
-            1281: -37,-24
-            1282: -38,-24
-            1283: -39,-24
-            1284: -39,-23
-            1285: -38,-23
-            1286: -37,-24
-            1287: -37,-24
-            1288: -39,-23
-            1289: -38,-23
-            1290: -38,-23
-            1291: -37,-23
-            1292: -38,-23
-            1293: -39,-24
-            1294: -38,-24
-            1295: -37,-24
-            1296: -37,-23
-            1297: -37,-23
-            1299: -43,-28
-            1300: -43,-27
-            1301: -43,-27
-            1302: -42,-26
-            1303: -42,-27
-            1304: -41,-27
-            1305: -41,-27
-            1306: -42,-27
-            1307: -41,-26
-            1308: -41,-27
-            1309: -40,-28
-            1310: -39,-27
-            1311: -39,-26
-            1312: -40,-26
-            1313: -40,-27
-            1314: -40,-28
-            1315: -40,-28
-            1316: -39,-27
-            1317: -39,-26
-            1318: -40,-27
-            1319: -41,-28
-            1320: -41,-28
-            1321: -41,-27
-            1322: -41,-27
-            1323: -41,-26
-            1324: -42,-26
-            1325: -42,-27
-            1331: -47,-28
-            1332: -46,-28
-            1333: -46,-27
-            1334: -46,-27
-            1335: -47,-26
-            1336: -46,-26
-            1337: -45,-26
-            1338: -45,-27
-            1339: -45,-27
-            1340: -46,-28
-            1341: -47,-27
-            1342: -47,-26
-            1343: -46,-27
-            1344: -46,-27
-            1345: -44,-27
-            1346: -44,-27
-            1347: -44,-27
-            1348: -44,-27
-            1354: -40,-29
-            1355: -39,-29
-            1356: -39,-29
-            1357: -39,-29
-            1358: -40,-29
-            1371: -39,-34
-            1372: -38,-34
-            1373: -38,-33
-            1374: -38,-33
-            1375: -38,-34
-            1376: -39,-34
-            1377: -39,-34
-            1378: -39,-34
-            1379: -40,-34
-            1380: -40,-33
-            1381: -40,-33
-            1382: -40,-33
-            1383: -40,-32
-            1384: -39,-32
-            1385: -39,-31
-            1386: -39,-31
-            1387: -40,-31
-            1388: -39,-30
-            1389: -39,-30
-            1390: -39,-29
-            1391: -40,-30
-            1392: -40,-31
-            1393: -40,-32
-            1394: -40,-32
-            1489: -36,-32
-            1490: -36,-31
-            1491: -36,-29
-            1492: -36,-27
-            1493: -34,-27
-            1494: -33,-27
-            1495: -33,-28
-            1496: -33,-29
-            1497: -35,-27
-            1498: -36,-28
-            1499: -37,-30
-            1500: -37,-28
-            1501: -36,-27
-            1502: -34,-31
-            1503: -34,-32
-            1504: -35,-32
-            1505: -33,-32
-            1506: -33,-30
-            1507: -35,-33
-            1508: -34,-35
-            1509: -35,-34
-            1510: -35,-34
-            1511: -35,-34
-            1512: -34,-31
-            1513: -36,-31
-            1514: -36,-29
-            1515: -36,-30
-            1585: -34,-37
-            1586: -34,-38
-            1587: -34,-40
-            1588: -33,-42
-            1589: -34,-44
-            1590: -35,-44
-            1591: -35,-41
-            1592: -31,-41
-            1593: -30,-42
-            1594: -29,-41
-            1595: -31,-39
-            1596: -30,-38
-            1597: -28,-39
-            1598: -29,-41
-            1599: -29,-39
-            1660: -27,-24
-            1661: -26,-23
-            1662: -25,-22
-            1663: -23,-24
-            1664: -22,-24
+            1253: -39,-25
+            1254: -38,-25
+            1255: -37,-25
+            1256: -37,-24
+            1257: -38,-24
+            1258: -39,-24
+            1259: -39,-23
+            1260: -38,-23
+            1261: -37,-24
+            1262: -37,-24
+            1263: -39,-23
+            1264: -38,-23
+            1265: -38,-23
+            1266: -37,-23
+            1267: -38,-23
+            1268: -39,-24
+            1269: -38,-24
+            1270: -37,-24
+            1271: -37,-23
+            1272: -37,-23
+            1274: -43,-28
+            1275: -43,-27
+            1276: -43,-27
+            1277: -42,-26
+            1278: -42,-27
+            1279: -41,-27
+            1280: -41,-27
+            1281: -42,-27
+            1282: -41,-26
+            1283: -41,-27
+            1284: -40,-28
+            1285: -39,-27
+            1286: -39,-26
+            1287: -40,-26
+            1288: -40,-27
+            1289: -40,-28
+            1290: -40,-28
+            1291: -39,-27
+            1292: -39,-26
+            1293: -40,-27
+            1294: -41,-28
+            1295: -41,-28
+            1296: -41,-27
+            1297: -41,-27
+            1298: -41,-26
+            1299: -42,-26
+            1300: -42,-27
+            1306: -47,-28
+            1307: -46,-28
+            1308: -46,-27
+            1309: -46,-27
+            1310: -47,-26
+            1311: -46,-26
+            1312: -45,-26
+            1313: -45,-27
+            1314: -45,-27
+            1315: -46,-28
+            1316: -47,-27
+            1317: -47,-26
+            1318: -46,-27
+            1319: -46,-27
+            1320: -44,-27
+            1321: -44,-27
+            1322: -44,-27
+            1323: -44,-27
+            1329: -40,-29
+            1330: -39,-29
+            1331: -39,-29
+            1332: -39,-29
+            1333: -40,-29
+            1346: -39,-34
+            1347: -38,-34
+            1348: -38,-33
+            1349: -38,-33
+            1350: -38,-34
+            1351: -39,-34
+            1352: -39,-34
+            1353: -39,-34
+            1354: -40,-34
+            1355: -40,-33
+            1356: -40,-33
+            1357: -40,-33
+            1358: -40,-32
+            1359: -39,-32
+            1360: -39,-31
+            1361: -39,-31
+            1362: -40,-31
+            1363: -39,-30
+            1364: -39,-30
+            1365: -39,-29
+            1366: -40,-30
+            1367: -40,-31
+            1368: -40,-32
+            1369: -40,-32
+            1464: -36,-32
+            1465: -36,-31
+            1466: -36,-29
+            1467: -36,-27
+            1468: -34,-27
+            1469: -33,-27
+            1470: -33,-28
+            1471: -33,-29
+            1472: -35,-27
+            1473: -36,-28
+            1474: -37,-30
+            1475: -37,-28
+            1476: -36,-27
+            1477: -34,-31
+            1478: -34,-32
+            1479: -35,-32
+            1480: -33,-32
+            1481: -33,-30
+            1482: -35,-33
+            1483: -34,-35
+            1484: -35,-34
+            1485: -35,-34
+            1486: -35,-34
+            1487: -34,-31
+            1488: -36,-31
+            1489: -36,-29
+            1490: -36,-30
+            1560: -34,-37
+            1561: -34,-38
+            1562: -34,-40
+            1563: -33,-42
+            1564: -34,-44
+            1565: -35,-44
+            1566: -35,-41
+            1567: -31,-41
+            1568: -30,-42
+            1569: -29,-41
+            1570: -31,-39
+            1571: -30,-38
+            1572: -28,-39
+            1573: -29,-41
+            1574: -29,-39
+            1635: -27,-24
+            1636: -26,-23
+            1637: -25,-22
+            1638: -23,-24
+            1639: -22,-24
+            1640: -22,-22
+            1641: -23,-21
+            1642: -23,-20
+            1643: -23,-18
+            1644: -22,-19
+            1645: -24,-19
+            1646: -23,-18
+            1647: -19,-18
+            1648: -20,-18
+            1649: -21,-18
+            1650: -20,-18
+            1651: -21,-17
+            1652: -21,-17
+            1653: -25,-18
+            1654: -25,-22
+            1655: -27,-22
+            1656: -26,-24
+            1657: -27,-24
+            1658: -24,-25
+            1659: -21,-24
+            1660: -21,-20
+            1661: -23,-24
+            1662: -23,-21
+            1663: -25,-24
+            1664: -22,-22
             1665: -22,-22
-            1666: -23,-21
-            1667: -23,-20
-            1668: -23,-18
-            1669: -22,-19
-            1670: -24,-19
-            1671: -23,-18
-            1672: -19,-18
-            1673: -20,-18
-            1674: -21,-18
-            1675: -20,-18
-            1676: -21,-17
-            1677: -21,-17
-            1678: -25,-18
-            1679: -25,-22
-            1680: -27,-22
-            1681: -26,-24
-            1682: -27,-24
-            1683: -24,-25
-            1684: -21,-24
-            1685: -21,-20
-            1686: -23,-24
-            1687: -23,-21
-            1688: -25,-24
-            1689: -22,-22
-            1690: -22,-22
-            1691: -24,-24
-            1814: -13,-29
-            1815: -13,-29
-            1816: -12,-25
-            1817: -10,-22
-            1818: -10,-24
-            1819: -12,-23
-            1820: -11,-22
-            1821: -11,-23
-            1822: -11,-24
-            1964: -7,-38
-            1965: -8,-38
-            1966: -10,-38
-            1967: -11,-37
-            1968: -10,-37
-            1969: -9,-36
-            1970: -8,-36
-            1971: -10,-36
-            1972: -11,-36
-            1973: -12,-37
-            1974: -13,-38
-            1975: -13,-39
-            1976: -12,-40
-            1977: -12,-41
-            1978: -13,-42
-            1979: -13,-42
-            1980: -12,-40
-            1981: -12,-41
-            1982: -13,-42
-            1983: -12,-44
-            1984: -12,-45
-            1985: -12,-47
-            1986: -13,-48
-            1987: -12,-50
-            1988: -11,-50
-            1989: -12,-49
-            1990: -11,-48
-            1991: -12,-48
-            1992: -13,-49
-            1993: -13,-49
-            1994: -12,-48
-            1995: -12,-45
-            1996: -12,-44
-            1997: -13,-45
-            1998: -13,-43
-            1999: -13,-42
-            2000: -13,-40
-            2001: -12,-39
-            2002: -12,-39
-            2003: -11,-41
-            2004: -11,-43
-            2005: -11,-45
-            2006: -11,-45
-            2007: -11,-43
-            2008: -11,-42
-            2009: -14,-43
-            2010: -14,-46
-            2011: -14,-40
-            2012: -13,-37
-            2013: -13,-36
-            2014: -14,-37
-            2015: -12,-36
-            2016: -8,-38
-            2017: -7,-37
-            2018: -7,-36
-            2019: -8,-34
-            2020: -8,-32
-            2021: -8,-31
-            2022: -8,-31
-            2023: -7,-31
-            2024: -7,-32
-            2025: -6,-34
-            2026: -5,-32
-            2027: -5,-31
-            2028: -4,-32
-            2029: -4,-33
-            2030: -3,-34
-            2031: -3,-33
-            2032: -4,-31
-            2033: -5,-32
-            2034: -7,-34
-            2035: -14,-49
-            2036: -14,-49
-            2037: -13,-50
-            2038: -13,-51
-            2139: -40,-40
-            2140: -39,-40
-            2141: -38,-39
-            2142: -39,-39
-            2143: -40,-39
-            2144: -40,-38
-            2145: -39,-38
-            2146: -39,-37
-            2147: -40,-37
-            2148: -40,-37
-            2149: -41,-36
-            2150: -41,-37
-            2151: -39,-37
-            2152: -38,-38
-            2153: -38,-38
-            2154: -39,-37
-            2155: -41,-36
-            2156: -40,-38
-            2157: -39,-39
-            2158: -38,-38
-            2159: -39,-37
-            2160: -40,-37
-            2161: -39,-38
-            2162: -38,-38
-            2163: -40,-37
-            2257: -29,-49
-            2258: -29,-48
-            2259: -28,-47
-            2260: -27,-48
-            2261: -25,-48
-            2262: -26,-47
-            2263: -27,-47
-            2264: -26,-48
-            2265: -24,-48
-            2266: -32,-46
-            2267: -36,-46
-            2268: -37,-46
-            2269: -38,-46
-            2270: -37,-48
-            2271: -34,-48
-            2272: -33,-49
-            2273: -35,-49
-            2274: -36,-47
-            2275: -37,-49
-            2276: -35,-50
-            2277: -33,-48
-            2278: -33,-48
-            2279: -33,-51
-            2280: -35,-52
-            2281: -38,-51
-            2282: -39,-51
-            2283: -39,-53
-            2284: -37,-52
-            2285: -35,-52
-            2286: -37,-52
-            2287: -39,-50
-            2288: -37,-49
-            2289: -36,-52
-            2290: -35,-51
-            2291: -34,-51
-            2292: -42,-50
-            2293: -43,-50
-            2294: -43,-51
-            2295: -41,-51
-            2296: -41,-51
-            2346: -20,-50
-            2347: -21,-50
-            2348: -22,-50
-            2349: -22,-50
-            2350: -22,-49
-            2351: -21,-49
-            2352: -20,-49
-            2353: -20,-49
-            2354: -21,-49
-            2355: -22,-48
-            2356: -22,-48
-            2357: -21,-48
-            2358: -20,-47
-            2359: -21,-47
-            2360: -22,-46
-            2361: -21,-46
-            2362: -20,-45
-            2363: -22,-44
-            2364: -23,-44
-            2365: -23,-44
-            2366: -25,-45
-            2367: -25,-45
-            2368: -26,-44
-            2369: -28,-44
-            2370: -28,-44
-            2371: -28,-45
-            2372: -29,-45
-            2373: -30,-45
-            2374: -30,-44
-            2375: -31,-44
-            2376: -31,-44
-            2377: -29,-44
-            2378: -26,-44
-            2379: -25,-44
-            2380: -20,-40
-            2381: -21,-40
-            2382: -21,-40
-            2383: -22,-40
-            2384: -22,-39
-            2385: -21,-38
-            2386: -20,-37
-            2387: -21,-37
-            2388: -22,-37
-            2389: -21,-36
-            2390: -21,-36
-            2391: -20,-36
-            2392: -21,-37
-            2393: -21,-38
-            2394: -21,-39
-            2395: -21,-39
-            2396: -21,-39
-            2397: -21,-37
-            2398: -21,-37
-            2402: -20,-54
-            2403: -21,-54
-            2404: -21,-53
-            2405: -21,-53
-            2406: -21,-53
-            2407: -23,-53
-            2408: -23,-52
-            2409: -23,-52
-            2410: -23,-51
-            2411: -22,-51
-            2412: -21,-51
-            2413: -20,-52
-            2414: -20,-51
-            2415: -20,-52
-            2416: -22,-53
-            2420: -26,-53
-            2421: -28,-53
-            2422: -29,-53
-            2423: -30,-52
-            2424: -30,-52
-            2425: -30,-51
-            2426: -28,-52
-            2427: -26,-51
-            2428: -26,-51
-            2429: -26,-52
-            2430: -25,-52
-            2431: -27,-53
-            2432: -25,-53
-            2433: -25,-53
-            2434: -30,-51
-            2435: -30,-53
-            2436: -28,-51
-            2443: -27,-57
-            2444: -27,-56
-            2445: -26,-55
-            2446: -26,-55
-            2447: -26,-57
-            2448: -24,-56
-            2449: -24,-55
-            2450: -24,-55
-            2451: -23,-56
-            2452: -23,-57
-            2453: -23,-55
-            2454: -27,-55
-            2455: -26,-57
-            2456: -27,-56
-            2457: -23,-55
-            2470: -29,-55
-            2471: -29,-56
-            2472: -31,-56
-            2473: -32,-56
-            2474: -31,-55
-            2475: -28,-61
-            2476: -28,-60
-            2477: -27,-60
-            2478: -26,-60
-            2479: -25,-60
-            2480: -25,-58
-            2481: -24,-59
-            2482: -24,-60
-            2483: -24,-60
-            2484: -23,-60
-            2485: -24,-59
-            2486: -25,-60
-            2487: -24,-61
-            2488: -26,-63
-            2489: -27,-63
-            2490: -27,-65
-            2491: -25,-65
-            2492: -24,-65
-            2493: -25,-63
-            2494: -25,-63
-            2495: -24,-64
-            2496: -26,-65
-            2497: -27,-61
-            2498: -27,-61
-            2499: -29,-59
-            2500: -29,-58
-            2501: -29,-57
-            2507: -18,-54
-            2508: -18,-54
-            2509: -18,-53
-            2510: -18,-53
-            2511: -17,-53
-            2512: -16,-54
-            2513: -16,-54
-            2514: -15,-53
-            2515: -14,-52
-            2516: -12,-53
-            2517: -11,-53
-            2518: -11,-52
-            2519: -11,-52
-            2520: -15,-52
-            2521: -10,-54
-            2522: -13,-54
-            2523: -15,-54
-            2524: -16,-54
-            2525: -14,-52
-            2526: -11,-52
-            2527: -10,-53
-            2528: -17,-53
-            2529: -16,-52
-            2530: -13,-54
-            2531: -15,-54
-            2532: -13,-53
-            2533: -11,-52
-            2538: -8,-54
-            2539: -7,-54
-            2540: -8,-53
-            2541: -8,-52
-            2542: -7,-52
-            2543: -7,-54
-            2544: -6,-54
-            2545: -6,-53
-            2546: -7,-53
-            2547: -6,-52
-            2548: -6,-52
-            2549: -6,-51
-            2550: -6,-49
-            2551: -5,-49
-            2552: -6,-49
-            2553: -6,-50
-            2554: -6,-51
-            2555: -7,-53
-            2557: -5,-48
-            2558: -5,-47
-            2559: -5,-46
-            2560: -5,-46
-            2561: -5,-45
-            2562: -5,-45
-            2563: -5,-43
-            2564: -5,-44
-            2565: -4,-43
-            2566: -4,-45
-            2567: -3,-43
-            2568: -4,-43
-            2569: -5,-43
-            2570: -3,-43
-            2704: 18,-3
-            2705: 18,-3
-            2706: 19,-3
-            2707: 19,-4
-            2708: 19,-5
-            2709: 19,-7
-            2710: 19,-7
-            2711: 20,-7
-            2712: 21,-7
-            2713: 21,-6
-            2714: 21,-5
-            2715: 21,-4
-            2716: 21,-4
-            2717: 22,-3
-            2718: 22,-4
-            2719: 22,-6
-            2720: 23,-6
-            2721: 24,-6
-            2722: 24,-5
-            2723: 25,-4
-            2724: 25,-3
-            2725: 25,-3
-            2726: 25,-5
-            2727: 23,-7
-            2728: 24,-3
-            2729: 24,-3
-            2730: 21,-3
-            2731: 22,-3
-            2732: 18,-5
-            2755: 23,-13
-            2756: 22,-13
-            2757: 22,-12
-            2758: 22,-11
-            2759: 22,-9
-            2760: 22,-9
-            2761: 23,-10
-            2762: 24,-11
-            2763: 24,-11
-            2764: 22,-10
-            2765: 22,-13
-            2766: 22,-12
-            2767: 22,-11
-            2768: 23,-11
-            2769: 24,-9
-            2770: 26,-10
-            2771: 26,-9
-            2772: 27,-9
-            2773: 26,-8
-            2774: 28,-8
-            2775: 29,-9
-            2776: 29,-8
-            2777: 30,-7
-            2778: 28,-7
-            2779: 28,-7
-            2780: 30,-9
-            2781: 30,-7
-            2792: 22,-16
-            2793: 22,-15
-            2794: 23,-16
-            2795: 23,-16
-            2796: 24,-15
-            2797: 25,-16
-            2798: 25,-16
-            2799: 26,-15
-            2800: 26,-14
-            2801: 25,-14
-            2802: 26,-12
-            2803: 26,-14
-            2804: 25,-14
-            2805: 25,-13
-            2806: 25,-13
-            2807: 25,-13
-            2808: 24,-15
-            3022: 24,6
-            3023: 23,6
-            3024: 15,6
-            3025: 15,6
-            3026: 18,8
-            3027: 18,7
-            3028: 17,7
-            3029: 20,11
-            3030: 20,6
-            3031: 24,8
-            3032: 26,6
-            3033: 28,8
-            3034: 28,6
-            3035: 29,5
-            3036: 29,4
-            3037: 31,7
-            3038: 34,7
-            3039: 35,5
-            3040: 33,7
-            3041: 29,8
-            3042: 29,10
-            3043: 28,9
-            3044: 30,10
-            3045: 30,8
-            3046: 26,8
-            3047: 20,11
-            3048: 17,11
-            3049: 15,11
-            3050: 17,8
-            3051: 17,7
-            3052: 21,7
-            3053: 23,10
-            3054: 23,10
-            3055: 25,11
-            3056: 24,13
-            3057: 23,13
-            3058: 24,14
-            3059: 26,14
-            3060: 26,13
-            3061: 23,15
-            3062: 24,15
-            3063: 26,15
-            3064: 26,16
-            3065: 23,16
-            3066: 22,16
-            3067: 20,16
-            3068: 19,16
-            3069: 20,18
-            3070: 21,18
-            3071: 21,18
-            3072: 23,19
-            3073: 25,18
-            3074: 25,16
-            3075: 26,18
-            3076: 24,18
-            3077: 22,17
-            3078: 22,20
-            3079: 26,18
-            3080: 22,18
-            3081: 20,16
-            3082: 19,16
-            3083: 27,16
-            3195: 43,21
-            3196: 43,21
-            3197: 44,21
-            3198: 42,23
-            3199: 42,23
-            3200: 42,24
-            3201: 42,24
-            3202: 43,24
-            3203: 43,23
-            3204: 43,22
-            3205: 42,22
-            3206: 42,21
-            3221: 10,21
-            3222: 10,22
-            3223: 8,22
-            3224: 8,22
-            3225: 8,21
-            3226: 7,21
-            3227: 5,21
-            3228: 4,21
-            3229: 5,22
-            3230: 5,22
-            3231: 6,22
-            3232: 6,21
-            3233: 10,22
-            3239: 12,23
-            3240: 12,22
-            3241: 12,22
-            3242: 13,22
-            3243: 12,20
-            3244: 12,20
-            3245: 12,17
-            3246: 12,19
-            3247: 12,19
-            3248: 13,22
-            3249: 13,22
-            3250: 13,19
-            3251: 13,17
-            3252: 13,16
-            3253: 13,14
-            3254: 13,12
-            3255: 13,11
-            3256: 12,12
-            3257: 12,14
-            3258: 12,15
-            3259: 12,14
-            3260: 12,13
-            3261: 13,9
-            3262: 13,8
-            3263: 12,8
-            3264: 12,8
-            3265: 11,8
-            3266: 11,9
-            3267: 12,9
-            3268: 13,8
-            3269: 13,7
-            3270: 13,6
-            3271: 13,5
-            3272: 13,4
-            3273: 14,4
-            3274: 15,4
-            3275: 12,12
-            3276: 12,15
-            3277: 17,23
-            3278: 17,22
-            3279: 16,21
-            3280: 16,20
-            3281: 17,20
-            3282: 19,21
-            3283: 18,22
-            3284: 17,23
-            3285: 16,22
-            3286: 15,21
-            3294: 16,25
-            3295: 16,27
-            3296: 17,27
+            1666: -24,-24
+            1789: -13,-29
+            1790: -13,-29
+            1791: -12,-25
+            1792: -10,-22
+            1793: -10,-24
+            1794: -12,-23
+            1795: -11,-22
+            1796: -11,-23
+            1797: -11,-24
+            1939: -7,-38
+            1940: -8,-38
+            1941: -10,-38
+            1942: -11,-37
+            1943: -10,-37
+            1944: -9,-36
+            1945: -8,-36
+            1946: -10,-36
+            1947: -11,-36
+            1948: -12,-37
+            1949: -13,-38
+            1950: -13,-39
+            1951: -12,-40
+            1952: -12,-41
+            1953: -13,-42
+            1954: -13,-42
+            1955: -12,-40
+            1956: -12,-41
+            1957: -13,-42
+            1958: -12,-44
+            1959: -12,-45
+            1960: -12,-47
+            1961: -13,-48
+            1962: -12,-50
+            1963: -11,-50
+            1964: -12,-49
+            1965: -11,-48
+            1966: -12,-48
+            1967: -13,-49
+            1968: -13,-49
+            1969: -12,-48
+            1970: -12,-45
+            1971: -12,-44
+            1972: -13,-45
+            1973: -13,-43
+            1974: -13,-42
+            1975: -13,-40
+            1976: -12,-39
+            1977: -12,-39
+            1978: -11,-41
+            1979: -11,-43
+            1980: -11,-45
+            1981: -11,-45
+            1982: -11,-43
+            1983: -11,-42
+            1984: -14,-43
+            1985: -14,-46
+            1986: -14,-40
+            1987: -13,-37
+            1988: -13,-36
+            1989: -14,-37
+            1990: -12,-36
+            1991: -8,-38
+            1992: -7,-37
+            1993: -7,-36
+            1994: -8,-34
+            1995: -8,-32
+            1996: -8,-31
+            1997: -8,-31
+            1998: -7,-31
+            1999: -7,-32
+            2000: -6,-34
+            2001: -5,-32
+            2002: -5,-31
+            2003: -4,-32
+            2004: -4,-33
+            2005: -3,-34
+            2006: -3,-33
+            2007: -4,-31
+            2008: -5,-32
+            2009: -7,-34
+            2010: -14,-49
+            2011: -14,-49
+            2012: -13,-50
+            2013: -13,-51
+            2114: -40,-40
+            2115: -39,-40
+            2116: -38,-39
+            2117: -39,-39
+            2118: -40,-39
+            2119: -40,-38
+            2120: -39,-38
+            2121: -39,-37
+            2122: -40,-37
+            2123: -40,-37
+            2124: -41,-36
+            2125: -41,-37
+            2126: -39,-37
+            2127: -38,-38
+            2128: -38,-38
+            2129: -39,-37
+            2130: -41,-36
+            2131: -40,-38
+            2132: -39,-39
+            2133: -38,-38
+            2134: -39,-37
+            2135: -40,-37
+            2136: -39,-38
+            2137: -38,-38
+            2138: -40,-37
+            2232: -29,-49
+            2233: -29,-48
+            2234: -28,-47
+            2235: -27,-48
+            2236: -25,-48
+            2237: -26,-47
+            2238: -27,-47
+            2239: -26,-48
+            2240: -24,-48
+            2241: -32,-46
+            2242: -36,-46
+            2243: -37,-46
+            2244: -38,-46
+            2245: -37,-48
+            2246: -34,-48
+            2247: -33,-49
+            2248: -35,-49
+            2249: -36,-47
+            2250: -37,-49
+            2251: -35,-50
+            2252: -33,-48
+            2253: -33,-48
+            2254: -33,-51
+            2255: -35,-52
+            2256: -38,-51
+            2257: -39,-51
+            2258: -39,-53
+            2259: -37,-52
+            2260: -35,-52
+            2261: -37,-52
+            2262: -39,-50
+            2263: -37,-49
+            2264: -36,-52
+            2265: -35,-51
+            2266: -34,-51
+            2267: -42,-50
+            2268: -43,-50
+            2269: -43,-51
+            2270: -41,-51
+            2271: -41,-51
+            2321: -20,-50
+            2322: -21,-50
+            2323: -22,-50
+            2324: -22,-50
+            2325: -22,-49
+            2326: -21,-49
+            2327: -20,-49
+            2328: -20,-49
+            2329: -21,-49
+            2330: -22,-48
+            2331: -22,-48
+            2332: -21,-48
+            2333: -20,-47
+            2334: -21,-47
+            2335: -22,-46
+            2336: -21,-46
+            2337: -20,-45
+            2338: -22,-44
+            2339: -23,-44
+            2340: -23,-44
+            2341: -25,-45
+            2342: -25,-45
+            2343: -26,-44
+            2344: -28,-44
+            2345: -28,-44
+            2346: -28,-45
+            2347: -29,-45
+            2348: -30,-45
+            2349: -30,-44
+            2350: -31,-44
+            2351: -31,-44
+            2352: -29,-44
+            2353: -26,-44
+            2354: -25,-44
+            2355: -20,-40
+            2356: -21,-40
+            2357: -21,-40
+            2358: -22,-40
+            2359: -22,-39
+            2360: -21,-38
+            2361: -20,-37
+            2362: -21,-37
+            2363: -22,-37
+            2364: -21,-36
+            2365: -21,-36
+            2366: -20,-36
+            2367: -21,-37
+            2368: -21,-38
+            2369: -21,-39
+            2370: -21,-39
+            2371: -21,-39
+            2372: -21,-37
+            2373: -21,-37
+            2377: -20,-54
+            2378: -21,-54
+            2379: -21,-53
+            2380: -21,-53
+            2381: -21,-53
+            2382: -23,-53
+            2383: -23,-52
+            2384: -23,-52
+            2385: -23,-51
+            2386: -22,-51
+            2387: -21,-51
+            2388: -20,-52
+            2389: -20,-51
+            2390: -20,-52
+            2391: -22,-53
+            2395: -26,-53
+            2396: -28,-53
+            2397: -29,-53
+            2398: -30,-52
+            2399: -30,-52
+            2400: -30,-51
+            2401: -28,-52
+            2402: -26,-51
+            2403: -26,-51
+            2404: -26,-52
+            2405: -25,-52
+            2406: -27,-53
+            2407: -25,-53
+            2408: -25,-53
+            2409: -30,-51
+            2410: -30,-53
+            2411: -28,-51
+            2418: -27,-57
+            2419: -27,-56
+            2420: -26,-55
+            2421: -26,-55
+            2422: -26,-57
+            2423: -24,-56
+            2424: -24,-55
+            2425: -24,-55
+            2426: -23,-56
+            2427: -23,-57
+            2428: -23,-55
+            2429: -27,-55
+            2430: -26,-57
+            2431: -27,-56
+            2432: -23,-55
+            2445: -29,-55
+            2446: -29,-56
+            2447: -31,-56
+            2448: -32,-56
+            2449: -31,-55
+            2450: -28,-61
+            2451: -28,-60
+            2452: -27,-60
+            2453: -26,-60
+            2454: -25,-60
+            2455: -25,-58
+            2456: -24,-59
+            2457: -24,-60
+            2458: -24,-60
+            2459: -23,-60
+            2460: -24,-59
+            2461: -25,-60
+            2462: -24,-61
+            2463: -26,-63
+            2464: -27,-63
+            2465: -27,-65
+            2466: -25,-65
+            2467: -24,-65
+            2468: -25,-63
+            2469: -25,-63
+            2470: -24,-64
+            2471: -26,-65
+            2472: -27,-61
+            2473: -27,-61
+            2474: -29,-59
+            2475: -29,-58
+            2476: -29,-57
+            2482: -18,-54
+            2483: -18,-54
+            2484: -18,-53
+            2485: -18,-53
+            2486: -17,-53
+            2487: -16,-54
+            2488: -16,-54
+            2489: -15,-53
+            2490: -14,-52
+            2491: -12,-53
+            2492: -11,-53
+            2493: -11,-52
+            2494: -11,-52
+            2495: -15,-52
+            2496: -10,-54
+            2497: -13,-54
+            2498: -15,-54
+            2499: -16,-54
+            2500: -14,-52
+            2501: -11,-52
+            2502: -10,-53
+            2503: -17,-53
+            2504: -16,-52
+            2505: -13,-54
+            2506: -15,-54
+            2507: -13,-53
+            2508: -11,-52
+            2513: -8,-54
+            2514: -7,-54
+            2515: -8,-53
+            2516: -8,-52
+            2517: -7,-52
+            2518: -7,-54
+            2519: -6,-54
+            2520: -6,-53
+            2521: -7,-53
+            2522: -6,-52
+            2523: -6,-52
+            2524: -6,-51
+            2525: -6,-49
+            2526: -5,-49
+            2527: -6,-49
+            2528: -6,-50
+            2529: -6,-51
+            2530: -7,-53
+            2532: -5,-48
+            2533: -5,-47
+            2534: -5,-46
+            2535: -5,-46
+            2536: -5,-45
+            2537: -5,-45
+            2538: -5,-43
+            2539: -5,-44
+            2540: -4,-43
+            2541: -4,-45
+            2542: -3,-43
+            2543: -4,-43
+            2544: -5,-43
+            2545: -3,-43
+            2679: 18,-3
+            2680: 18,-3
+            2681: 19,-3
+            2682: 19,-4
+            2683: 19,-5
+            2684: 19,-7
+            2685: 19,-7
+            2686: 20,-7
+            2687: 21,-7
+            2688: 21,-6
+            2689: 21,-5
+            2690: 21,-4
+            2691: 21,-4
+            2692: 22,-3
+            2693: 22,-4
+            2694: 22,-6
+            2695: 23,-6
+            2696: 24,-6
+            2697: 24,-5
+            2698: 25,-4
+            2699: 25,-3
+            2700: 25,-3
+            2701: 25,-5
+            2702: 23,-7
+            2703: 24,-3
+            2704: 24,-3
+            2705: 21,-3
+            2706: 22,-3
+            2707: 18,-5
+            2730: 23,-13
+            2731: 22,-13
+            2732: 22,-12
+            2733: 22,-11
+            2734: 22,-9
+            2735: 22,-9
+            2736: 23,-10
+            2737: 24,-11
+            2738: 24,-11
+            2739: 22,-10
+            2740: 22,-13
+            2741: 22,-12
+            2742: 22,-11
+            2743: 23,-11
+            2744: 24,-9
+            2745: 26,-10
+            2746: 26,-9
+            2747: 27,-9
+            2748: 26,-8
+            2749: 28,-8
+            2750: 29,-9
+            2751: 29,-8
+            2752: 30,-7
+            2753: 28,-7
+            2754: 28,-7
+            2755: 30,-9
+            2756: 30,-7
+            2767: 22,-16
+            2768: 22,-15
+            2769: 23,-16
+            2770: 23,-16
+            2771: 24,-15
+            2772: 25,-16
+            2773: 25,-16
+            2774: 26,-15
+            2775: 26,-14
+            2776: 25,-14
+            2777: 26,-12
+            2778: 26,-14
+            2779: 25,-14
+            2780: 25,-13
+            2781: 25,-13
+            2782: 25,-13
+            2783: 24,-15
+            2997: 24,6
+            2998: 23,6
+            2999: 15,6
+            3000: 15,6
+            3001: 18,8
+            3002: 18,7
+            3003: 17,7
+            3004: 20,11
+            3005: 20,6
+            3006: 24,8
+            3007: 26,6
+            3008: 28,8
+            3009: 28,6
+            3010: 29,5
+            3011: 29,4
+            3012: 31,7
+            3013: 34,7
+            3014: 35,5
+            3015: 33,7
+            3016: 29,8
+            3017: 29,10
+            3018: 28,9
+            3019: 30,10
+            3020: 30,8
+            3021: 26,8
+            3022: 20,11
+            3023: 17,11
+            3024: 15,11
+            3025: 17,8
+            3026: 17,7
+            3027: 21,7
+            3028: 23,10
+            3029: 23,10
+            3030: 25,11
+            3031: 24,13
+            3032: 23,13
+            3033: 24,14
+            3034: 26,14
+            3035: 26,13
+            3036: 23,15
+            3037: 24,15
+            3038: 26,15
+            3039: 26,16
+            3040: 23,16
+            3041: 22,16
+            3042: 20,16
+            3043: 19,16
+            3044: 20,18
+            3045: 21,18
+            3046: 21,18
+            3047: 23,19
+            3048: 25,18
+            3049: 25,16
+            3050: 26,18
+            3051: 24,18
+            3052: 22,17
+            3053: 22,20
+            3054: 26,18
+            3055: 22,18
+            3056: 20,16
+            3057: 19,16
+            3058: 27,16
+            3170: 43,21
+            3171: 43,21
+            3172: 44,21
+            3173: 42,23
+            3174: 42,23
+            3175: 42,24
+            3176: 42,24
+            3177: 43,24
+            3178: 43,23
+            3179: 43,22
+            3180: 42,22
+            3181: 42,21
+            3196: 10,21
+            3197: 10,22
+            3198: 8,22
+            3199: 8,22
+            3200: 8,21
+            3201: 7,21
+            3202: 5,21
+            3203: 4,21
+            3204: 5,22
+            3205: 5,22
+            3206: 6,22
+            3207: 6,21
+            3208: 10,22
+            3214: 12,23
+            3215: 12,22
+            3216: 12,22
+            3217: 13,22
+            3218: 12,20
+            3219: 12,20
+            3220: 12,17
+            3221: 12,19
+            3222: 12,19
+            3223: 13,22
+            3224: 13,22
+            3225: 13,19
+            3226: 13,17
+            3227: 13,16
+            3228: 13,14
+            3229: 13,12
+            3230: 13,11
+            3231: 12,12
+            3232: 12,14
+            3233: 12,15
+            3234: 12,14
+            3235: 12,13
+            3236: 13,9
+            3237: 13,8
+            3238: 12,8
+            3239: 12,8
+            3240: 11,8
+            3241: 11,9
+            3242: 12,9
+            3243: 13,8
+            3244: 13,7
+            3245: 13,6
+            3246: 13,5
+            3247: 13,4
+            3248: 14,4
+            3249: 15,4
+            3250: 12,12
+            3251: 12,15
+            3252: 17,23
+            3253: 17,22
+            3254: 16,21
+            3255: 16,20
+            3256: 17,20
+            3257: 19,21
+            3258: 18,22
+            3259: 17,23
+            3260: 16,22
+            3261: 15,21
+            3269: 16,25
+            3270: 16,27
+            3271: 17,27
+            3272: 18,27
+            3273: 18,26
+            3274: 18,25
+            3275: 20,25
+            3276: 20,25
+            3277: 21,25
+            3278: 19,27
+            3279: 23,25
+            3280: 24,25
+            3281: 25,25
+            3282: 25,27
+            3283: 23,27
+            3284: 21,27
+            3285: 21,27
+            3286: 21,27
+            3287: 21,27
+            3288: 21,27
+            3289: 21,27
+            3290: 25,26
+            3291: 26,25
+            3292: 26,25
+            3293: 24,25
+            3294: 20,25
+            3295: 20,27
+            3296: 18,27
             3297: 18,27
-            3298: 18,26
-            3299: 18,25
+            3298: 20,26
+            3299: 21,25
             3300: 20,25
-            3301: 20,25
-            3302: 21,25
-            3303: 19,27
-            3304: 23,25
-            3305: 24,25
-            3306: 25,25
-            3307: 25,27
-            3308: 23,27
-            3309: 21,27
-            3310: 21,27
-            3311: 21,27
-            3312: 21,27
-            3313: 21,27
-            3314: 21,27
-            3315: 25,26
-            3316: 26,25
-            3317: 26,25
-            3318: 24,25
-            3319: 20,25
-            3320: 20,27
-            3321: 18,27
-            3322: 18,27
-            3323: 20,26
-            3324: 21,25
-            3325: 20,25
-            3897: -23,14
-            3898: -23,15
-            3899: -22,15
-            3900: -22,16
-            3901: -19,15
-            3902: -20,15
-            3903: -19,14
-            3904: -18,14
-            3905: -17,15
-            3906: -17,16
-            3907: -19,16
-            3908: -19,14
-            3909: -19,14
-            3910: -20,14
-            3911: -21,14
-            3912: -22,14
-            3913: -21,16
-            3914: -18,16
-            3915: -17,15
-            3916: -21,16
-            3917: -22,16
-            3918: -21,17
-            3919: -21,17
-            3920: -23,15
-            3921: -23,16
-            3922: -17,14
-            3923: -22,14
-            3924: -17,16
-            3933: -25,15
-            3934: -26,15
-            3935: -25,16
-            3936: -25,16
-            3937: -25,17
-            3938: -25,18
-            3939: -26,18
-            3940: -26,18
-            3941: -26,20
-            3942: -28,19
-            3943: -28,19
-            3944: -30,19
-            3945: -29,20
-            3946: -30,21
-            3947: -28,21
-            3948: -27,21
-            3949: -27,20
-            3950: -28,21
-            3951: -28,20
-            3952: -26,21
-            3953: -25,20
-            3954: -24,20
-            3955: -24,19
-            3956: -24,19
-            3957: -26,19
-            3958: -28,23
-            3959: -28,24
-            3960: -28,24
-            3961: -28,26
-            3962: -28,26
-            3963: -28,25
-            3964: -28,26
-            3965: -28,25
-            3966: -26,16
-            3967: -25,15
-            3969: -32,19
-            3970: -33,19
-            3971: -34,19
-            3972: -33,20
-            3973: -34,21
-            3974: -34,20
-            3975: -32,21
-            3976: -32,20
-            3977: -28,15
-            3978: -29,15
-            3979: -30,16
-            3980: -29,17
-            3981: -29,16
-            3982: -29,16
-            3983: -28,17
-            3984: -28,17
-            3985: -30,15
-            3986: -29,17
-            3987: -29,17
-            4086: -13,22
-            4087: -12,22
-            4088: -12,24
-            4089: -10,22
-            4090: -9,24
-            4091: -7,24
-            4092: -8,22
-            4093: -7,22
-            4094: -9,23
-            4095: -4,22
-            4096: -3,23
-            4097: -4,24
-            4098: -3,25
-            4678: -7,42
-            4679: -5,42
-            4680: -4,42
-            4681: -5,43
-            4682: -7,43
-            4683: -6,44
-            4684: -4,44
-            4685: -4,45
-            4686: -5,43
-            4687: -6,43
-            4688: -6,44
-            4689: -6,45
-            4690: -5,44
-            4691: -4,46
-            4692: -4,47
-            4693: -3,47
-            4694: -3,48
-            4695: -4,48
-            4696: -4,47
-            4697: -4,45
-            4698: -6,45
-            4699: -3,44
-            4700: -8,45
-            4701: -9,45
-            4702: -11,45
-            4703: -12,45
-            4704: -12,46
-            4705: -12,47
-            4706: -12,48
-            4707: -11,46
-            4708: -12,47
-            4709: -12,47
-            4710: -7,45
-            4711: -7,43
-            4712: -4,43
-            5362: 36,-28
-            5363: 36,-28
-            5364: 36,-29
-            5365: 35,-33
-            5366: 35,-33
-            5367: 36,-34
-            5368: 36,-35
-            5369: 35,-35
-            5370: 34,-35
-            5371: 34,-33
-            5372: 34,-32
-            5373: 34,-31
-            5374: 34,-29
-            5375: 34,-28
-            5376: 34,-30
-            5377: 35,-32
-            5378: 36,-31
-            5379: 34,-33
-            5380: 35,-35
-            5381: 36,-33
-            5382: 34,-28
-            5383: 36,-31
-            5384: 35,-32
-            5385: 35,-29
-            5434: 19,-30
-            5435: 17,-30
-            5898: 13,-38
-            5899: 12,-37
-            5900: 11,-37
-            5901: 11,-36
-            5902: 13,-36
-            5903: 13,-36
-            5904: 14,-36
-            5905: 12,-36
-            5906: 11,-37
-            5907: 15,-36
-            5908: 16,-37
-            5909: 13,-37
-            5910: 14,-38
-            5911: 13,-39
-            5912: 11,-39
-            5913: 10,-39
-            5914: 11,-38
-            5915: 12,-38
-            5916: 10,-37
-            5917: 10,-35
-            5918: 12,-35
-            5919: 14,-35
-            5920: 15,-35
-            5921: 16,-36
-            5922: 15,-37
-            5923: 10,-39
-            5924: 10,-38
-            5932: 18,-35
-            5933: 19,-35
-            5934: 20,-35
-            5935: 21,-35
-            5936: 22,-35
-            5937: 23,-35
-            5938: 23,-36
-            5939: 24,-37
-            5940: 25,-36
-            5941: 26,-35
-            5942: 25,-35
-            5943: 26,-36
-            5944: 25,-37
-            5945: 23,-37
-            5946: 22,-38
-            5947: 23,-38
-            5948: 25,-38
-            5949: 27,-38
-            5950: 27,-36
-            5951: 27,-35
-            5952: 21,-37
-            5953: 20,-37
-            5954: 20,-38
-            5955: 18,-38
-            5956: 18,-38
-            5957: 18,-37
-            5958: 22,-37
-            5959: 24,-37
-            5960: 23,-36
-            5961: 24,-35
-            5962: 26,-35
-            5963: 26,-36
-            5964: 26,-38
-            5965: 26,-37
-            5966: 28,-38
-            5967: 29,-37
-            5968: 29,-37
-            5969: 29,-38
-            5970: 30,-37
-            5971: 30,-35
-            5972: 29,-35
-            5973: 31,-35
-            5974: 30,-34
-            5975: 31,-34
-            5976: 31,-35
-            5977: 32,-35
-            5978: 32,-34
-            5979: 30,-34
-            5980: 30,-38
-            5985: 36,-40
-            5986: 36,-39
-            5987: 35,-38
-            5988: 33,-37
-            5989: 35,-37
-            5990: 32,-37
-            5991: 32,-39
-            5992: 32,-40
-            5993: 34,-40
-            5994: 34,-39
-            5995: 33,-38
-            5996: 34,-37
-            5997: 35,-40
-            5998: 35,-39
-            5999: 36,-37
-            6000: 36,-37
-            6001: 33,-39
-            6216: -4,-54
-            6217: -4,-54
-            6218: -3,-53
-            6219: -1,-54
-            6220: -1,-54
-            6221: 0,-54
-            6222: 0,-53
-            6223: -1,-52
-            6224: 0,-51
-            6225: -1,-51
-            6226: -2,-52
-            6227: -3,-52
-            6228: -3,-51
-            6229: -4,-51
-            6230: -4,-52
-            6231: -4,-53
-            6232: -1,-53
-            6233: -1,-52
-            6234: -1,-53
-            6235: -3,-54
-            6236: -3,-53
-            6237: -3,-54
-            6238: -1,-53
-            6239: 0,-52
-            6240: -4,-51
-            6241: -2,-54
-            6242: 0,-53
-            6243: -1,-51
-            6244: -4,-52
-            6245: 0,-52
-            6246: -1,-53
-            6247: -3,-53
-            6248: -2,-53
-            6249: -2,-53
-            6250: 0,-52
-            6287: 3,-53
-            6288: 2,-54
-            6289: 4,-55
-            6290: 3,-56
-            6291: 3,-57
-            6292: 3,-58
-            6293: 3,-60
-            6294: 2,-61
-            6295: 4,-61
-            6296: 4,-59
-            6297: 2,-59
-            6298: 2,-58
-            6299: 4,-57
-            6300: 3,-54
-            6301: 5,-56
-            6302: 1,-58
-            6303: 3,-62
-            6304: 3,-61
-            6349: -8,-60
-            6350: -8,-60
-            6351: -7,-61
-            6352: -5,-61
-            6353: -2,-61
-            6354: -4,-61
-            6355: 0,-61
-            6356: 0,-60
-            6357: 0,-58
-            6358: -4,-56
-            6359: -6,-56
-            6360: -7,-56
-            6361: -8,-57
-            6362: -2,-56
-            6405: -15,-57
-            6406: -16,-57
-            6407: -15,-57
-            6408: -11,-57
-            6409: -11,-57
-            6410: -13,-61
-            6411: -15,-61
-            6412: -16,-61
-            6413: -15,-60
-            6414: -13,-60
-            6415: -14,-60
-            6416: -16,-61
-            6417: -21,-64
-            6418: -21,-63
-            6419: -19,-63
-            6420: -18,-63
-            6421: -19,-62
-            6422: -21,-62
-            6423: -19,-60
-            6424: -21,-60
-            6425: -20,-59
-            6426: -19,-59
-            6427: -19,-57
-            6428: -21,-59
-            6429: -21,-56
-            6430: -19,-56
-            6431: -18,-58
-            6432: -16,-59
-            6433: -15,-58
-            6434: -15,-59
-            6435: -13,-57
-            6436: -12,-58
-            6437: -11,-60
-            6438: -10,-59
-            6439: -9,-59
-            6440: -14,-59
-            6441: -11,-58
-            6442: -8,-59
-            6443: -6,-58
-            6444: -6,-59
-            6445: -4,-58
-            6446: -3,-59
-            6447: -1,-60
-            6448: -1,-57
-            6449: -6,-57
-            6450: -7,-58
-            6451: -7,-60
-            6452: -2,-60
-            6453: -2,-58
-            6664: -7,-76
-            6665: -8,-76
-            6666: -7,-75
-            6667: -6,-74
-            6668: -8,-73
-            6669: -6,-72
-            6670: -5,-71
-            6671: -7,-71
-            6672: -8,-72
-            6673: -7,-72
-            6674: -8,-69
-            6675: -7,-68
-            6676: -6,-70
-            6677: -7,-71
-            6678: -7,-68
-            6679: -8,-65
-            6680: -6,-64
-            6681: -6,-66
-            6682: -6,-68
-            6683: -6,-68
-            6684: -5,-64
-            6685: -5,-64
-            6686: -5,-65
-            6687: -3,-63
-            6688: -3,-64
-            6689: -4,-65
-            6690: -1,-64
-            6691: -1,-63
-            6692: -4,-65
-            6693: -3,-67
-            6694: -3,-66
-            6695: -2,-63
-            6696: -1,-63
-            6697: -1,-65
-            6698: 2,-64
-            6699: 0,-63
-            6700: 0,-64
-            6701: 4,-64
-            6702: 5,-64
-            6703: 5,-67
-            6704: 4,-66
-            6705: 4,-66
-            6706: 3,-64
-            6707: 5,-63
-            6708: 7,-64
-            6709: 7,-66
-            6710: 6,-68
-            6711: 8,-69
-            6712: 6,-67
-            6713: 7,-65
-            6714: 8,-64
-            6715: 8,-65
-            6716: 8,-67
-            6717: 8,-69
-            6718: 6,-69
-            6719: 6,-69
-            6720: 6,-71
-            6721: 9,-71
-            6722: 7,-70
-            6723: 6,-72
-            6724: 7,-72
-            6725: 8,-73
-            6726: 7,-74
-            6727: 5,-72
-            6728: 6,-74
-            6729: 7,-75
-            6730: 5,-77
-            6731: 5,-74
-            6732: 5,-73
-            6733: 5,-75
-            6734: 4,-76
-            6735: 3,-73
-            6736: 3,-73
-            6737: 3,-76
-            6738: 2,-76
-            6739: 2,-75
-            6740: -1,-74
-            6741: 0,-76
-            6742: 1,-77
-            6743: -2,-76
-            6744: -1,-73
-            6745: -2,-75
-            6746: -2,-77
-            6747: -3,-76
-            6748: -3,-74
-            6749: -5,-75
-            6750: -6,-76
-            6751: -6,-74
-            6752: -4,-75
-            6753: -2,-77
-            6754: -3,-73
-            6755: -3,-76
-            6756: 1,-74
-            6757: 0,-73
-            6758: 2,-76
-            6759: 4,-74
-            6760: 5,-73
-            6761: 8,-72
-            6762: 10,-71
-            6763: 10,-69
-            6764: 11,-69
-            6765: 13,-71
-            6766: 12,-69
-            6767: 13,-69
-            6768: 14,-67
-            6769: 12,-65
-            6770: 10,-65
-            6771: 11,-64
-            6772: 13,-65
-            6773: 14,-64
-            6774: 12,-63
-            6775: 9,-64
-            6776: 12,-62
-            6777: 11,-61
-            6778: 13,-60
-            6779: 13,-61
-            6780: 13,-58
-            6781: 10,-60
-            6782: 13,-61
-            6783: 13,-61
-            6784: 11,-59
-            6785: 13,-59
-            7170: 8,-38
-            7171: 8,-38
-            7172: 8,-35
-            7173: 7,-35
-            7174: 6,-35
-            7175: 4,-35
-            7176: 4,-35
-            7177: 4,-38
-            7178: 6,-37
-            7179: 7,-37
-            7180: 6,-38
-            7181: 4,-37
-            7182: 6,-35
-            7196: 38,-41
-            7197: 38,-41
-            7198: 38,-39
-            7199: 38,-38
-            7200: 39,-37
-            7201: 39,-37
-            7202: 39,-39
-            7203: 40,-40
-            7204: 40,-40
-            7205: 41,-40
-            7206: 41,-38
-            7207: 42,-37
-            7208: 43,-39
-            7209: 43,-40
-            7210: 44,-40
-            7211: 45,-39
-            7212: 45,-38
-            7213: 45,-38
-            7214: 46,-40
-            7215: 46,-41
-            7216: 47,-41
-            7217: 47,-38
-            7218: 46,-37
-            7219: 43,-37
-            7220: 43,-38
-            7221: 42,-38
-            7222: 41,-41
-            7223: 40,-39
-            7224: 39,-40
-            7225: 39,-40
-            7226: 38,-37
-            7227: 40,-39
-            7228: 45,-41
-            7229: 46,-41
-            7230: 47,-39
-            7231: 44,-41
-            7232: 42,-41
-            7233: 44,-39
-            7234: 42,-38
-            7235: 42,-38
-            7236: 38,-37
-            7237: 29,-12
-            7238: 28,-13
-            7239: 28,-13
-            7240: 28,-12
-            7241: 28,-11
-            7242: 30,-11
-            7243: 30,-12
-            7244: 29,-13
-            7250: 6,-14
-            7251: 5,-14
-            7252: 4,-14
-            7253: 4,-13
-            7254: 6,-12
-            7255: 6,-13
-            7256: 6,-14
-            7257: 4,-12
-            7258: 4,-13
-            7298: -48,-16
-            7299: -48,-17
-            7300: -48,-19
-            7301: -49,-20
-            7302: -46,-24
-            7303: -45,-22
-            7304: -43,-21
-            7305: -43,-23
-            7306: -42,-23
-            7307: -41,-23
-            7308: -44,-16
-            7309: -45,-17
-            7310: -46,-18
-            7311: -46,-20
-            7312: -47,-22
-            7313: -47,-22
-            7314: -44,-21
-            7315: -42,-18
-            7316: -45,-17
-            7317: -46,-17
-            7318: -45,-17
-            7319: -46,-18
-            7320: -45,-21
-            7321: -42,-22
-            7322: -41,-23
-            7359: -49,-21
-            7360: -49,-22
-            7361: -49,-23
-            7362: -48,-24
-            7363: -47,-23
-            7364: -47,-21
-            7365: -47,-18
-            7366: -48,-19
-            7367: -48,-18
-            7368: -48,-16
-            7369: -48,-16
-            7370: -49,-16
-            7371: -43,-16
-            7372: -41,-17
-            7373: -43,-18
-            7374: -44,-18
-            7375: -42,-20
-            7376: -40,-21
-            7377: -42,-19
-            7378: -43,-18
-            7379: -41,-21
-            7380: -41,-24
-            7381: -45,-24
-            7382: -45,-23
-            7383: -41,-20
+            3872: -23,14
+            3873: -23,15
+            3874: -22,15
+            3875: -22,16
+            3876: -19,15
+            3877: -20,15
+            3878: -19,14
+            3879: -18,14
+            3880: -17,15
+            3881: -17,16
+            3882: -19,16
+            3883: -19,14
+            3884: -19,14
+            3885: -20,14
+            3886: -21,14
+            3887: -22,14
+            3888: -21,16
+            3889: -18,16
+            3890: -17,15
+            3891: -21,16
+            3892: -22,16
+            3893: -21,17
+            3894: -21,17
+            3895: -23,15
+            3896: -23,16
+            3897: -17,14
+            3898: -22,14
+            3899: -17,16
+            3908: -25,15
+            3909: -26,15
+            3910: -25,16
+            3911: -25,16
+            3912: -25,17
+            3913: -25,18
+            3914: -26,18
+            3915: -26,18
+            3916: -26,20
+            3917: -28,19
+            3918: -28,19
+            3919: -30,19
+            3920: -29,20
+            3921: -30,21
+            3922: -28,21
+            3923: -27,21
+            3924: -27,20
+            3925: -28,21
+            3926: -28,20
+            3927: -26,21
+            3928: -25,20
+            3929: -24,20
+            3930: -24,19
+            3931: -24,19
+            3932: -26,19
+            3933: -28,23
+            3934: -28,24
+            3935: -28,24
+            3936: -28,26
+            3937: -28,26
+            3938: -28,25
+            3939: -28,26
+            3940: -28,25
+            3941: -26,16
+            3942: -25,15
+            3944: -32,19
+            3945: -33,19
+            3946: -34,19
+            3947: -33,20
+            3948: -34,21
+            3949: -34,20
+            3950: -32,21
+            3951: -32,20
+            3952: -28,15
+            3953: -29,15
+            3954: -30,16
+            3955: -29,17
+            3956: -29,16
+            3957: -29,16
+            3958: -28,17
+            3959: -28,17
+            3960: -30,15
+            3961: -29,17
+            3962: -29,17
+            4061: -13,22
+            4062: -12,22
+            4063: -12,24
+            4064: -10,22
+            4065: -9,24
+            4066: -7,24
+            4067: -8,22
+            4068: -7,22
+            4069: -9,23
+            4070: -4,22
+            4071: -3,23
+            4072: -4,24
+            4073: -3,25
+            4653: -7,42
+            4654: -5,42
+            4655: -4,42
+            4656: -5,43
+            4657: -7,43
+            4658: -6,44
+            4659: -4,44
+            4660: -4,45
+            4661: -5,43
+            4662: -6,43
+            4663: -6,44
+            4664: -6,45
+            4665: -5,44
+            4666: -4,46
+            4667: -4,47
+            4668: -3,47
+            4669: -3,48
+            4670: -4,48
+            4671: -4,47
+            4672: -4,45
+            4673: -6,45
+            4674: -3,44
+            4675: -8,45
+            4676: -9,45
+            4677: -11,45
+            4678: -12,45
+            4679: -12,46
+            4680: -12,47
+            4681: -12,48
+            4682: -11,46
+            4683: -12,47
+            4684: -12,47
+            4685: -7,45
+            4686: -7,43
+            4687: -4,43
+            5337: 36,-28
+            5338: 36,-28
+            5339: 36,-29
+            5340: 35,-33
+            5341: 35,-33
+            5342: 36,-34
+            5343: 36,-35
+            5344: 35,-35
+            5345: 34,-35
+            5346: 34,-33
+            5347: 34,-32
+            5348: 34,-31
+            5349: 34,-29
+            5350: 34,-28
+            5351: 34,-30
+            5352: 35,-32
+            5353: 36,-31
+            5354: 34,-33
+            5355: 35,-35
+            5356: 36,-33
+            5357: 34,-28
+            5358: 36,-31
+            5359: 35,-32
+            5360: 35,-29
+            5409: 19,-30
+            5410: 17,-30
+            5873: 13,-38
+            5874: 12,-37
+            5875: 11,-37
+            5876: 11,-36
+            5877: 13,-36
+            5878: 13,-36
+            5879: 14,-36
+            5880: 12,-36
+            5881: 11,-37
+            5882: 15,-36
+            5883: 16,-37
+            5884: 13,-37
+            5885: 14,-38
+            5886: 13,-39
+            5887: 11,-39
+            5888: 10,-39
+            5889: 11,-38
+            5890: 12,-38
+            5891: 10,-37
+            5892: 10,-35
+            5893: 12,-35
+            5894: 14,-35
+            5895: 15,-35
+            5896: 16,-36
+            5897: 15,-37
+            5898: 10,-39
+            5899: 10,-38
+            5907: 18,-35
+            5908: 19,-35
+            5909: 20,-35
+            5910: 21,-35
+            5911: 22,-35
+            5912: 23,-35
+            5913: 23,-36
+            5914: 24,-37
+            5915: 25,-36
+            5916: 26,-35
+            5917: 25,-35
+            5918: 26,-36
+            5919: 25,-37
+            5920: 23,-37
+            5921: 22,-38
+            5922: 23,-38
+            5923: 25,-38
+            5924: 27,-38
+            5925: 27,-36
+            5926: 27,-35
+            5927: 21,-37
+            5928: 20,-37
+            5929: 20,-38
+            5930: 18,-38
+            5931: 18,-38
+            5932: 18,-37
+            5933: 22,-37
+            5934: 24,-37
+            5935: 23,-36
+            5936: 24,-35
+            5937: 26,-35
+            5938: 26,-36
+            5939: 26,-38
+            5940: 26,-37
+            5941: 28,-38
+            5942: 29,-37
+            5943: 29,-37
+            5944: 29,-38
+            5945: 30,-37
+            5946: 30,-35
+            5947: 29,-35
+            5948: 31,-35
+            5949: 30,-34
+            5950: 31,-34
+            5951: 31,-35
+            5952: 32,-35
+            5953: 32,-34
+            5954: 30,-34
+            5955: 30,-38
+            5960: 36,-40
+            5961: 36,-39
+            5962: 35,-38
+            5963: 33,-37
+            5964: 35,-37
+            5965: 32,-37
+            5966: 32,-39
+            5967: 32,-40
+            5968: 34,-40
+            5969: 34,-39
+            5970: 33,-38
+            5971: 34,-37
+            5972: 35,-40
+            5973: 35,-39
+            5974: 36,-37
+            5975: 36,-37
+            5976: 33,-39
+            6191: -4,-54
+            6192: -4,-54
+            6193: -3,-53
+            6194: -1,-54
+            6195: -1,-54
+            6196: 0,-54
+            6197: 0,-53
+            6198: -1,-52
+            6199: 0,-51
+            6200: -1,-51
+            6201: -2,-52
+            6202: -3,-52
+            6203: -3,-51
+            6204: -4,-51
+            6205: -4,-52
+            6206: -4,-53
+            6207: -1,-53
+            6208: -1,-52
+            6209: -1,-53
+            6210: -3,-54
+            6211: -3,-53
+            6212: -3,-54
+            6213: -1,-53
+            6214: 0,-52
+            6215: -4,-51
+            6216: -2,-54
+            6217: 0,-53
+            6218: -1,-51
+            6219: -4,-52
+            6220: 0,-52
+            6221: -1,-53
+            6222: -3,-53
+            6223: -2,-53
+            6224: -2,-53
+            6225: 0,-52
+            6262: 3,-53
+            6263: 2,-54
+            6264: 4,-55
+            6265: 3,-56
+            6266: 3,-57
+            6267: 3,-58
+            6268: 3,-60
+            6269: 2,-61
+            6270: 4,-61
+            6271: 4,-59
+            6272: 2,-59
+            6273: 2,-58
+            6274: 4,-57
+            6275: 3,-54
+            6276: 5,-56
+            6277: 1,-58
+            6278: 3,-62
+            6279: 3,-61
+            6324: -8,-60
+            6325: -8,-60
+            6326: -7,-61
+            6327: -5,-61
+            6328: -2,-61
+            6329: -4,-61
+            6330: 0,-61
+            6331: 0,-60
+            6332: 0,-58
+            6333: -4,-56
+            6334: -6,-56
+            6335: -7,-56
+            6336: -8,-57
+            6337: -2,-56
+            6380: -15,-57
+            6381: -16,-57
+            6382: -15,-57
+            6383: -11,-57
+            6384: -11,-57
+            6385: -13,-61
+            6386: -15,-61
+            6387: -16,-61
+            6388: -15,-60
+            6389: -13,-60
+            6390: -14,-60
+            6391: -16,-61
+            6392: -21,-64
+            6393: -21,-63
+            6394: -19,-63
+            6395: -18,-63
+            6396: -19,-62
+            6397: -21,-62
+            6398: -19,-60
+            6399: -21,-60
+            6400: -20,-59
+            6401: -19,-59
+            6402: -19,-57
+            6403: -21,-59
+            6404: -21,-56
+            6405: -19,-56
+            6406: -18,-58
+            6407: -16,-59
+            6408: -15,-58
+            6409: -15,-59
+            6410: -13,-57
+            6411: -12,-58
+            6412: -11,-60
+            6413: -10,-59
+            6414: -9,-59
+            6415: -14,-59
+            6416: -11,-58
+            6417: -8,-59
+            6418: -6,-58
+            6419: -6,-59
+            6420: -4,-58
+            6421: -3,-59
+            6422: -1,-60
+            6423: -1,-57
+            6424: -6,-57
+            6425: -7,-58
+            6426: -7,-60
+            6427: -2,-60
+            6428: -2,-58
+            6639: -7,-76
+            6640: -8,-76
+            6641: -7,-75
+            6642: -6,-74
+            6643: -8,-73
+            6644: -6,-72
+            6645: -5,-71
+            6646: -7,-71
+            6647: -8,-72
+            6648: -7,-72
+            6649: -8,-69
+            6650: -7,-68
+            6651: -6,-70
+            6652: -7,-71
+            6653: -7,-68
+            6654: -8,-65
+            6655: -6,-64
+            6656: -6,-66
+            6657: -6,-68
+            6658: -6,-68
+            6659: -5,-64
+            6660: -5,-64
+            6661: -5,-65
+            6662: -3,-63
+            6663: -3,-64
+            6664: -4,-65
+            6665: -1,-64
+            6666: -1,-63
+            6667: -4,-65
+            6668: -3,-67
+            6669: -3,-66
+            6670: -2,-63
+            6671: -1,-63
+            6672: -1,-65
+            6673: 2,-64
+            6674: 0,-63
+            6675: 0,-64
+            6676: 4,-64
+            6677: 5,-64
+            6678: 5,-67
+            6679: 4,-66
+            6680: 4,-66
+            6681: 3,-64
+            6682: 5,-63
+            6683: 7,-64
+            6684: 7,-66
+            6685: 6,-68
+            6686: 8,-69
+            6687: 6,-67
+            6688: 7,-65
+            6689: 8,-64
+            6690: 8,-65
+            6691: 8,-67
+            6692: 8,-69
+            6693: 6,-69
+            6694: 6,-69
+            6695: 6,-71
+            6696: 9,-71
+            6697: 7,-70
+            6698: 6,-72
+            6699: 7,-72
+            6700: 8,-73
+            6701: 7,-74
+            6702: 5,-72
+            6703: 6,-74
+            6704: 7,-75
+            6705: 5,-77
+            6706: 5,-74
+            6707: 5,-73
+            6708: 5,-75
+            6709: 4,-76
+            6710: 3,-73
+            6711: 3,-73
+            6712: 3,-76
+            6713: 2,-76
+            6714: 2,-75
+            6715: -1,-74
+            6716: 0,-76
+            6717: 1,-77
+            6718: -2,-76
+            6719: -1,-73
+            6720: -2,-75
+            6721: -2,-77
+            6722: -3,-76
+            6723: -3,-74
+            6724: -5,-75
+            6725: -6,-76
+            6726: -6,-74
+            6727: -4,-75
+            6728: -2,-77
+            6729: -3,-73
+            6730: -3,-76
+            6731: 1,-74
+            6732: 0,-73
+            6733: 2,-76
+            6734: 4,-74
+            6735: 5,-73
+            6736: 8,-72
+            6737: 10,-71
+            6738: 10,-69
+            6739: 11,-69
+            6740: 13,-71
+            6741: 12,-69
+            6742: 13,-69
+            6743: 14,-67
+            6744: 12,-65
+            6745: 10,-65
+            6746: 11,-64
+            6747: 13,-65
+            6748: 14,-64
+            6749: 12,-63
+            6750: 9,-64
+            6751: 12,-62
+            6752: 11,-61
+            6753: 13,-60
+            6754: 13,-61
+            6755: 13,-58
+            6756: 10,-60
+            6757: 13,-61
+            6758: 13,-61
+            6759: 11,-59
+            6760: 13,-59
+            7145: 8,-38
+            7146: 8,-38
+            7147: 8,-35
+            7148: 7,-35
+            7149: 6,-35
+            7150: 4,-35
+            7151: 4,-35
+            7152: 4,-38
+            7153: 6,-37
+            7154: 7,-37
+            7155: 6,-38
+            7156: 4,-37
+            7157: 6,-35
+            7171: 38,-41
+            7172: 38,-41
+            7173: 38,-39
+            7174: 38,-38
+            7175: 39,-37
+            7176: 39,-37
+            7177: 39,-39
+            7178: 40,-40
+            7179: 40,-40
+            7180: 41,-40
+            7181: 41,-38
+            7182: 42,-37
+            7183: 43,-39
+            7184: 43,-40
+            7185: 44,-40
+            7186: 45,-39
+            7187: 45,-38
+            7188: 45,-38
+            7189: 46,-40
+            7190: 46,-41
+            7191: 47,-41
+            7192: 47,-38
+            7193: 46,-37
+            7194: 43,-37
+            7195: 43,-38
+            7196: 42,-38
+            7197: 41,-41
+            7198: 40,-39
+            7199: 39,-40
+            7200: 39,-40
+            7201: 38,-37
+            7202: 40,-39
+            7203: 45,-41
+            7204: 46,-41
+            7205: 47,-39
+            7206: 44,-41
+            7207: 42,-41
+            7208: 44,-39
+            7209: 42,-38
+            7210: 42,-38
+            7211: 38,-37
+            7212: 29,-12
+            7213: 28,-13
+            7214: 28,-13
+            7215: 28,-12
+            7216: 28,-11
+            7217: 30,-11
+            7218: 30,-12
+            7219: 29,-13
+            7225: 6,-14
+            7226: 5,-14
+            7227: 4,-14
+            7228: 4,-13
+            7229: 6,-12
+            7230: 6,-13
+            7231: 6,-14
+            7232: 4,-12
+            7233: 4,-13
+            7273: -48,-16
+            7274: -48,-17
+            7275: -48,-19
+            7276: -49,-20
+            7277: -46,-24
+            7278: -45,-22
+            7279: -43,-21
+            7280: -43,-23
+            7281: -42,-23
+            7282: -41,-23
+            7283: -44,-16
+            7284: -45,-17
+            7285: -46,-18
+            7286: -46,-20
+            7287: -47,-22
+            7288: -47,-22
+            7289: -44,-21
+            7290: -42,-18
+            7291: -45,-17
+            7292: -46,-17
+            7293: -45,-17
+            7294: -46,-18
+            7295: -45,-21
+            7296: -42,-22
+            7297: -41,-23
+            7334: -49,-21
+            7335: -49,-22
+            7336: -49,-23
+            7337: -48,-24
+            7338: -47,-23
+            7339: -47,-21
+            7340: -47,-18
+            7341: -48,-19
+            7342: -48,-18
+            7343: -48,-16
+            7344: -48,-16
+            7345: -49,-16
+            7346: -43,-16
+            7347: -41,-17
+            7348: -43,-18
+            7349: -44,-18
+            7350: -42,-20
+            7351: -40,-21
+            7352: -42,-19
+            7353: -43,-18
+            7354: -41,-21
+            7355: -41,-24
+            7356: -45,-24
+            7357: -45,-23
+            7358: -41,-20
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtHeavy
           decals:
-            7290: 43.129646,-38.225346
-            7291: 43,-38
+            7265: 43.129646,-38.225346
+            7266: 43,-38
         - node:
             color: '#FFFFFFFF'
             id: DirtHeavyMonotile
           decals:
-            1366: -39,-33
-            1367: -39,-33
-            1368: -39,-33
-            1369: -39,-33
-            1370: -39,-33
+            1341: -39,-33
+            1342: -39,-33
+            1343: -39,-33
+            1344: -39,-33
+            1345: -39,-33
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtHeavyMonotile
           decals:
-            7295: 47,-37
-            7296: 47,-37
+            7270: 47,-37
+            7271: 47,-37
         - node:
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            1803: -19,-34
-            1804: -19,-34
-            1805: -19,-34
-            1806: -18,-33
-            1807: -18,-32
-            1808: -18,-31
-            1809: -19,-31
-            1810: -17,-34
-            1811: -17,-33
-            1812: -17,-32
-            1813: -17,-31
-            1877: -17,-50
-            1878: -18,-50
-            1879: -18,-48
-            1880: -17,-48
-            1881: -17,-49
-            1882: -17,-46
-            1883: -18,-46
-            1884: -17,-45
-            1885: -16,-47
-            1886: -17,-46
-            1887: -17,-44
-            1888: -18,-43
-            1889: -17,-43
-            1890: -16,-43
-            1891: -16,-42
-            1892: -17,-40
-            1893: -18,-39
-            1894: -16,-40
-            1895: -16,-41
-            1896: -18,-37
-            1897: -17,-36
-            1898: -17,-37
-            1899: -17,-38
-            1900: -17,-36
-            1901: -17,-38
-            1902: -13,-33
-            1903: -13,-32
-            1904: -12,-32
-            1905: -12,-33
-            1906: -11,-31
-            1907: -13,-33
-            1908: -8,-40
-            1909: -9,-41
-            1910: -8,-43
-            1911: -8,-44
-            1912: -8,-45
-            1913: -9,-46
-            1914: -9,-44
-            1915: -8,-43
-            1916: -7,-41
-            1917: -7,-40
-            1918: -8,-42
-            1919: -9,-46
-            1920: -8,-45
-            1921: -8,-42
-            1922: -8,-43
-            1923: -8,-44
-            1924: -8,-42
-            1925: -7,-41
-            1926: -7,-44
-            1927: -7,-44
-            1928: -8,-44
-            1929: -7,-43
-            1930: -9,-43
-            1931: -7,-44
-            2297: -44,-48
-            2298: -44,-47
-            2299: -43,-46
-            2300: -43,-47
-            2301: -42,-48
-            2302: -42,-46
-            2303: -43,-47
-            2304: -43,-48
-            2305: -42,-46
-            2306: -40,-46
-            2307: -40,-47
-            2308: -44,-53
-            2309: -44,-53
-            2310: -44,-53
-            2311: -42,-53
+            1778: -19,-34
+            1779: -19,-34
+            1780: -19,-34
+            1781: -18,-33
+            1782: -18,-32
+            1783: -18,-31
+            1784: -19,-31
+            1785: -17,-34
+            1786: -17,-33
+            1787: -17,-32
+            1788: -17,-31
+            1852: -17,-50
+            1853: -18,-50
+            1854: -18,-48
+            1855: -17,-48
+            1856: -17,-49
+            1857: -17,-46
+            1858: -18,-46
+            1859: -17,-45
+            1860: -16,-47
+            1861: -17,-46
+            1862: -17,-44
+            1863: -18,-43
+            1864: -17,-43
+            1865: -16,-43
+            1866: -16,-42
+            1867: -17,-40
+            1868: -18,-39
+            1869: -16,-40
+            1870: -16,-41
+            1871: -18,-37
+            1872: -17,-36
+            1873: -17,-37
+            1874: -17,-38
+            1875: -17,-36
+            1876: -17,-38
+            1877: -13,-33
+            1878: -13,-32
+            1879: -12,-32
+            1880: -12,-33
+            1881: -11,-31
+            1882: -13,-33
+            1883: -8,-40
+            1884: -9,-41
+            1885: -8,-43
+            1886: -8,-44
+            1887: -8,-45
+            1888: -9,-46
+            1889: -9,-44
+            1890: -8,-43
+            1891: -7,-41
+            1892: -7,-40
+            1893: -8,-42
+            1894: -9,-46
+            1895: -8,-45
+            1896: -8,-42
+            1897: -8,-43
+            1898: -8,-44
+            1899: -8,-42
+            1900: -7,-41
+            1901: -7,-44
+            1902: -7,-44
+            1903: -8,-44
+            1904: -7,-43
+            1905: -9,-43
+            1906: -7,-44
+            2272: -44,-48
+            2273: -44,-47
+            2274: -43,-46
+            2275: -43,-47
+            2276: -42,-48
+            2277: -42,-46
+            2278: -43,-47
+            2279: -43,-48
+            2280: -42,-46
+            2281: -40,-46
+            2282: -40,-47
+            2283: -44,-53
+            2284: -44,-53
+            2285: -44,-53
+            2286: -42,-53
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
-            7292: 44,-37
-            7293: 40,-37
+            7267: 44,-37
+            7268: 40,-37
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtMedium
           decals:
-            7294: 41,-37
+            7269: 41,-37
         - node:
             color: '#FFFFFFFF'
             id: Flowersbr2
           decals:
-            6004: 14,-26
+            5979: 14,-26
         - node:
             color: '#FFFFFFFF'
             id: Flowersbr3
           decals:
-            6005: 14,-27
+            5980: 14,-27
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv1
           decals:
-            6013: 3,47
+            5988: 3,47
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv2
           decals:
-            6012: 3,48
+            5987: 3,48
         - node:
             color: '#FFFFFFFF'
             id: Flowerspv3
           decals:
-            6011: 3,49
+            5986: 3,49
         - node:
             color: '#FFFFFFFF'
             id: Flowersy1
@@ -3643,9 +3647,9 @@ entities:
             363: 5,-4
             403: 3,6
             404: -8,3
-            3664: 40,-9
-            3665: 34,-8
-            3673: 32,-3
+            3639: 40,-9
+            3640: 34,-8
+            3648: 32,-3
         - node:
             color: '#FFFFFFFF'
             id: Flowersy2
@@ -3798,113 +3802,113 @@ entities:
             259: -3,-4
             260: -4,-3
             454: -8,6
-            3713: 36,-3
-            3714: 36,-4
-            3715: 33,-3
-            3716: 33,-4
-            3717: 41,-4
-            3718: 42,-4
-            3719: 43,-4
-            3720: 44,-4
-            3721: 44,-5
-            3722: 44,-6
-            3723: 44,-7
-            3724: 44,-8
-            3725: 44,-9
-            3726: 44,-10
-            3727: 44,-11
-            3728: 44,-12
-            3729: 44,-13
-            3730: 43,-13
-            3731: 42,-13
-            3732: 41,-13
-            3733: 40,-13
-            3734: 39,-13
-            3735: 35,-13
-            3736: 34,-13
-            3737: 33,-13
-            3738: 32,-13
-            3741: 45,-13
-            3742: 45,-7
-            3743: 45,-5
-            4797: 0,49
-            4798: 1,49
-            4799: 0,50
-            4800: 1,50
-            4801: 1,51
-            4802: 0,51
-            4803: 0,52
-            4804: 1,52
-            4805: 1,53
-            4806: 0,53
-            4807: 2,53
-            4808: 2,52
-            4809: 2,51
-            4810: -1,53
-            4811: -1,52
-            4812: -1,51
-            4817: 2,54
-            4818: 2,55
-            4819: 1,55
-            4820: 0,55
-            4821: -1,55
-            4822: -1,54
-            4823: -1,57
-            4824: -1,56
-            4825: 0,56
-            4826: 1,56
-            4827: 2,56
-            4828: 2,57
-            4833: -1,58
-            4834: -1,59
-            4835: -1,60
-            4836: -1,61
-            4837: -1,62
-            4838: 0,62
-            4839: 1,62
-            4840: 2,62
-            4841: 2,61
-            4842: 2,60
-            4843: 2,59
-            4844: 2,58
-            4845: 1,58
-            4846: 0,58
-            4847: 0,59
-            4848: 0,60
-            4849: 0,61
-            4850: 1,61
-            4851: 1,60
-            4852: 1,59
-            4853: -2,60
-            4854: -2,59
-            4855: -2,61
-            4856: -2,62
-            4857: 3,62
-            4858: 3,61
-            4859: 3,60
-            4860: 3,59
-            4861: 4,60
-            4862: 4,61
-            4863: -3,61
-            4864: -3,60
-            4865: -4,61
-            4866: 5,61
-            4867: 6,61
-            4868: 6,60
-            4869: 6,59
-            4870: 6,58
-            4871: -5,61
-            4872: -5,60
-            4873: -6,60
-            4874: -6,59
-            4875: -6,58
-            4876: -5,58
-            4877: -5,59
-            4878: -5,62
-            4879: 6,62
-            4947: 7,58
-            4948: 7,59
-            4949: 7,60
+            3688: 36,-3
+            3689: 36,-4
+            3690: 33,-3
+            3691: 33,-4
+            3692: 41,-4
+            3693: 42,-4
+            3694: 43,-4
+            3695: 44,-4
+            3696: 44,-5
+            3697: 44,-6
+            3698: 44,-7
+            3699: 44,-8
+            3700: 44,-9
+            3701: 44,-10
+            3702: 44,-11
+            3703: 44,-12
+            3704: 44,-13
+            3705: 43,-13
+            3706: 42,-13
+            3707: 41,-13
+            3708: 40,-13
+            3709: 39,-13
+            3710: 35,-13
+            3711: 34,-13
+            3712: 33,-13
+            3713: 32,-13
+            3716: 45,-13
+            3717: 45,-7
+            3718: 45,-5
+            4772: 0,49
+            4773: 1,49
+            4774: 0,50
+            4775: 1,50
+            4776: 1,51
+            4777: 0,51
+            4778: 0,52
+            4779: 1,52
+            4780: 1,53
+            4781: 0,53
+            4782: 2,53
+            4783: 2,52
+            4784: 2,51
+            4785: -1,53
+            4786: -1,52
+            4787: -1,51
+            4792: 2,54
+            4793: 2,55
+            4794: 1,55
+            4795: 0,55
+            4796: -1,55
+            4797: -1,54
+            4798: -1,57
+            4799: -1,56
+            4800: 0,56
+            4801: 1,56
+            4802: 2,56
+            4803: 2,57
+            4808: -1,58
+            4809: -1,59
+            4810: -1,60
+            4811: -1,61
+            4812: -1,62
+            4813: 0,62
+            4814: 1,62
+            4815: 2,62
+            4816: 2,61
+            4817: 2,60
+            4818: 2,59
+            4819: 2,58
+            4820: 1,58
+            4821: 0,58
+            4822: 0,59
+            4823: 0,60
+            4824: 0,61
+            4825: 1,61
+            4826: 1,60
+            4827: 1,59
+            4828: -2,60
+            4829: -2,59
+            4830: -2,61
+            4831: -2,62
+            4832: 3,62
+            4833: 3,61
+            4834: 3,60
+            4835: 3,59
+            4836: 4,60
+            4837: 4,61
+            4838: -3,61
+            4839: -3,60
+            4840: -4,61
+            4841: 5,61
+            4842: 6,61
+            4843: 6,60
+            4844: 6,59
+            4845: 6,58
+            4846: -5,61
+            4847: -5,60
+            4848: -6,60
+            4849: -6,59
+            4850: -6,58
+            4851: -5,58
+            4852: -5,59
+            4853: -5,62
+            4854: 6,62
+            4922: 7,58
+            4923: 7,59
+            4924: 7,60
         - node:
             color: '#222222E6'
             id: FullTileOverlayGreyscale
@@ -3928,159 +3932,159 @@ entities:
             488: -9,14
             489: -9,15
             490: -9,16
-            4584: 1,26
-            4759: 1,46
-            4760: 2,46
-            4761: 3,46
-            4762: 4,46
-            4763: 4,47
-            4764: 4,48
-            4765: 4,49
-            4766: 4,50
-            4767: 3,50
-            4768: 5,47
-            4888: 0,59
-            4889: 1,59
-            4890: -1,53
-            4891: -1,52
-            4892: 0,52
-            4893: 1,52
-            4894: 2,52
-            4895: 2,53
-            4905: 2,50
-            4906: 2,54
-            4907: -1,54
-            4908: -1,55
-            4909: -1,56
-            4910: -1,57
-            4911: 2,57
-            4912: 2,56
-            4913: 2,55
-            4914: -1,58
-            4915: -1,59
-            4916: 2,58
-            4917: 2,59
-            4918: -2,59
-            4919: 3,59
-            4920: -2,60
-            4921: -3,60
-            4922: 3,60
-            4923: 4,60
-            4924: -3,61
-            4925: -4,61
-            4926: 4,61
-            4927: 5,61
-            5004: 3,70
-            5005: 2,70
-            5006: 0,70
-            5007: -1,70
-            5008: -2,70
-            5009: 4,70
-            5010: -3,70
-            5011: -4,70
-            5012: -5,70
-            5013: -6,70
-            5014: -3,69
-            5015: -4,69
-            5016: -5,69
-            5017: 5,70
-            5018: 5,69
-            5019: 6,69
-            5020: 6,70
-            5021: 7,69
-            5022: 7,70
-            5023: 8,70
-            5030: -5,71
-            5031: 7,71
-            5032: 7,72
-            5033: -5,72
-            5053: 3,85
-            5054: 2,85
-            5055: 1,85
-            5056: 0,85
-            5057: -1,85
-            5060: -2,84
-            5061: -3,84
-            5062: -4,84
-            5063: -5,84
-            5064: -5,83
-            5065: -5,82
-            5066: -5,81
-            5067: -5,80
-            5068: -5,79
-            5069: -5,78
-            5070: -5,75
-            5071: -5,74
-            5072: -5,73
-            6456: 3,26
-            6462: 4,26
-            6464: 4,27
-            6465: 4,25
-            6467: 4,24
+            4559: 1,26
+            4734: 1,46
+            4735: 2,46
+            4736: 3,46
+            4737: 4,46
+            4738: 4,47
+            4739: 4,48
+            4740: 4,49
+            4741: 4,50
+            4742: 3,50
+            4743: 5,47
+            4863: 0,59
+            4864: 1,59
+            4865: -1,53
+            4866: -1,52
+            4867: 0,52
+            4868: 1,52
+            4869: 2,52
+            4870: 2,53
+            4880: 2,50
+            4881: 2,54
+            4882: -1,54
+            4883: -1,55
+            4884: -1,56
+            4885: -1,57
+            4886: 2,57
+            4887: 2,56
+            4888: 2,55
+            4889: -1,58
+            4890: -1,59
+            4891: 2,58
+            4892: 2,59
+            4893: -2,59
+            4894: 3,59
+            4895: -2,60
+            4896: -3,60
+            4897: 3,60
+            4898: 4,60
+            4899: -3,61
+            4900: -4,61
+            4901: 4,61
+            4902: 5,61
+            4979: 3,70
+            4980: 2,70
+            4981: 0,70
+            4982: -1,70
+            4983: -2,70
+            4984: 4,70
+            4985: -3,70
+            4986: -4,70
+            4987: -5,70
+            4988: -6,70
+            4989: -3,69
+            4990: -4,69
+            4991: -5,69
+            4992: 5,70
+            4993: 5,69
+            4994: 6,69
+            4995: 6,70
+            4996: 7,69
+            4997: 7,70
+            4998: 8,70
+            5005: -5,71
+            5006: 7,71
+            5007: 7,72
+            5008: -5,72
+            5028: 3,85
+            5029: 2,85
+            5030: 1,85
+            5031: 0,85
+            5032: -1,85
+            5035: -2,84
+            5036: -3,84
+            5037: -4,84
+            5038: -5,84
+            5039: -5,83
+            5040: -5,82
+            5041: -5,81
+            5042: -5,80
+            5043: -5,79
+            5044: -5,78
+            5045: -5,75
+            5046: -5,74
+            5047: -5,73
+            6431: 3,26
+            6437: 4,26
+            6439: 4,27
+            6440: 4,25
+            6442: 4,24
         - node:
             color: '#50BCB193'
             id: FullTileOverlayGreyscale
           decals:
-            3330: 29,17
-            3331: 29,18
-            3332: 29,19
-            3333: 29,20
-            3334: 29,21
-            3335: 29,22
-            3336: 29,23
-            3337: 30,23
-            3338: 32,23
-            3339: 32,23
-            3340: 33,23
-            3341: 34,23
-            3342: 29,24
-            3343: 29,25
-            3344: 29,26
-            3345: 29,27
-            3346: 29,28
-            3347: 30,28
-            3348: 31,28
-            3368: 40,28
-            3369: 38,27
-            3370: 38,26
-            3371: 38,25
-            3372: 41,28
-            3373: 42,28
-            3374: 43,28
-            3375: 43,27
-            3376: 43,29
-            3377: 43,30
-            3422: 43,31
-            3423: 43,32
-            3424: 44,32
-            3425: 45,32
-            3426: 43,33
-            3427: 43,34
-            3428: 43,35
-            3429: 42,35
-            3430: 43,36
-            3431: 43,37
-            3432: 43,38
-            3433: 42,38
-            3434: 43,39
-            3435: 44,39
-            3436: 45,39
-            3437: 29,29
-            3438: 29,30
-            3439: 29,31
-            3440: 28,31
-            3441: 27,31
-            3442: 26,31
-            3443: 29,32
-            3444: 29,33
-            3445: 29,34
-            3446: 29,35
-            3447: 30,35
-            3448: 29,36
-            3449: 29,37
-            3450: 29,38
-            3451: 30,38
-            3452: 29,39
+            3305: 29,17
+            3306: 29,18
+            3307: 29,19
+            3308: 29,20
+            3309: 29,21
+            3310: 29,22
+            3311: 29,23
+            3312: 30,23
+            3313: 32,23
+            3314: 32,23
+            3315: 33,23
+            3316: 34,23
+            3317: 29,24
+            3318: 29,25
+            3319: 29,26
+            3320: 29,27
+            3321: 29,28
+            3322: 30,28
+            3323: 31,28
+            3343: 40,28
+            3344: 38,27
+            3345: 38,26
+            3346: 38,25
+            3347: 41,28
+            3348: 42,28
+            3349: 43,28
+            3350: 43,27
+            3351: 43,29
+            3352: 43,30
+            3397: 43,31
+            3398: 43,32
+            3399: 44,32
+            3400: 45,32
+            3401: 43,33
+            3402: 43,34
+            3403: 43,35
+            3404: 42,35
+            3405: 43,36
+            3406: 43,37
+            3407: 43,38
+            3408: 42,38
+            3409: 43,39
+            3410: 44,39
+            3411: 45,39
+            3412: 29,29
+            3413: 29,30
+            3414: 29,31
+            3415: 28,31
+            3416: 27,31
+            3417: 26,31
+            3418: 29,32
+            3419: 29,33
+            3420: 29,34
+            3421: 29,35
+            3422: 30,35
+            3423: 29,36
+            3424: 29,37
+            3425: 29,38
+            3426: 30,38
+            3427: 29,39
         - node:
             color: '#52B4E996'
             id: FullTileOverlayGreyscale
@@ -4088,179 +4092,179 @@ entities:
             537: 9,-11
             568: 5,-16
             569: 9,-13
-            2754: 24,-11
-            5159: 18,-22
-            5422: 31,-30
-            5520: 3,-25
-            5521: 4,-25
-            5522: 5,-25
-            5523: 6,-25
-            5524: 7,-25
-            5525: 8,-25
-            5526: 9,-25
-            5527: 10,-25
-            5528: 11,-25
-            5529: 10,-28
-            5530: 4,-28
-            5531: 4,-22
-            5532: 10,-22
-            5732: 12,-25
-            5733: 13,-25
-            5734: 13,-24
-            5735: 13,-23
-            5736: 13,-22
-            5737: 13,-21
-            5738: 13,-20
-            5739: 13,-19
-            5740: 13,-18
-            5741: 13,-17
-            5742: 13,-16
-            5743: 13,-15
-            5744: 13,-14
-            5745: 13,-13
-            5746: 14,-25
-            5747: 15,-25
-            5748: 16,-25
-            5749: 17,-25
-            5750: 18,-25
-            5751: 19,-25
-            5752: 20,-25
-            5753: 21,-25
-            5754: 21,-26
-            5755: 21,-27
-            5756: 21,-28
-            5757: 20,-28
-            5758: 19,-28
-            5759: 18,-28
-            5760: 17,-28
-            5761: 16,-28
-            5762: 15,-28
-            5763: 14,-28
-            5764: 13,-28
-            5765: 13,-27
-            5766: 13,-26
-            5767: 18,-24
-            5768: 18,-23
-            5769: 13,-29
-            5770: 13,-30
-            5771: 13,-31
-            5776: 25,-24
-            5777: 31,-24
-            5807: 37,-24
-            5808: 37,-23
-            5809: 37,-22
-            5810: 37,-21
-            5811: 37,-20
-            5812: 37,-19
-            5813: 37,-18
-            5814: 37,-17
-            5815: 37,-16
-            5816: 37,-15
-            5817: 37,-14
-            5818: 38,-17
-            5819: 39,-17
-            5856: 31,-23
-            5893: 25,-23
-            5929: 25,-35
-            6029: 1,-25
-            6030: 2,-25
-            7165: 4,-38
-            7166: 7,-35
-            7183: 38,-37
-            7184: 45,-40
-            7185: 42,-39
-            7246: 4,-14
+            2729: 24,-11
+            5134: 18,-22
+            5397: 31,-30
+            5495: 3,-25
+            5496: 4,-25
+            5497: 5,-25
+            5498: 6,-25
+            5499: 7,-25
+            5500: 8,-25
+            5501: 9,-25
+            5502: 10,-25
+            5503: 11,-25
+            5504: 10,-28
+            5505: 4,-28
+            5506: 4,-22
+            5507: 10,-22
+            5707: 12,-25
+            5708: 13,-25
+            5709: 13,-24
+            5710: 13,-23
+            5711: 13,-22
+            5712: 13,-21
+            5713: 13,-20
+            5714: 13,-19
+            5715: 13,-18
+            5716: 13,-17
+            5717: 13,-16
+            5718: 13,-15
+            5719: 13,-14
+            5720: 13,-13
+            5721: 14,-25
+            5722: 15,-25
+            5723: 16,-25
+            5724: 17,-25
+            5725: 18,-25
+            5726: 19,-25
+            5727: 20,-25
+            5728: 21,-25
+            5729: 21,-26
+            5730: 21,-27
+            5731: 21,-28
+            5732: 20,-28
+            5733: 19,-28
+            5734: 18,-28
+            5735: 17,-28
+            5736: 16,-28
+            5737: 15,-28
+            5738: 14,-28
+            5739: 13,-28
+            5740: 13,-27
+            5741: 13,-26
+            5742: 18,-24
+            5743: 18,-23
+            5744: 13,-29
+            5745: 13,-30
+            5746: 13,-31
+            5751: 25,-24
+            5752: 31,-24
+            5782: 37,-24
+            5783: 37,-23
+            5784: 37,-22
+            5785: 37,-21
+            5786: 37,-20
+            5787: 37,-19
+            5788: 37,-18
+            5789: 37,-17
+            5790: 37,-16
+            5791: 37,-15
+            5792: 37,-14
+            5793: 38,-17
+            5794: 39,-17
+            5831: 31,-23
+            5868: 25,-23
+            5904: 25,-35
+            6004: 1,-25
+            6005: 2,-25
+            7140: 4,-38
+            7141: 7,-35
+            7158: 38,-37
+            7159: 45,-40
+            7160: 42,-39
+            7221: 4,-14
         - node:
             color: '#8C347F96'
             id: FullTileOverlayGreyscale
           decals:
-            7498: 9,15
-            7499: 10,15
-            7500: 11,15
-            7501: 11,14
-            7502: 11,13
-            7503: 11,12
-            7504: 11,11
-            7505: 10,11
-            7506: 9,11
-            7507: 8,11
-            7508: 7,12
-            7509: 7,13
-            7510: 8,13
-            7511: 9,13
-            7512: 9,14
+            7473: 9,15
+            7474: 10,15
+            7475: 11,15
+            7476: 11,14
+            7477: 11,13
+            7478: 11,12
+            7479: 11,11
+            7480: 10,11
+            7481: 9,11
+            7482: 8,11
+            7483: 7,12
+            7484: 7,13
+            7485: 8,13
+            7486: 9,13
+            7487: 9,14
         - node:
             color: '#9FED5815'
             id: FullTileOverlayGreyscale
           decals:
-            3161: 40,19
-            3162: 41,19
-            3163: 42,19
-            3164: 43,19
+            3136: 40,19
+            3137: 41,19
+            3138: 42,19
+            3139: 43,19
         - node:
             color: '#9FED5896'
             id: FullTileOverlayGreyscale
           decals:
-            2856: 29,1
-            2857: 29,2
-            2858: 29,3
-            2960: 29,4
-            2961: 29,5
-            2962: 29,6
-            2963: 29,7
-            2964: 29,8
-            2988: 28,7
-            2990: 36,7
-            2991: 34,7
-            2992: 33,7
-            2993: 32,7
-            2994: 31,7
-            2995: 30,7
-            3084: 28,14
-            3085: 29,14
-            3089: 30,16
-            3090: 31,16
-            3095: 33,14
-            3096: 33,15
-            3097: 33,16
-            3098: 33,17
-            3099: 33,18
-            3100: 33,19
-            3101: 33,20
-            3102: 36,18
-            3103: 36,17
-            3104: 36,16
-            3105: 36,15
-            3106: 36,14
-            3116: 37,13
-            3117: 38,13
-            3118: 38,12
-            3119: 37,12
-            3120: 37,19
-            3121: 38,18
-            3122: 39,18
-            3159: 31,14
-            3160: 31,15
-            3287: 19,27
-            4950: 7,58
-            4951: 7,59
-            4952: 7,60
-            5316: 40,-27
-            5317: 40,-28
-            5318: 40,-29
-            5319: 40,-30
-            5320: 40,-31
-            5321: 40,-32
-            5322: 39,-32
-            5323: 38,-32
-            5324: 41,-32
-            5325: 42,-32
-            5326: 43,-32
-            5327: 44,-32
-            5328: 45,-32
-            5329: 45,-31
-            5330: 45,-30
-            5847: 40,-26
+            2831: 29,1
+            2832: 29,2
+            2833: 29,3
+            2935: 29,4
+            2936: 29,5
+            2937: 29,6
+            2938: 29,7
+            2939: 29,8
+            2963: 28,7
+            2965: 36,7
+            2966: 34,7
+            2967: 33,7
+            2968: 32,7
+            2969: 31,7
+            2970: 30,7
+            3059: 28,14
+            3060: 29,14
+            3064: 30,16
+            3065: 31,16
+            3070: 33,14
+            3071: 33,15
+            3072: 33,16
+            3073: 33,17
+            3074: 33,18
+            3075: 33,19
+            3076: 33,20
+            3077: 36,18
+            3078: 36,17
+            3079: 36,16
+            3080: 36,15
+            3081: 36,14
+            3091: 37,13
+            3092: 38,13
+            3093: 38,12
+            3094: 37,12
+            3095: 37,19
+            3096: 38,18
+            3097: 39,18
+            3134: 31,14
+            3135: 31,15
+            3262: 19,27
+            4925: 7,58
+            4926: 7,59
+            4927: 7,60
+            5291: 40,-27
+            5292: 40,-28
+            5293: 40,-29
+            5294: 40,-30
+            5295: 40,-31
+            5296: 40,-32
+            5297: 39,-32
+            5298: 38,-32
+            5299: 41,-32
+            5300: 42,-32
+            5301: 43,-32
+            5302: 44,-32
+            5303: 45,-32
+            5304: 45,-31
+            5305: 45,-30
+            5822: 40,-26
         - node:
             color: '#A4610696'
             id: FullTileOverlayGreyscale
@@ -4346,270 +4350,269 @@ entities:
             987: -34,10
             988: -34,11
             989: -34,12
-            990: -34,13
-            991: -33,6
-            992: -32,6
-            993: -35,7
-            994: -33,10
-            1001: -36,7
-            1002: -37,6
-            1003: -37,7
-            1004: -37,8
-            1005: -37,9
-            1006: -37,10
-            1007: -38,11
-            1008: -38,10
-            1009: -38,9
-            1010: -38,8
-            1011: -38,7
-            1012: -38,6
-            1013: -39,5
-            1014: -39,6
-            1015: -40,6
-            1016: -41,6
-            1017: -42,6
-            1018: -43,6
-            1019: -44,6
-            1020: -44,7
-            1021: -43,7
-            1022: -43,8
-            1023: -43,9
-            1024: -43,10
-            1025: -43,11
-            1026: -42,11
-            1027: -42,10
-            1028: -41,10
-            1029: -41,11
-            1030: -40,11
-            1031: -40,10
-            1032: -39,10
-            1033: -39,11
-            1038: -39,7
-            1039: -40,7
-            1040: -41,7
-            1041: -42,7
-            1042: -42,8
-            1043: -42,9
-            1044: -41,9
-            1045: -40,9
-            1046: -39,9
-            1047: -39,8
-            1048: -40,8
-            1049: -41,8
-            1072: -38,-6
-            1073: -39,-6
-            1074: -40,-6
-            1075: -38,-5
-            1076: -39,-5
-            1077: -40,-5
-            1078: -41,-5
-            1079: -42,-5
-            1080: -43,-5
-            1081: -43,-4
-            1082: -43,-3
-            1083: -43,-2
-            1084: -42,-2
-            1085: -41,-2
-            1086: -40,-2
-            1087: -39,-2
-            1088: -38,-2
-            1089: -38,-3
-            1090: -38,-4
-            1091: -38,-1
-            1092: -38,0
-            1093: -39,0
-            1094: -40,0
-            1095: -41,0
-            1096: -42,0
-            1097: -43,0
-            1098: -43,1
-            1099: -43,2
-            1100: -43,3
-            1101: -42,3
-            1102: -41,3
-            1103: -40,3
-            1104: -39,3
-            1105: -38,3
-            1106: -38,2
-            1107: -38,1
-            1108: -40,4
-            1109: -39,4
-            1110: -38,4
-            1111: -37,4
-            2656: -34,8
-            2657: -34,6
-            7344: -42,-21
-            7345: -41,-20
-            7349: -47,-17
-            7358: -47,-21
+            990: -33,6
+            991: -32,6
+            992: -35,7
+            993: -33,10
+            1000: -36,7
+            1001: -37,6
+            1002: -37,7
+            1003: -37,8
+            1004: -37,9
+            1005: -37,10
+            1006: -38,11
+            1007: -38,10
+            1008: -38,9
+            1009: -38,8
+            1010: -38,7
+            1011: -38,6
+            1012: -39,5
+            1013: -39,6
+            1014: -40,6
+            1015: -41,6
+            1016: -42,6
+            1017: -43,6
+            1018: -44,6
+            1019: -44,7
+            1020: -43,7
+            1021: -43,8
+            1022: -43,9
+            1023: -43,10
+            1024: -43,11
+            1025: -42,11
+            1026: -42,10
+            1027: -41,10
+            1028: -41,11
+            1029: -40,11
+            1030: -40,10
+            1031: -39,10
+            1032: -39,11
+            1037: -39,7
+            1038: -40,7
+            1039: -41,7
+            1040: -42,7
+            1041: -42,8
+            1042: -42,9
+            1043: -41,9
+            1044: -40,9
+            1045: -39,9
+            1046: -39,8
+            1047: -40,8
+            1048: -41,8
+            1071: -38,-6
+            1072: -39,-6
+            1073: -40,-6
+            1074: -38,-5
+            1075: -39,-5
+            1076: -40,-5
+            1077: -41,-5
+            1078: -42,-5
+            1079: -43,-5
+            1080: -43,-4
+            1081: -43,-3
+            1082: -43,-2
+            1083: -42,-2
+            1084: -41,-2
+            1085: -40,-2
+            1086: -39,-2
+            1087: -38,-2
+            1088: -38,-3
+            1089: -38,-4
+            1090: -38,-1
+            1091: -38,0
+            1092: -39,0
+            1093: -40,0
+            1094: -41,0
+            1095: -42,0
+            1096: -43,0
+            1097: -43,1
+            1098: -43,2
+            1099: -43,3
+            1100: -42,3
+            1101: -41,3
+            1102: -40,3
+            1103: -39,3
+            1104: -38,3
+            1105: -38,2
+            1106: -38,1
+            1107: -40,4
+            1108: -39,4
+            1109: -38,4
+            1110: -37,4
+            2631: -34,8
+            2632: -34,6
+            7319: -42,-21
+            7320: -41,-20
+            7324: -47,-17
+            7333: -47,-21
         - node:
             color: '#D381C996'
             id: FullTileOverlayGreyscale
           decals:
-            1198: -34,0
-            1199: -34,-1
-            1200: -34,-2
-            1201: -34,-3
-            1202: -34,-4
-            1203: -34,-5
-            1204: -34,-6
-            1205: -34,-7
-            1206: -34,-8
-            1207: -34,-9
-            1208: -34,-10
-            1209: -34,-11
-            1210: -34,-12
-            1211: -34,-13
-            1212: -34,-14
-            1213: -34,-15
-            1254: -34,-16
-            1255: -34,-17
-            1263: -34,-18
-            1274: -38,-24
-            1275: -37,-24
-            1328: -47,-26
-            1360: -40,-33
-            1361: -39,-33
-            1363: -40,-30
-            1468: -30,-26
-            1469: -30,-27
-            1470: -30,-28
-            1471: -30,-29
-            1472: -30,-30
-            1473: -30,-31
-            1474: -30,-32
-            1475: -31,-32
-            1476: -32,-32
-            1477: -33,-32
-            1478: -34,-32
-            1479: -34,-33
-            1480: -34,-34
-            1481: -34,-35
-            1482: -29,-31
-            1483: -28,-31
-            1574: -34,-36
-            1575: -34,-37
-            1576: -34,-38
-            1577: -34,-39
-            1578: -34,-40
-            1579: -34,-41
-            1580: -34,-42
-            1581: -34,-43
-            1618: -27,-31
-            1619: -26,-31
-            1620: -26,-30
-            1621: -26,-29
-            1622: -26,-28
-            1623: -25,-28
-            1629: -28,-23
-            1630: -23,-26
-            1751: -24,-28
-            1752: -23,-28
-            1753: -23,-27
-            1754: -22,-28
-            1755: -22,-29
-            1756: -21,-28
-            1757: -20,-28
-            1758: -19,-28
-            1759: -18,-28
-            1760: -17,-28
-            1761: -17,-27
-            1762: -17,-26
-            1763: -16,-28
-            1764: -15,-28
-            1765: -14,-28
-            1766: -13,-28
-            1767: -12,-28
-            1768: -11,-28
-            1769: -10,-28
-            1770: -9,-28
-            1771: -11,-27
-            1772: -11,-26
-            1773: -11,-25
-            1774: -11,-24
-            1775: -11,-23
-            2055: -8,-28
-            2056: -7,-28
-            2057: -6,-28
-            2058: -5,-28
-            2059: -4,-28
-            2060: -3,-28
-            2061: -2,-28
-            2062: -8,-29
-            2063: -8,-30
-            2083: -42,-43
-            2084: -43,-43
-            2333: -24,-45
-            2338: -21,-47
-            2344: -21,-50
-            2437: -26,-55
-            2438: -26,-56
-            2439: -23,-57
+            1197: -34,0
+            1198: -34,-1
+            1199: -34,-2
+            1200: -34,-3
+            1201: -34,-4
+            1202: -34,-5
+            1203: -34,-6
+            1204: -34,-7
+            1205: -34,-8
+            1206: -34,-9
+            1207: -34,-10
+            1208: -34,-11
+            1209: -34,-12
+            1210: -34,-13
+            1211: -34,-14
+            1212: -34,-15
+            1229: -34,-16
+            1230: -34,-17
+            1238: -34,-18
+            1249: -38,-24
+            1250: -37,-24
+            1303: -47,-26
+            1335: -40,-33
+            1336: -39,-33
+            1338: -40,-30
+            1443: -30,-26
+            1444: -30,-27
+            1445: -30,-28
+            1446: -30,-29
+            1447: -30,-30
+            1448: -30,-31
+            1449: -30,-32
+            1450: -31,-32
+            1451: -32,-32
+            1452: -33,-32
+            1453: -34,-32
+            1454: -34,-33
+            1455: -34,-34
+            1456: -34,-35
+            1457: -29,-31
+            1458: -28,-31
+            1549: -34,-36
+            1550: -34,-37
+            1551: -34,-38
+            1552: -34,-39
+            1553: -34,-40
+            1554: -34,-41
+            1555: -34,-42
+            1556: -34,-43
+            1593: -27,-31
+            1594: -26,-31
+            1595: -26,-30
+            1596: -26,-29
+            1597: -26,-28
+            1598: -25,-28
+            1604: -28,-23
+            1605: -23,-26
+            1726: -24,-28
+            1727: -23,-28
+            1728: -23,-27
+            1729: -22,-28
+            1730: -22,-29
+            1731: -21,-28
+            1732: -20,-28
+            1733: -19,-28
+            1734: -18,-28
+            1735: -17,-28
+            1736: -17,-27
+            1737: -17,-26
+            1738: -16,-28
+            1739: -15,-28
+            1740: -14,-28
+            1741: -13,-28
+            1742: -12,-28
+            1743: -11,-28
+            1744: -10,-28
+            1745: -9,-28
+            1746: -11,-27
+            1747: -11,-26
+            1748: -11,-25
+            1749: -11,-24
+            1750: -11,-23
+            2030: -8,-28
+            2031: -7,-28
+            2032: -6,-28
+            2033: -5,-28
+            2034: -4,-28
+            2035: -3,-28
+            2036: -2,-28
+            2037: -8,-29
+            2038: -8,-30
+            2058: -42,-43
+            2059: -43,-43
+            2308: -24,-45
+            2313: -21,-47
+            2319: -21,-50
+            2412: -26,-55
+            2413: -26,-56
+            2414: -23,-57
         - node:
             color: '#D4D4D428'
             id: FullTileOverlayGreyscale
           decals:
-            1195: -40,-11
-            1196: -40,-12
-            1197: -40,-10
-            2094: -43,-41
-            2095: -43,-40
-            2096: -39,-42
-            2097: -38,-42
-            2098: -38,-42
-            2100: -45,-39
-            2101: -45,-40
-            2102: -45,-41
-            2121: -43,-31
-            2122: -43,-30
-            2123: -44,-30
-            2124: -44,-31
-            2125: -45,-31
-            2126: -45,-30
-            2127: -44,-32
-            2168: -37,-48
-            2169: -37,-47
-            2184: -34,-45
-            2185: -34,-46
-            2186: -34,-47
-            2187: -34,-48
-            2188: -34,-49
-            2189: -35,-49
-            2190: -35,-48
-            2192: -33,-48
-            2193: -32,-48
-            2196: -34,-50
-            2197: -34,-51
-            2198: -35,-51
-            2199: -35,-50
-            2200: -36,-50
-            2201: -37,-50
-            2202: -38,-50
-            2203: -39,-50
-            2204: -40,-50
-            2205: -40,-51
-            2206: -40,-52
-            2207: -40,-53
-            2242: -41,-51
-            2243: -42,-51
-            2244: -43,-51
-            2245: -43,-50
-            2246: -42,-50
-            3676: 37,-14
-            3677: 37,-13
-            3678: 37,-12
-            4299: -20,30
-            7285: -45,-42
-            7286: -40,-42
-            7287: -41,-42
+            1194: -40,-11
+            1195: -40,-12
+            1196: -40,-10
+            2069: -43,-41
+            2070: -43,-40
+            2071: -39,-42
+            2072: -38,-42
+            2073: -38,-42
+            2075: -45,-39
+            2076: -45,-40
+            2077: -45,-41
+            2096: -43,-31
+            2097: -43,-30
+            2098: -44,-30
+            2099: -44,-31
+            2100: -45,-31
+            2101: -45,-30
+            2102: -44,-32
+            2143: -37,-48
+            2144: -37,-47
+            2159: -34,-45
+            2160: -34,-46
+            2161: -34,-47
+            2162: -34,-48
+            2163: -34,-49
+            2164: -35,-49
+            2165: -35,-48
+            2167: -33,-48
+            2168: -32,-48
+            2171: -34,-50
+            2172: -34,-51
+            2173: -35,-51
+            2174: -35,-50
+            2175: -36,-50
+            2176: -37,-50
+            2177: -38,-50
+            2178: -39,-50
+            2179: -40,-50
+            2180: -40,-51
+            2181: -40,-52
+            2182: -40,-53
+            2217: -41,-51
+            2218: -42,-51
+            2219: -43,-51
+            2220: -43,-50
+            2221: -42,-50
+            3651: 37,-14
+            3652: 37,-13
+            3653: 37,-12
+            4274: -20,30
+            7260: -45,-42
+            7261: -40,-42
+            7262: -41,-42
         - node:
             angle: 1.5707963267948966 rad
             color: '#D4D4D428'
             id: FullTileOverlayGreyscale
           decals:
-            2112: -45,-37
-            2113: -45,-36
-            2114: -45,-35
+            2087: -45,-37
+            2088: -45,-36
+            2089: -45,-35
         - node:
             color: '#DE3A3A96'
             id: FullTileOverlayGreyscale
@@ -4617,639 +4620,639 @@ entities:
             491: -15,14
             492: -15,15
             493: -15,16
-            3863: 44,-14
-            3864: 45,-15
-            3865: 46,-15
-            3866: 47,-15
-            3890: -18,14
-            3893: -19,16
-            3894: -22,15
-            3925: -28,22
-            3988: -1,19
-            3989: 0,19
-            3999: -2,19
-            4000: -3,19
-            4001: -4,19
-            4002: -5,19
-            4003: -6,19
-            4004: -7,19
-            4005: -8,19
-            4006: -9,19
-            4007: -10,19
-            4008: -11,19
-            4009: -12,19
-            4010: -13,19
-            4011: -14,19
-            4012: -15,19
-            4013: -16,19
-            4014: -16,20
-            4058: -22,25
-            4059: -22,24
-            4060: -21,24
-            4061: -21,25
-            4062: -20,25
-            4063: -20,24
-            4064: -19,24
-            4065: -19,25
-            4105: -15,21
-            4106: -17,21
-            4107: -17,24
-            4108: -15,24
-            4109: -16,25
-            4110: -16,26
-            4150: -16,27
-            4151: -16,28
-            4152: -17,28
-            4153: -16,29
-            4154: -15,28
-            4155: -14,28
-            4156: -13,28
-            4157: -12,28
-            4158: -11,28
-            4159: -10,28
-            4160: -9,28
-            4161: -8,28
-            4162: -7,28
-            4163: -6,28
-            4164: -5,28
-            4165: -4,28
-            4166: -4,29
-            4167: -13,29
-            4168: -7,30
-            4169: -6,30
-            4170: -4,30
-            4200: -4,31
-            4201: -13,30
-            4202: -12,36
-            4203: -12,35
-            4204: -12,34
-            4205: -11,34
-            4206: -11,35
-            4207: -10,36
-            4208: -13,36
-            4209: -13,37
-            4238: -16,30
-            4239: -16,31
-            4240: -16,32
-            4241: -17,32
-            4242: -17,33
-            4243: -16,33
-            4244: -16,34
-            4245: -17,34
-            4246: -17,35
-            4247: -16,35
-            4295: -20,35
-            4296: -20,34
-            4297: -20,33
-            4298: -20,32
-            4306: -10,37
-            4307: -10,38
-            4308: -10,39
-            4309: -10,40
-            4348: -32,26
-            4349: -31,26
-            4350: -30,26
-            4351: -30,25
-            4352: -32,25
-            4353: -31,25
-            4392: -37,20
-            4393: -37,21
-            4394: -37,22
-            4395: -37,23
-            4396: -37,24
-            4397: -37,25
-            4398: -37,26
-            4399: -37,27
-            4425: -37,28
-            4426: -37,29
-            4427: -38,29
-            4428: -39,29
-            4429: -36,29
-            4430: -35,29
-            4437: -24,37
-            4438: -24,36
-            4439: -24,35
-            4440: -24,34
-            4441: -24,33
-            4442: -24,32
-            4443: -24,31
-            4444: -24,30
-            4445: -24,29
-            4446: -25,29
-            4447: -26,29
-            4448: -27,29
-            4449: -28,29
-            4450: -29,29
-            4451: -30,29
-            4452: -31,29
-            4453: -32,29
-            4454: -33,29
-            4455: -34,29
-            4456: -25,35
-            4457: -26,35
-            4458: -24,28
-            4459: -24,27
-            4460: -24,26
-            4461: -23,28
-            4462: -22,28
-            4463: -21,28
-            4464: -20,28
-            4465: -19,28
-            4466: -18,28
-            4520: -3,35
-            4521: -5,35
-            4522: -5,32
-            4523: -3,32
-            4524: -2,37
-            4525: -2,38
-            4551: -1,37
-            4552: -1,38
-            4553: 0,38
-            4554: 0,37
-            4944: -6,58
-            4945: -6,59
-            4946: -6,60
+            3838: 44,-14
+            3839: 45,-15
+            3840: 46,-15
+            3841: 47,-15
+            3865: -18,14
+            3868: -19,16
+            3869: -22,15
+            3900: -28,22
+            3963: -1,19
+            3964: 0,19
+            3974: -2,19
+            3975: -3,19
+            3976: -4,19
+            3977: -5,19
+            3978: -6,19
+            3979: -7,19
+            3980: -8,19
+            3981: -9,19
+            3982: -10,19
+            3983: -11,19
+            3984: -12,19
+            3985: -13,19
+            3986: -14,19
+            3987: -15,19
+            3988: -16,19
+            3989: -16,20
+            4033: -22,25
+            4034: -22,24
+            4035: -21,24
+            4036: -21,25
+            4037: -20,25
+            4038: -20,24
+            4039: -19,24
+            4040: -19,25
+            4080: -15,21
+            4081: -17,21
+            4082: -17,24
+            4083: -15,24
+            4084: -16,25
+            4085: -16,26
+            4125: -16,27
+            4126: -16,28
+            4127: -17,28
+            4128: -16,29
+            4129: -15,28
+            4130: -14,28
+            4131: -13,28
+            4132: -12,28
+            4133: -11,28
+            4134: -10,28
+            4135: -9,28
+            4136: -8,28
+            4137: -7,28
+            4138: -6,28
+            4139: -5,28
+            4140: -4,28
+            4141: -4,29
+            4142: -13,29
+            4143: -7,30
+            4144: -6,30
+            4145: -4,30
+            4175: -4,31
+            4176: -13,30
+            4177: -12,36
+            4178: -12,35
+            4179: -12,34
+            4180: -11,34
+            4181: -11,35
+            4182: -10,36
+            4183: -13,36
+            4184: -13,37
+            4213: -16,30
+            4214: -16,31
+            4215: -16,32
+            4216: -17,32
+            4217: -17,33
+            4218: -16,33
+            4219: -16,34
+            4220: -17,34
+            4221: -17,35
+            4222: -16,35
+            4270: -20,35
+            4271: -20,34
+            4272: -20,33
+            4273: -20,32
+            4281: -10,37
+            4282: -10,38
+            4283: -10,39
+            4284: -10,40
+            4323: -32,26
+            4324: -31,26
+            4325: -30,26
+            4326: -30,25
+            4327: -32,25
+            4328: -31,25
+            4367: -37,20
+            4368: -37,21
+            4369: -37,22
+            4370: -37,23
+            4371: -37,24
+            4372: -37,25
+            4373: -37,26
+            4374: -37,27
+            4400: -37,28
+            4401: -37,29
+            4402: -38,29
+            4403: -39,29
+            4404: -36,29
+            4405: -35,29
+            4412: -24,37
+            4413: -24,36
+            4414: -24,35
+            4415: -24,34
+            4416: -24,33
+            4417: -24,32
+            4418: -24,31
+            4419: -24,30
+            4420: -24,29
+            4421: -25,29
+            4422: -26,29
+            4423: -27,29
+            4424: -28,29
+            4425: -29,29
+            4426: -30,29
+            4427: -31,29
+            4428: -32,29
+            4429: -33,29
+            4430: -34,29
+            4431: -25,35
+            4432: -26,35
+            4433: -24,28
+            4434: -24,27
+            4435: -24,26
+            4436: -23,28
+            4437: -22,28
+            4438: -21,28
+            4439: -20,28
+            4440: -19,28
+            4441: -18,28
+            4495: -3,35
+            4496: -5,35
+            4497: -5,32
+            4498: -3,32
+            4499: -2,37
+            4500: -2,38
+            4526: -1,37
+            4527: -1,38
+            4528: 0,38
+            4529: 0,37
+            4919: -6,58
+            4920: -6,59
+            4921: -6,60
         - node:
             color: '#EFB34195'
             id: FullTileOverlayGreyscale
           decals:
-            6251: 8,-59
-            6252: 8,-60
-            6253: 8,-61
-            6254: 6,-59
-            6255: 6,-60
-            6256: 6,-61
+            6226: 8,-59
+            6227: 8,-60
+            6228: 8,-61
+            6229: 6,-59
+            6230: 6,-60
+            6231: 6,-61
         - node:
             color: '#EFB34196'
             id: FullTileOverlayGreyscale
           decals:
-            2506: -11,-53
-            2535: -5,-49
-            4880: -2,62
-            4881: -1,62
-            4882: 0,62
-            4883: 1,62
-            4884: 2,62
-            4885: 3,62
-            6175: 6,-47
-            6192: 7,-48
-            6193: 7,-49
-            6194: 7,-50
-            6195: 7,-51
-            6196: 7,-52
-            6197: 8,-48
-            6198: 6,-51
-            6199: 5,-51
-            6200: 7,-53
-            6201: 8,-53
-            6202: 7,-54
-            6203: 7,-55
-            6204: 7,-56
-            6205: 7,-57
-            6206: 6,-56
-            6207: 9,-48
-            6208: 9,-53
-            6209: -4,-53
-            6210: -1,-52
-            6481: 14,-67
-            6482: 13,-67
-            6483: 12,-67
-            6484: 11,-67
-            6485: 10,-67
-            6505: 6,-68
-            6506: 6,-67
-            6507: 6,-66
-            6508: 6,-65
-            6509: 6,-64
-            6510: 5,-64
-            6511: 4,-64
-            6512: 3,-64
-            6513: 2,-64
-            6514: 1,-64
-            6515: 0,-64
-            6516: -1,-64
-            6517: -2,-64
-            6518: -3,-64
-            6519: -4,-64
-            6520: -5,-64
-            6521: -6,-64
-            6522: -6,-65
-            6523: -6,-66
-            6524: -6,-67
-            6525: -6,-68
-            6526: -6,-72
-            6527: -6,-73
-            6528: 6,-72
-            6529: 6,-73
-            6809: 20,-52
-            6810: 20,-51
-            6811: 21,-51
-            6812: 21,-52
-            6813: 29,-53
-            6814: 29,-52
-            6815: 30,-52
-            6816: 30,-53
-            6817: 25,-63
-            6818: 26,-63
-            6819: 27,-63
-            6820: 28,-63
-            6821: 29,-63
-            7042: 10,-48
+            2481: -11,-53
+            2510: -5,-49
+            4855: -2,62
+            4856: -1,62
+            4857: 0,62
+            4858: 1,62
+            4859: 2,62
+            4860: 3,62
+            6150: 6,-47
+            6167: 7,-48
+            6168: 7,-49
+            6169: 7,-50
+            6170: 7,-51
+            6171: 7,-52
+            6172: 8,-48
+            6173: 6,-51
+            6174: 5,-51
+            6175: 7,-53
+            6176: 8,-53
+            6177: 7,-54
+            6178: 7,-55
+            6179: 7,-56
+            6180: 7,-57
+            6181: 6,-56
+            6182: 9,-48
+            6183: 9,-53
+            6184: -4,-53
+            6185: -1,-52
+            6456: 14,-67
+            6457: 13,-67
+            6458: 12,-67
+            6459: 11,-67
+            6460: 10,-67
+            6480: 6,-68
+            6481: 6,-67
+            6482: 6,-66
+            6483: 6,-65
+            6484: 6,-64
+            6485: 5,-64
+            6486: 4,-64
+            6487: 3,-64
+            6488: 2,-64
+            6489: 1,-64
+            6490: 0,-64
+            6491: -1,-64
+            6492: -2,-64
+            6493: -3,-64
+            6494: -4,-64
+            6495: -5,-64
+            6496: -6,-64
+            6497: -6,-65
+            6498: -6,-66
+            6499: -6,-67
+            6500: -6,-68
+            6501: -6,-72
+            6502: -6,-73
+            6503: 6,-72
+            6504: 6,-73
+            6784: 20,-52
+            6785: 20,-51
+            6786: 21,-51
+            6787: 21,-52
+            6788: 29,-53
+            6789: 29,-52
+            6790: 30,-52
+            6791: 30,-53
+            6792: 25,-63
+            6793: 26,-63
+            6794: 27,-63
+            6795: 28,-63
+            6796: 29,-63
+            7017: 10,-48
         - node:
             color: '#FF924493'
             id: FullTileOverlayGreyscale
           decals:
-            5293: 30,-20
+            5268: 30,-20
         - node:
             color: '#FFFFFFFF'
             id: FullTileOverlayGreyscale
           decals:
-            1247: -34,-16
-            1248: -34,-17
-            1261: -34,-18
-            1262: -33,-18
-            1417: -30,-27
-            1418: -30,-26
-            1419: -30,-28
-            1420: -30,-29
-            1421: -30,-30
-            1422: -30,-31
-            1423: -30,-32
-            1424: -31,-32
-            1425: -32,-32
-            1426: -33,-32
-            1427: -34,-32
-            1428: -35,-32
-            1429: -36,-32
-            1430: -36,-31
-            1431: -35,-31
-            1432: -34,-31
-            1433: -33,-31
-            1434: -32,-31
-            1435: -31,-31
-            1436: -36,-30
-            1437: -36,-29
-            1438: -36,-28
-            1439: -34,-33
-            1440: -34,-34
-            1441: -34,-35
-            1442: -29,-32
-            1443: -29,-31
-            1444: -28,-31
-            1547: -34,-36
-            1548: -34,-37
-            1549: -34,-38
-            1550: -34,-39
-            1551: -34,-40
-            1552: -34,-41
-            1553: -34,-42
-            1554: -34,-43
-            1555: -35,-43
-            1556: -35,-44
-            1557: -34,-44
-            1600: -27,-31
-            1601: -26,-31
-            1602: -26,-30
-            1603: -26,-29
-            1604: -26,-28
-            1605: -25,-28
-            1627: -28,-23
-            1628: -23,-26
-            1692: -23,-28
-            1693: -23,-27
-            1694: -22,-28
-            1695: -21,-28
-            1696: -20,-28
-            1697: -19,-28
-            1698: -18,-28
-            1699: -17,-28
-            1700: -17,-27
-            1701: -17,-26
-            1702: -22,-29
-            1703: -16,-28
-            1704: -15,-28
-            1705: -14,-28
-            1706: -13,-28
-            1707: -12,-28
-            1708: -11,-28
-            1709: -11,-27
-            1710: -11,-26
-            1711: -11,-25
-            1712: -11,-24
-            1713: -11,-23
-            1714: -11,-22
-            1715: -10,-28
-            1716: -9,-28
-            1721: -24,-28
-            1776: -22,-30
-            1777: -22,-31
-            1778: -22,-32
-            1779: -22,-33
-            1780: -22,-34
-            1781: -21,-33
-            1782: -21,-34
-            1844: -8,-28
-            1845: -8,-29
-            1846: -8,-30
-            1847: -8,-31
-            1848: -8,-32
-            1849: -8,-33
-            1850: -8,-34
-            1851: -8,-35
-            1861: -8,-36
-            1862: -8,-37
-            1863: -9,-37
-            1864: -9,-36
-            1865: -10,-36
-            1866: -10,-37
-            1867: -11,-37
-            1868: -11,-36
-            1869: -12,-36
-            1870: -12,-37
-            1871: -13,-37
-            1872: -13,-36
-            1873: -13,-38
-            1874: -12,-38
-            1875: -12,-39
-            1876: -13,-39
-            1933: -13,-50
-            1934: -12,-50
-            1935: -12,-49
-            1936: -13,-49
-            1937: -13,-48
-            1938: -12,-48
-            1939: -12,-47
-            1940: -13,-47
-            1941: -13,-46
-            1942: -12,-46
-            1943: -12,-45
-            1944: -13,-45
-            1945: -13,-44
-            1946: -12,-44
-            1947: -12,-43
-            1948: -13,-43
-            1949: -13,-42
-            1950: -12,-42
-            1951: -12,-41
-            1952: -13,-41
-            1953: -13,-40
-            1954: -12,-40
-            2039: -7,-28
-            2040: -6,-28
-            2041: -5,-28
-            2042: -4,-28
-            2043: -3,-28
-            2044: -2,-28
-            5108: 13,-13
-            5109: 13,-14
-            5110: 13,-15
-            5111: 13,-16
-            5112: 13,-17
-            5113: 15,-15
-            5114: 16,-15
-            5115: 17,-15
-            5116: 17,-16
-            5117: 16,-16
-            5118: 15,-16
-            5147: 17,-20
-            5148: 18,-20
-            5149: 19,-20
-            5150: 19,-21
-            5151: 18,-21
-            5152: 17,-21
-            5160: 25,-22
-            5161: 26,-22
-            5162: 26,-21
-            5163: 25,-21
-            5164: 24,-21
-            5165: 23,-21
-            5166: 22,-21
-            5167: 22,-20
-            5168: 23,-20
-            5169: 24,-20
-            5170: 25,-20
-            5171: 26,-20
-            5172: 26,-19
-            5173: 25,-19
-            5174: 24,-19
-            5175: 23,-19
-            5176: 22,-19
-            5177: 22,-18
-            5178: 23,-18
-            5179: 24,-18
-            5180: 25,-18
-            5181: 26,-18
-            5211: 28,-16
-            5212: 28,-17
-            5213: 28,-18
-            5214: 28,-19
-            5215: 28,-20
-            5216: 28,-21
-            5217: 30,-22
-            5218: 31,-22
-            5219: 31,-22
-            5220: 32,-22
-            5221: 33,-22
-            5222: 34,-21
-            5223: 33,-21
-            5224: 32,-21
-            5225: 31,-21
-            5226: 30,-21
-            5227: 29,-21
-            5228: 29,-20
-            5229: 30,-20
-            5230: 31,-20
-            5231: 32,-20
-            5232: 33,-20
-            5233: 34,-20
-            5234: 34,-19
-            5235: 33,-19
-            5236: 32,-19
-            5237: 31,-19
-            5238: 30,-19
-            5239: 29,-19
-            5240: 29,-18
-            5241: 30,-18
-            5242: 31,-18
-            5243: 32,-18
-            5244: 33,-18
-            5245: 34,-18
-            5246: 34,-17
-            5247: 33,-17
-            5248: 32,-17
-            5249: 31,-17
-            5250: 30,-17
-            5251: 29,-17
-            5252: 29,-16
-            5253: 30,-16
-            5254: 31,-16
-            5255: 32,-16
-            5256: 33,-16
-            5257: 34,-16
-            5265: 34,-22
-            5269: 29,-22
-            5270: 28,-22
-            5386: 26,-27
-            5387: 27,-27
-            5388: 26,-28
-            5389: 27,-28
-            5390: 27,-29
-            5391: 27,-30
-            5392: 26,-30
-            5393: 26,-29
-            5394: 26,-31
-            5395: 26,-32
-            5396: 27,-32
-            5397: 27,-31
-            5398: 25,-29
-            5399: 31,-31
-            5400: 31,-30
-            5401: 31,-29
-            5402: 32,-29
-            5436: 5,-29
-            5437: 6,-29
-            5438: 6,-30
-            5439: 5,-30
-            5440: 5,-31
-            5441: 6,-31
-            5442: 6,-32
-            5443: 5,-32
-            5444: 7,-32
-            5445: 7,-31
-            5446: 8,-31
-            5447: 8,-32
-            5448: 9,-32
-            5449: 9,-31
-            5450: 10,-31
-            5451: 10,-32
-            5452: 11,-32
-            5453: 11,-31
-            5470: 8,-21
-            5471: 9,-21
-            5472: 8,-20
-            5473: 8,-19
-            5474: 9,-19
-            5475: 10,-20
-            5476: 10,-19
-            5477: 11,-19
-            5482: 9,-20
-            5485: 3,-26
-            5486: 3,-25
-            5487: 3,-24
-            5488: 4,-24
-            5489: 4,-25
-            5490: 4,-26
-            5491: 5,-25
-            5492: 6,-25
-            5493: 7,-25
-            5494: 8,-25
-            5495: 9,-25
-            5496: 10,-25
-            5497: 10,-26
-            5498: 10,-24
-            5499: 10,-23
-            5500: 9,-23
-            5501: 8,-23
-            5502: 7,-23
-            5503: 6,-23
-            5504: 5,-23
-            5505: 4,-23
-            5506: 4,-22
-            5507: 10,-22
-            5508: 10,-27
-            5509: 10,-28
-            5510: 9,-27
-            5511: 8,-27
-            5512: 7,-27
-            5513: 6,-27
-            5514: 5,-27
-            5515: 4,-27
-            5516: 4,-28
-            5517: 11,-26
-            5518: 11,-25
-            5519: 11,-24
-            5579: 13,-18
-            5580: 13,-19
-            5581: 13,-20
-            5582: 13,-21
-            5583: 13,-22
-            5584: 13,-23
-            5585: 13,-24
-            5586: 13,-25
-            5587: 13,-26
-            5588: 13,-27
-            5589: 13,-28
-            5590: 13,-29
-            5591: 13,-30
-            5592: 13,-31
-            5593: 12,-31
-            5594: 12,-25
-            5595: 14,-20
-            5596: 14,-21
-            5597: 14,-25
-            5598: 15,-25
-            5599: 16,-25
-            5600: 17,-25
-            5601: 18,-25
-            5602: 19,-25
-            5603: 20,-25
-            5604: 14,-28
-            5605: 15,-28
-            5606: 16,-28
-            5607: 18,-28
-            5608: 17,-28
-            5609: 19,-28
-            5610: 20,-28
-            5611: 18,-23
-            5612: 18,-24
-            5613: 21,-28
-            5614: 21,-27
-            5615: 21,-26
-            5616: 21,-25
-            5617: 22,-28
-            5618: 22,-27
-            5619: 22,-26
-            5620: 34,-25
-            5621: 35,-25
-            5622: 25,-24
-            5625: 31,-24
-            5626: 36,-25
-            5627: 37,-25
-            5628: 38,-25
-            5629: 39,-25
-            5630: 40,-25
-            5631: 40,-26
-            5632: 41,-25
-            5633: 42,-25
-            5634: 37,-24
-            5635: 37,-23
-            5636: 37,-22
-            5637: 37,-21
-            5638: 37,-20
-            5639: 37,-19
-            5640: 37,-18
-            5641: 37,-17
-            5642: 37,-16
-            5643: 37,-15
-            5644: 37,-14
-            5645: 38,-17
-            5646: 39,-17
-            5772: 12,-32
-            5773: 13,-32
-            5780: 22,-25
-            5781: 23,-25
-            5782: 24,-25
-            5783: 25,-25
-            5784: 26,-25
-            5785: 27,-25
-            5786: 28,-25
-            5787: 29,-25
-            5788: 30,-25
-            5789: 31,-25
-            5790: 32,-25
-            5791: 33,-25
-            5855: 31,-23
-            5892: 25,-23
+            1222: -34,-16
+            1223: -34,-17
+            1236: -34,-18
+            1237: -33,-18
+            1392: -30,-27
+            1393: -30,-26
+            1394: -30,-28
+            1395: -30,-29
+            1396: -30,-30
+            1397: -30,-31
+            1398: -30,-32
+            1399: -31,-32
+            1400: -32,-32
+            1401: -33,-32
+            1402: -34,-32
+            1403: -35,-32
+            1404: -36,-32
+            1405: -36,-31
+            1406: -35,-31
+            1407: -34,-31
+            1408: -33,-31
+            1409: -32,-31
+            1410: -31,-31
+            1411: -36,-30
+            1412: -36,-29
+            1413: -36,-28
+            1414: -34,-33
+            1415: -34,-34
+            1416: -34,-35
+            1417: -29,-32
+            1418: -29,-31
+            1419: -28,-31
+            1522: -34,-36
+            1523: -34,-37
+            1524: -34,-38
+            1525: -34,-39
+            1526: -34,-40
+            1527: -34,-41
+            1528: -34,-42
+            1529: -34,-43
+            1530: -35,-43
+            1531: -35,-44
+            1532: -34,-44
+            1575: -27,-31
+            1576: -26,-31
+            1577: -26,-30
+            1578: -26,-29
+            1579: -26,-28
+            1580: -25,-28
+            1602: -28,-23
+            1603: -23,-26
+            1667: -23,-28
+            1668: -23,-27
+            1669: -22,-28
+            1670: -21,-28
+            1671: -20,-28
+            1672: -19,-28
+            1673: -18,-28
+            1674: -17,-28
+            1675: -17,-27
+            1676: -17,-26
+            1677: -22,-29
+            1678: -16,-28
+            1679: -15,-28
+            1680: -14,-28
+            1681: -13,-28
+            1682: -12,-28
+            1683: -11,-28
+            1684: -11,-27
+            1685: -11,-26
+            1686: -11,-25
+            1687: -11,-24
+            1688: -11,-23
+            1689: -11,-22
+            1690: -10,-28
+            1691: -9,-28
+            1696: -24,-28
+            1751: -22,-30
+            1752: -22,-31
+            1753: -22,-32
+            1754: -22,-33
+            1755: -22,-34
+            1756: -21,-33
+            1757: -21,-34
+            1819: -8,-28
+            1820: -8,-29
+            1821: -8,-30
+            1822: -8,-31
+            1823: -8,-32
+            1824: -8,-33
+            1825: -8,-34
+            1826: -8,-35
+            1836: -8,-36
+            1837: -8,-37
+            1838: -9,-37
+            1839: -9,-36
+            1840: -10,-36
+            1841: -10,-37
+            1842: -11,-37
+            1843: -11,-36
+            1844: -12,-36
+            1845: -12,-37
+            1846: -13,-37
+            1847: -13,-36
+            1848: -13,-38
+            1849: -12,-38
+            1850: -12,-39
+            1851: -13,-39
+            1908: -13,-50
+            1909: -12,-50
+            1910: -12,-49
+            1911: -13,-49
+            1912: -13,-48
+            1913: -12,-48
+            1914: -12,-47
+            1915: -13,-47
+            1916: -13,-46
+            1917: -12,-46
+            1918: -12,-45
+            1919: -13,-45
+            1920: -13,-44
+            1921: -12,-44
+            1922: -12,-43
+            1923: -13,-43
+            1924: -13,-42
+            1925: -12,-42
+            1926: -12,-41
+            1927: -13,-41
+            1928: -13,-40
+            1929: -12,-40
+            2014: -7,-28
+            2015: -6,-28
+            2016: -5,-28
+            2017: -4,-28
+            2018: -3,-28
+            2019: -2,-28
+            5083: 13,-13
+            5084: 13,-14
+            5085: 13,-15
+            5086: 13,-16
+            5087: 13,-17
+            5088: 15,-15
+            5089: 16,-15
+            5090: 17,-15
+            5091: 17,-16
+            5092: 16,-16
+            5093: 15,-16
+            5122: 17,-20
+            5123: 18,-20
+            5124: 19,-20
+            5125: 19,-21
+            5126: 18,-21
+            5127: 17,-21
+            5135: 25,-22
+            5136: 26,-22
+            5137: 26,-21
+            5138: 25,-21
+            5139: 24,-21
+            5140: 23,-21
+            5141: 22,-21
+            5142: 22,-20
+            5143: 23,-20
+            5144: 24,-20
+            5145: 25,-20
+            5146: 26,-20
+            5147: 26,-19
+            5148: 25,-19
+            5149: 24,-19
+            5150: 23,-19
+            5151: 22,-19
+            5152: 22,-18
+            5153: 23,-18
+            5154: 24,-18
+            5155: 25,-18
+            5156: 26,-18
+            5186: 28,-16
+            5187: 28,-17
+            5188: 28,-18
+            5189: 28,-19
+            5190: 28,-20
+            5191: 28,-21
+            5192: 30,-22
+            5193: 31,-22
+            5194: 31,-22
+            5195: 32,-22
+            5196: 33,-22
+            5197: 34,-21
+            5198: 33,-21
+            5199: 32,-21
+            5200: 31,-21
+            5201: 30,-21
+            5202: 29,-21
+            5203: 29,-20
+            5204: 30,-20
+            5205: 31,-20
+            5206: 32,-20
+            5207: 33,-20
+            5208: 34,-20
+            5209: 34,-19
+            5210: 33,-19
+            5211: 32,-19
+            5212: 31,-19
+            5213: 30,-19
+            5214: 29,-19
+            5215: 29,-18
+            5216: 30,-18
+            5217: 31,-18
+            5218: 32,-18
+            5219: 33,-18
+            5220: 34,-18
+            5221: 34,-17
+            5222: 33,-17
+            5223: 32,-17
+            5224: 31,-17
+            5225: 30,-17
+            5226: 29,-17
+            5227: 29,-16
+            5228: 30,-16
+            5229: 31,-16
+            5230: 32,-16
+            5231: 33,-16
+            5232: 34,-16
+            5240: 34,-22
+            5244: 29,-22
+            5245: 28,-22
+            5361: 26,-27
+            5362: 27,-27
+            5363: 26,-28
+            5364: 27,-28
+            5365: 27,-29
+            5366: 27,-30
+            5367: 26,-30
+            5368: 26,-29
+            5369: 26,-31
+            5370: 26,-32
+            5371: 27,-32
+            5372: 27,-31
+            5373: 25,-29
+            5374: 31,-31
+            5375: 31,-30
+            5376: 31,-29
+            5377: 32,-29
+            5411: 5,-29
+            5412: 6,-29
+            5413: 6,-30
+            5414: 5,-30
+            5415: 5,-31
+            5416: 6,-31
+            5417: 6,-32
+            5418: 5,-32
+            5419: 7,-32
+            5420: 7,-31
+            5421: 8,-31
+            5422: 8,-32
+            5423: 9,-32
+            5424: 9,-31
+            5425: 10,-31
+            5426: 10,-32
+            5427: 11,-32
+            5428: 11,-31
+            5445: 8,-21
+            5446: 9,-21
+            5447: 8,-20
+            5448: 8,-19
+            5449: 9,-19
+            5450: 10,-20
+            5451: 10,-19
+            5452: 11,-19
+            5457: 9,-20
+            5460: 3,-26
+            5461: 3,-25
+            5462: 3,-24
+            5463: 4,-24
+            5464: 4,-25
+            5465: 4,-26
+            5466: 5,-25
+            5467: 6,-25
+            5468: 7,-25
+            5469: 8,-25
+            5470: 9,-25
+            5471: 10,-25
+            5472: 10,-26
+            5473: 10,-24
+            5474: 10,-23
+            5475: 9,-23
+            5476: 8,-23
+            5477: 7,-23
+            5478: 6,-23
+            5479: 5,-23
+            5480: 4,-23
+            5481: 4,-22
+            5482: 10,-22
+            5483: 10,-27
+            5484: 10,-28
+            5485: 9,-27
+            5486: 8,-27
+            5487: 7,-27
+            5488: 6,-27
+            5489: 5,-27
+            5490: 4,-27
+            5491: 4,-28
+            5492: 11,-26
+            5493: 11,-25
+            5494: 11,-24
+            5554: 13,-18
+            5555: 13,-19
+            5556: 13,-20
+            5557: 13,-21
+            5558: 13,-22
+            5559: 13,-23
+            5560: 13,-24
+            5561: 13,-25
+            5562: 13,-26
+            5563: 13,-27
+            5564: 13,-28
+            5565: 13,-29
+            5566: 13,-30
+            5567: 13,-31
+            5568: 12,-31
+            5569: 12,-25
+            5570: 14,-20
+            5571: 14,-21
+            5572: 14,-25
+            5573: 15,-25
+            5574: 16,-25
+            5575: 17,-25
+            5576: 18,-25
+            5577: 19,-25
+            5578: 20,-25
+            5579: 14,-28
+            5580: 15,-28
+            5581: 16,-28
+            5582: 18,-28
+            5583: 17,-28
+            5584: 19,-28
+            5585: 20,-28
+            5586: 18,-23
+            5587: 18,-24
+            5588: 21,-28
+            5589: 21,-27
+            5590: 21,-26
+            5591: 21,-25
+            5592: 22,-28
+            5593: 22,-27
+            5594: 22,-26
+            5595: 34,-25
+            5596: 35,-25
+            5597: 25,-24
+            5600: 31,-24
+            5601: 36,-25
+            5602: 37,-25
+            5603: 38,-25
+            5604: 39,-25
+            5605: 40,-25
+            5606: 40,-26
+            5607: 41,-25
+            5608: 42,-25
+            5609: 37,-24
+            5610: 37,-23
+            5611: 37,-22
+            5612: 37,-21
+            5613: 37,-20
+            5614: 37,-19
+            5615: 37,-18
+            5616: 37,-17
+            5617: 37,-16
+            5618: 37,-15
+            5619: 37,-14
+            5620: 38,-17
+            5621: 39,-17
+            5747: 12,-32
+            5748: 13,-32
+            5755: 22,-25
+            5756: 23,-25
+            5757: 24,-25
+            5758: 25,-25
+            5759: 26,-25
+            5760: 27,-25
+            5761: 28,-25
+            5762: 29,-25
+            5763: 30,-25
+            5764: 31,-25
+            5765: 32,-25
+            5766: 33,-25
+            5830: 31,-23
+            5867: 25,-23
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale
@@ -5264,99 +5267,99 @@ entities:
             291: 6,-9
             292: 7,-8
             293: 8,-8
-            3752: 34,-11
-            3753: 35,-11
-            3754: 36,-11
-            3755: 37,-11
-            3756: 38,-11
-            3757: 39,-11
-            3758: 40,-11
-            3759: 41,-11
-            3808: 42,-5
-            3809: 41,-5
-            3810: 40,-5
-            3811: 39,-5
-            3812: 38,-5
-            3813: 37,-5
-            3814: 36,-5
-            3815: 33,-5
+            3727: 34,-11
+            3728: 35,-11
+            3729: 36,-11
+            3730: 37,-11
+            3731: 38,-11
+            3732: 39,-11
+            3733: 40,-11
+            3734: 41,-11
+            3783: 42,-5
+            3784: 41,-5
+            3785: 40,-5
+            3786: 39,-5
+            3787: 38,-5
+            3788: 37,-5
+            3789: 36,-5
+            3790: 33,-5
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale
           decals:
-            5058: 3,84
-            5059: -1,84
-            6454: 2,26
-            6470: 5,27
-            6471: 6,27
-            6472: 7,27
-            6473: 8,27
+            5033: 3,84
+            5034: -1,84
+            6429: 2,26
+            6445: 5,27
+            6446: 6,27
+            6447: 7,27
+            6448: 8,27
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale
           decals:
-            3359: 39,27
-            3360: 37,27
-            3361: 36,27
-            3362: 35,27
-            3363: 34,27
-            3364: 33,27
-            3365: 32,27
+            3334: 39,27
+            3335: 37,27
+            3336: 36,27
+            3337: 35,27
+            3338: 34,27
+            3339: 33,27
+            3340: 32,27
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale
           decals:
-            5420: 31,-31
-            5484: 9,-19
-            5540: 10,-23
-            5541: 9,-23
-            5542: 8,-23
-            5543: 7,-23
-            5544: 5,-23
-            5545: 4,-23
-            5546: 6,-23
-            5794: 22,-25
-            5795: 23,-25
-            5796: 24,-25
-            5797: 25,-25
-            5798: 28,-25
-            5799: 29,-25
-            5800: 30,-25
-            5801: 31,-25
-            5802: 32,-25
-            5803: 33,-25
-            5804: 34,-25
-            5805: 35,-25
-            5806: 36,-25
-            5820: 38,-25
-            5821: 39,-25
-            5822: 40,-25
-            5823: 41,-25
-            5824: 42,-25
-            5827: 37,-25
-            7247: 5,-12
+            5395: 31,-31
+            5459: 9,-19
+            5515: 10,-23
+            5516: 9,-23
+            5517: 8,-23
+            5518: 7,-23
+            5519: 5,-23
+            5520: 4,-23
+            5521: 6,-23
+            5769: 22,-25
+            5770: 23,-25
+            5771: 24,-25
+            5772: 25,-25
+            5773: 28,-25
+            5774: 29,-25
+            5775: 30,-25
+            5776: 31,-25
+            5777: 32,-25
+            5778: 33,-25
+            5779: 34,-25
+            5780: 35,-25
+            5781: 36,-25
+            5795: 38,-25
+            5796: 39,-25
+            5797: 40,-25
+            5798: 41,-25
+            5799: 42,-25
+            5802: 37,-25
+            7222: 5,-12
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale
           decals:
-            2966: 27,6
-            2967: 26,6
-            2968: 25,6
-            2969: 24,6
-            2970: 23,6
-            2971: 22,6
-            2972: 21,6
-            2973: 20,6
-            2974: 19,6
-            2975: 18,6
-            2976: 17,6
-            3107: 35,18
-            3108: 34,18
+            2941: 27,6
+            2942: 26,6
+            2943: 25,6
+            2944: 24,6
+            2945: 23,6
+            2946: 22,6
+            2947: 21,6
+            2948: 20,6
+            2949: 19,6
+            2950: 18,6
+            2951: 17,6
+            3082: 35,18
+            3083: 34,18
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale
           decals:
-            7342: -43,-18
+            7317: -43,-18
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale
@@ -5389,17 +5392,17 @@ entities:
             865: -29,0
             866: -31,0
             867: -32,0
-            1214: -33,0
-            1582: -34,-44
-            1583: -35,-44
-            2069: -36,-44
-            2070: -37,-44
-            2071: -38,-44
-            2072: -39,-44
-            2073: -40,-44
-            2074: -41,-44
-            2075: -42,-44
-            2076: -43,-44
+            1213: -33,0
+            1557: -34,-44
+            1558: -35,-44
+            2044: -36,-44
+            2045: -37,-44
+            2046: -38,-44
+            2047: -39,-44
+            2048: -40,-44
+            2049: -41,-44
+            2050: -42,-44
+            2051: -43,-44
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale
@@ -5408,196 +5411,196 @@ entities:
             460: -14,2
             461: -18,2
             462: -19,2
-            2128: -43,-32
-            2129: -45,-32
-            2174: -37,-49
-            2585: -20,2
-            2586: -21,2
-            2587: -22,2
-            2588: -23,2
-            2589: -24,2
-            2590: -25,2
-            2591: -26,2
-            2592: -27,2
-            2593: -28,2
-            2594: -29,2
-            2595: -30,2
-            2596: -31,2
-            2597: -32,2
-            2688: 13,2
-            2689: 15,2
-            2690: 16,2
-            2691: 17,2
-            3470: 27,2
-            3471: 26,2
-            3472: 25,2
-            3473: 24,2
-            3474: 23,2
-            3475: 22,2
-            3476: 21,2
-            3477: 20,2
-            3478: 19,2
-            3479: 18,2
-            3489: 31,2
-            3490: 32,2
-            3491: 33,2
-            3492: 34,2
-            3493: 35,2
-            3503: 35,8
-            3504: 34,8
-            3505: 33,8
-            3506: 32,8
-            3507: 31,8
-            3513: 17,10
-            3514: 18,10
-            3515: 19,10
-            3560: 27,33
-            3576: 31,30
-            3577: 32,30
-            3578: 33,30
-            3579: 34,30
-            3580: 35,30
-            3581: 36,30
-            3582: 37,30
-            3583: 38,30
-            3584: 39,30
-            3699: 34,-6
-            3700: 35,-6
-            3701: 36,-6
-            3702: 37,-6
-            3703: 38,-6
-            3704: 39,-6
-            3705: 40,-6
-            3706: 41,-6
-            4015: -3,20
-            4016: -4,20
-            4017: -5,20
-            4018: -6,20
-            4019: -7,20
-            4020: -8,20
-            4021: -9,20
-            4022: -10,20
-            4023: -11,20
-            4024: -12,20
-            4025: -13,20
-            4026: -14,20
-            4148: -25,25
-            4149: -26,25
-            4190: -6,29
-            4191: -7,29
-            4192: -8,29
-            4193: -9,29
-            4194: -10,29
-            4195: -11,29
-            4252: -17,36
-            4253: -16,36
-            4289: -20,36
-            4365: -39,37
-            4366: -40,37
-            4367: -41,37
-            4368: -42,37
-            4433: -38,30
-            4434: -37,30
-            4435: -36,30
-            4467: -34,30
-            4468: -33,30
-            4469: -32,30
-            4470: -31,30
-            4471: -30,30
-            4472: -29,30
-            4473: -28,30
-            4474: -27,30
-            4475: -26,30
-            4490: -22,29
-            4491: -21,29
-            4492: -20,29
-            4493: -19,29
-            4494: -18,29
-            6128: 8,-40
-            6129: 7,-40
-            6130: 6,-40
-            6131: 5,-40
-            6132: 4,-40
-            6340: -1,-56
-            6341: -2,-56
-            6342: -3,-56
-            6343: -4,-56
-            6344: -5,-56
-            6345: -6,-56
-            6346: -7,-56
-            6886: 29,-64
-            6887: 28,-64
-            6888: 27,-64
-            6889: 26,-64
-            6890: 25,-64
-            6897: 30,-54
-            6898: 29,-54
-            6923: 23,-50
-            6924: 24,-50
-            6925: 25,-50
-            6926: 26,-50
-            6927: 27,-50
-            6928: 28,-50
-            6929: 29,-50
-            6930: 30,-50
-            6931: 31,-50
-            7133: 11,-41
-            7134: 12,-41
-            7135: 14,-41
-            7136: 13,-41
-            7137: 15,-41
-            7138: 16,-41
-            7139: 17,-41
-            7140: 18,-41
-            7141: 19,-41
-            7142: 20,-41
-            7143: 21,-41
-            7144: 22,-41
-            7145: 23,-41
-            7146: 24,-41
-            7147: 25,-41
-            7148: 26,-41
-            7149: 27,-41
-            7150: 28,-41
-            7151: 29,-41
-            7155: 31,-42
+            2103: -43,-32
+            2104: -45,-32
+            2149: -37,-49
+            2560: -20,2
+            2561: -21,2
+            2562: -22,2
+            2563: -23,2
+            2564: -24,2
+            2565: -25,2
+            2566: -26,2
+            2567: -27,2
+            2568: -28,2
+            2569: -29,2
+            2570: -30,2
+            2571: -31,2
+            2572: -32,2
+            2663: 13,2
+            2664: 15,2
+            2665: 16,2
+            2666: 17,2
+            3445: 27,2
+            3446: 26,2
+            3447: 25,2
+            3448: 24,2
+            3449: 23,2
+            3450: 22,2
+            3451: 21,2
+            3452: 20,2
+            3453: 19,2
+            3454: 18,2
+            3464: 31,2
+            3465: 32,2
+            3466: 33,2
+            3467: 34,2
+            3468: 35,2
+            3478: 35,8
+            3479: 34,8
+            3480: 33,8
+            3481: 32,8
+            3482: 31,8
+            3488: 17,10
+            3489: 18,10
+            3490: 19,10
+            3535: 27,33
+            3551: 31,30
+            3552: 32,30
+            3553: 33,30
+            3554: 34,30
+            3555: 35,30
+            3556: 36,30
+            3557: 37,30
+            3558: 38,30
+            3559: 39,30
+            3674: 34,-6
+            3675: 35,-6
+            3676: 36,-6
+            3677: 37,-6
+            3678: 38,-6
+            3679: 39,-6
+            3680: 40,-6
+            3681: 41,-6
+            3990: -3,20
+            3991: -4,20
+            3992: -5,20
+            3993: -6,20
+            3994: -7,20
+            3995: -8,20
+            3996: -9,20
+            3997: -10,20
+            3998: -11,20
+            3999: -12,20
+            4000: -13,20
+            4001: -14,20
+            4123: -25,25
+            4124: -26,25
+            4165: -6,29
+            4166: -7,29
+            4167: -8,29
+            4168: -9,29
+            4169: -10,29
+            4170: -11,29
+            4227: -17,36
+            4228: -16,36
+            4264: -20,36
+            4340: -39,37
+            4341: -40,37
+            4342: -41,37
+            4343: -42,37
+            4408: -38,30
+            4409: -37,30
+            4410: -36,30
+            4442: -34,30
+            4443: -33,30
+            4444: -32,30
+            4445: -31,30
+            4446: -30,30
+            4447: -29,30
+            4448: -28,30
+            4449: -27,30
+            4450: -26,30
+            4465: -22,29
+            4466: -21,29
+            4467: -20,29
+            4468: -19,29
+            4469: -18,29
+            6103: 8,-40
+            6104: 7,-40
+            6105: 6,-40
+            6106: 5,-40
+            6107: 4,-40
+            6315: -1,-56
+            6316: -2,-56
+            6317: -3,-56
+            6318: -4,-56
+            6319: -5,-56
+            6320: -6,-56
+            6321: -7,-56
+            6861: 29,-64
+            6862: 28,-64
+            6863: 27,-64
+            6864: 26,-64
+            6865: 25,-64
+            6872: 30,-54
+            6873: 29,-54
+            6898: 23,-50
+            6899: 24,-50
+            6900: 25,-50
+            6901: 26,-50
+            6902: 27,-50
+            6903: 28,-50
+            6904: 29,-50
+            6905: 30,-50
+            6906: 31,-50
+            7108: 11,-41
+            7109: 12,-41
+            7110: 14,-41
+            7111: 13,-41
+            7112: 15,-41
+            7113: 16,-41
+            7114: 17,-41
+            7115: 18,-41
+            7116: 19,-41
+            7117: 20,-41
+            7118: 21,-41
+            7119: 22,-41
+            7120: 23,-41
+            7121: 24,-41
+            7122: 25,-41
+            7123: 26,-41
+            7124: 27,-41
+            7125: 28,-41
+            7126: 29,-41
+            7130: 31,-42
         - node:
             color: '#D4D4D496'
             id: HalfTileOverlayGreyscale
           decals:
-            5357: 36,-29
+            5332: 36,-29
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale
           decals:
-            2740: 29,-3
-            2741: 28,-3
-            3880: 45,-17
-            4104: -16,23
-            4218: -8,34
-            4220: -10,35
-            4527: -4,34
-            4528: -4,40
-            4529: -5,40
-            4530: -6,40
-            5469: 5,-19
-            6183: 3,-49
+            2715: 29,-3
+            2716: 28,-3
+            3855: 45,-17
+            4079: -16,23
+            4193: -8,34
+            4195: -10,35
+            4502: -4,34
+            4503: -4,40
+            4504: -5,40
+            4505: -6,40
+            5444: 5,-19
+            6158: 3,-49
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale
           decals:
-            6108: 1,-42
-            6109: 2,-42
-            6118: 9,-42
-            6119: 8,-42
-            6120: 7,-42
-            6121: 4,-42
-            6169: 0,-47
-            6170: 1,-47
-            6171: 2,-47
-            6172: 3,-47
-            6173: 4,-47
-            6174: 5,-47
+            6083: 1,-42
+            6084: 2,-42
+            6093: 9,-42
+            6094: 8,-42
+            6095: 7,-42
+            6096: 4,-42
+            6144: 0,-47
+            6145: 1,-47
+            6146: 2,-47
+            6147: 3,-47
+            6148: 4,-47
+            6149: 5,-47
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale
@@ -5613,76 +5616,76 @@ entities:
             79: 13,0
             815: -28,-6
             816: -27,-6
-            1260: -33,-24
-            1461: -32,-33
-            1462: -31,-33
-            1463: -30,-33
-            1464: -29,-33
-            1610: -26,-32
-            1611: -27,-32
-            1624: -24,-29
-            1741: -20,-29
-            1742: -19,-29
-            1743: -18,-29
-            1744: -17,-29
-            1745: -16,-29
-            1746: -15,-29
-            1747: -14,-29
-            1748: -13,-29
-            1749: -12,-29
-            1750: -11,-29
-            2046: -10,-29
-            2047: -6,-29
-            2052: -4,-29
-            2053: -3,-29
-            2809: 14,0
-            2810: 15,0
-            2811: 16,0
-            2812: 17,0
-            2813: 18,0
-            2814: 19,0
-            2815: 20,0
-            2816: 21,0
-            2817: 22,0
-            2818: 23,0
-            2819: 24,0
-            2820: 25,0
-            2821: 26,0
-            2822: 27,0
-            2823: 28,0
-            2824: 29,0
-            2825: 30,0
-            2826: 31,0
-            2827: 32,0
-            2828: 33,0
-            2945: 23,9
-            2946: 24,9
-            2947: 25,9
-            5124: 15,-17
-            5125: 16,-17
-            5126: 17,-17
-            5127: 19,-16
-            5663: 15,-29
-            5664: 16,-29
-            5665: 17,-29
-            5666: 18,-29
-            5667: 19,-29
-            5668: 20,-29
-            5669: 21,-29
-            5670: 22,-29
-            5674: 24,-26
-            5675: 25,-26
-            5678: 28,-26
-            5679: 29,-26
-            5680: 30,-26
-            5681: 31,-26
-            5682: 32,-26
-            5683: 33,-26
-            5684: 34,-26
-            5685: 35,-26
-            5686: 36,-26
-            5687: 37,-26
-            5828: 38,-26
+            1235: -33,-24
+            1436: -32,-33
+            1437: -31,-33
+            1438: -30,-33
+            1439: -29,-33
+            1585: -26,-32
+            1586: -27,-32
+            1599: -24,-29
+            1716: -20,-29
+            1717: -19,-29
+            1718: -18,-29
+            1719: -17,-29
+            1720: -16,-29
+            1721: -15,-29
+            1722: -14,-29
+            1723: -13,-29
+            1724: -12,-29
+            1725: -11,-29
+            2021: -10,-29
+            2022: -6,-29
+            2027: -4,-29
+            2028: -3,-29
+            2784: 14,0
+            2785: 15,0
+            2786: 16,0
+            2787: 17,0
+            2788: 18,0
+            2789: 19,0
+            2790: 20,0
+            2791: 21,0
+            2792: 22,0
+            2793: 23,0
+            2794: 24,0
+            2795: 25,0
+            2796: 26,0
+            2797: 27,0
+            2798: 28,0
+            2799: 29,0
+            2800: 30,0
+            2801: 31,0
+            2802: 32,0
+            2803: 33,0
+            2920: 23,9
+            2921: 24,9
+            2922: 25,9
+            5099: 15,-17
+            5100: 16,-17
+            5101: 17,-17
+            5102: 19,-16
+            5638: 15,-29
+            5639: 16,-29
+            5640: 17,-29
+            5641: 18,-29
+            5642: 19,-29
+            5643: 20,-29
+            5644: 21,-29
+            5645: 22,-29
+            5649: 24,-26
+            5650: 25,-26
+            5653: 28,-26
+            5654: 29,-26
+            5655: 30,-26
+            5656: 31,-26
+            5657: 32,-26
+            5658: 33,-26
+            5659: 34,-26
+            5660: 35,-26
+            5661: 36,-26
+            5662: 37,-26
+            5803: 38,-26
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale180
@@ -5699,68 +5702,68 @@ entities:
             270: -2,-4
             304: 8,9
             305: 7,9
-            3760: 41,-6
-            3761: 40,-6
-            3762: 39,-6
-            3763: 38,-6
-            3764: 37,-6
-            3765: 36,-6
-            3766: 35,-6
-            3767: 34,-6
-            3791: 33,-12
-            3792: 34,-12
-            3793: 35,-12
-            3796: 39,-12
-            3797: 40,-12
-            3798: 41,-12
-            3799: 42,-12
+            3735: 41,-6
+            3736: 40,-6
+            3737: 39,-6
+            3738: 38,-6
+            3739: 37,-6
+            3740: 36,-6
+            3741: 35,-6
+            3742: 34,-6
+            3766: 33,-12
+            3767: 34,-12
+            3768: 35,-12
+            3771: 39,-12
+            3772: 40,-12
+            3773: 41,-12
+            3774: 42,-12
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale180
           decals:
-            5024: 6,71
-            5025: 8,71
-            5026: 9,71
-            5027: -4,71
-            5028: -6,71
-            5029: -7,71
-            6455: 2,26
-            6474: 5,24
-            6475: 6,24
-            6476: 7,24
-            6477: 8,24
+            4999: 6,71
+            5000: 8,71
+            5001: 9,71
+            5002: -4,71
+            5003: -6,71
+            5004: -7,71
+            6430: 2,26
+            6449: 5,24
+            6450: 6,24
+            6451: 7,24
+            6452: 8,24
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale180
           decals:
-            3351: 32,29
-            3352: 33,29
-            3353: 34,29
-            3354: 35,29
-            3355: 36,29
-            3356: 37,29
-            3357: 38,29
-            3358: 39,29
+            3326: 32,29
+            3327: 33,29
+            3328: 34,29
+            3329: 35,29
+            3330: 36,29
+            3331: 37,29
+            3332: 38,29
+            3333: 39,29
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale180
           decals:
-            5421: 31,-29
-            5483: 9,-20
-            5533: 10,-27
-            5534: 9,-27
-            5535: 8,-27
-            5536: 7,-27
-            5537: 6,-27
-            5538: 5,-27
-            5539: 4,-27
-            5825: 42,-25
-            5826: 41,-25
-            5896: 13,-36
-            5928: 24,-37
-            7167: 8,-38
-            7192: 43,-38
-            7193: 42,-38
+            5396: 31,-29
+            5458: 9,-20
+            5508: 10,-27
+            5509: 9,-27
+            5510: 8,-27
+            5511: 7,-27
+            5512: 6,-27
+            5513: 5,-27
+            5514: 4,-27
+            5800: 42,-25
+            5801: 41,-25
+            5871: 13,-36
+            5903: 24,-37
+            7142: 8,-38
+            7167: 43,-38
+            7168: 42,-38
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale180
@@ -5774,51 +5777,51 @@ entities:
             68: 11,1
             69: 12,1
             70: 13,1
-            2841: 14,1
-            2842: 15,1
-            2843: 16,1
-            2844: 17,1
-            2845: 18,1
-            2846: 19,1
-            2847: 20,1
-            2848: 21,1
-            2849: 22,1
-            2850: 23,1
-            2851: 24,1
-            2852: 25,1
-            2853: 26,1
-            2854: 27,1
-            2855: 28,1
-            2977: 17,7
-            2978: 18,7
-            2979: 19,7
-            2980: 20,7
-            2981: 21,7
-            2982: 22,7
-            2983: 23,7
-            2984: 24,7
-            2985: 25,7
-            2986: 26,7
-            2987: 27,7
-            3109: 35,14
-            3110: 34,14
-            5831: 22,-25
-            5832: 23,-25
-            5833: 24,-25
-            5834: 25,-25
-            5835: 28,-25
-            5836: 29,-25
-            5837: 30,-25
-            5838: 31,-25
-            5839: 32,-25
-            5840: 33,-25
-            5841: 34,-25
-            5842: 35,-25
-            5843: 36,-25
-            5844: 37,-25
-            5845: 38,-25
-            5846: 39,-25
-            5848: 40,-25
+            2816: 14,1
+            2817: 15,1
+            2818: 16,1
+            2819: 17,1
+            2820: 18,1
+            2821: 19,1
+            2822: 20,1
+            2823: 21,1
+            2824: 22,1
+            2825: 23,1
+            2826: 24,1
+            2827: 25,1
+            2828: 26,1
+            2829: 27,1
+            2830: 28,1
+            2952: 17,7
+            2953: 18,7
+            2954: 19,7
+            2955: 20,7
+            2956: 21,7
+            2957: 22,7
+            2958: 23,7
+            2959: 24,7
+            2960: 25,7
+            2961: 26,7
+            2962: 27,7
+            3084: 35,14
+            3085: 34,14
+            5806: 22,-25
+            5807: 23,-25
+            5808: 24,-25
+            5809: 25,-25
+            5810: 28,-25
+            5811: 29,-25
+            5812: 30,-25
+            5813: 31,-25
+            5814: 32,-25
+            5815: 33,-25
+            5816: 34,-25
+            5817: 35,-25
+            5818: 36,-25
+            5819: 37,-25
+            5820: 38,-25
+            5821: 39,-25
+            5823: 40,-25
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale180
@@ -5854,24 +5857,24 @@ entities:
             852: -32,1
             874: -30,4
             875: -29,4
-            1155: -33,1
-            1165: -43,-13
-            1166: -44,-13
-            1167: -45,-13
+            1154: -33,1
+            1164: -43,-13
+            1165: -44,-13
+            1166: -45,-13
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale180
           decals:
-            1584: -35,-43
-            2077: -37,-43
-            2078: -36,-43
-            2079: -38,-43
-            2080: -39,-43
-            2081: -40,-43
-            2082: -41,-43
-            2085: -43,-42
-            2400: -21,-53
-            2442: -27,-57
+            1559: -35,-43
+            2052: -37,-43
+            2053: -36,-43
+            2054: -38,-43
+            2055: -39,-43
+            2056: -40,-43
+            2057: -41,-43
+            2060: -43,-42
+            2375: -21,-53
+            2417: -27,-57
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale180
@@ -5880,234 +5883,234 @@ entities:
             464: -14,-1
             465: -18,-1
             466: -19,-1
-            2103: -43,-39
-            2175: -37,-46
-            2191: -35,-47
-            2194: -33,-47
-            2195: -32,-47
-            2581: -23,-1
-            2582: -24,-1
-            2583: -25,-1
-            2584: -26,-1
-            2611: -36,6
-            2640: -32,-1
-            2643: -27,-1
-            2644: -28,-1
-            2684: 13,-1
-            2685: 15,-1
-            2686: 16,-1
-            2687: 17,-1
-            3453: 18,-1
-            3454: 19,-1
-            3455: 20,-1
-            3456: 21,-1
-            3457: 22,-1
-            3458: 23,-1
-            3459: 24,-1
-            3460: 25,-1
-            3461: 26,-1
-            3462: 27,-1
-            3463: 28,-1
-            3464: 29,-1
-            3465: 30,-1
-            3466: 31,-1
-            3467: 32,-1
-            3468: 33,-1
-            3499: 32,6
-            3500: 33,6
-            3501: 34,6
-            3502: 35,6
-            3559: 27,29
-            3622: 41,27
-            3627: 36,26
-            3628: 35,26
-            3629: 34,26
-            3630: 33,26
-            3631: 32,26
-            3632: 31,26
-            3679: 37,-11
-            3680: 38,-11
-            3681: 39,-11
-            3682: 40,-11
-            3683: 41,-11
-            3684: 36,-11
-            3685: 35,-11
-            3686: 34,-11
-            4031: -16,18
-            4032: -15,18
-            4033: -14,18
-            4034: -13,18
-            4035: -12,18
-            4036: -11,18
-            4037: -10,18
-            4038: -9,18
-            4039: -8,18
-            4040: -7,18
-            4041: -6,18
-            4042: -5,18
-            4043: -4,18
-            4044: -3,18
-            4146: -25,23
-            4147: -26,23
-            4173: -14,27
-            4174: -13,27
-            4175: -12,27
-            4176: -11,27
-            4177: -10,27
-            4178: -9,27
-            4179: -8,27
-            4180: -7,27
-            4181: -6,27
-            4182: -5,27
-            4183: -4,27
-            4258: -17,31
-            4290: -20,31
-            4495: -18,27
-            4496: -19,27
-            4497: -20,27
-            4498: -21,27
-            4499: -22,27
-            4503: -26,28
-            4504: -27,28
-            4505: -28,28
-            4506: -29,28
-            4507: -30,28
-            4508: -31,28
-            4509: -32,28
-            4510: -33,28
-            4511: -34,28
-            6090: 0,-43
-            6091: 1,-43
-            6092: 2,-43
-            6133: 4,-43
-            6134: 7,-43
-            6135: 8,-43
-            6330: -7,-61
-            6331: -6,-61
-            6332: -5,-61
-            6333: -4,-61
-            6334: -3,-61
-            6335: -2,-61
-            6336: -1,-61
-            6879: 25,-62
-            6880: 26,-62
-            6881: 27,-62
-            6882: 28,-62
-            6883: 29,-62
-            6895: 29,-51
-            6896: 30,-51
-            6907: 16,-49
-            6908: 17,-49
-            6909: 18,-49
-            6910: 19,-49
-            6911: 20,-49
-            6912: 21,-49
-            6913: 22,-49
-            6914: 23,-49
-            6915: 24,-49
-            6916: 25,-49
-            6917: 26,-49
-            6918: 27,-49
-            6919: 28,-49
-            6920: 29,-49
-            6921: 30,-49
-            6922: 31,-49
-            6948: 31,-65
-            6949: 30,-65
-            6950: 29,-65
-            6951: 28,-65
-            6952: 27,-65
-            6953: 26,-65
-            6954: 25,-65
-            6955: 24,-65
-            6956: 23,-65
+            2078: -43,-39
+            2150: -37,-46
+            2166: -35,-47
+            2169: -33,-47
+            2170: -32,-47
+            2556: -23,-1
+            2557: -24,-1
+            2558: -25,-1
+            2559: -26,-1
+            2586: -36,6
+            2615: -32,-1
+            2618: -27,-1
+            2619: -28,-1
+            2659: 13,-1
+            2660: 15,-1
+            2661: 16,-1
+            2662: 17,-1
+            3428: 18,-1
+            3429: 19,-1
+            3430: 20,-1
+            3431: 21,-1
+            3432: 22,-1
+            3433: 23,-1
+            3434: 24,-1
+            3435: 25,-1
+            3436: 26,-1
+            3437: 27,-1
+            3438: 28,-1
+            3439: 29,-1
+            3440: 30,-1
+            3441: 31,-1
+            3442: 32,-1
+            3443: 33,-1
+            3474: 32,6
+            3475: 33,6
+            3476: 34,6
+            3477: 35,6
+            3534: 27,29
+            3597: 41,27
+            3602: 36,26
+            3603: 35,26
+            3604: 34,26
+            3605: 33,26
+            3606: 32,26
+            3607: 31,26
+            3654: 37,-11
+            3655: 38,-11
+            3656: 39,-11
+            3657: 40,-11
+            3658: 41,-11
+            3659: 36,-11
+            3660: 35,-11
+            3661: 34,-11
+            4006: -16,18
+            4007: -15,18
+            4008: -14,18
+            4009: -13,18
+            4010: -12,18
+            4011: -11,18
+            4012: -10,18
+            4013: -9,18
+            4014: -8,18
+            4015: -7,18
+            4016: -6,18
+            4017: -5,18
+            4018: -4,18
+            4019: -3,18
+            4121: -25,23
+            4122: -26,23
+            4148: -14,27
+            4149: -13,27
+            4150: -12,27
+            4151: -11,27
+            4152: -10,27
+            4153: -9,27
+            4154: -8,27
+            4155: -7,27
+            4156: -6,27
+            4157: -5,27
+            4158: -4,27
+            4233: -17,31
+            4265: -20,31
+            4470: -18,27
+            4471: -19,27
+            4472: -20,27
+            4473: -21,27
+            4474: -22,27
+            4478: -26,28
+            4479: -27,28
+            4480: -28,28
+            4481: -29,28
+            4482: -30,28
+            4483: -31,28
+            4484: -32,28
+            4485: -33,28
+            4486: -34,28
+            6065: 0,-43
+            6066: 1,-43
+            6067: 2,-43
+            6108: 4,-43
+            6109: 7,-43
+            6110: 8,-43
+            6305: -7,-61
+            6306: -6,-61
+            6307: -5,-61
+            6308: -4,-61
+            6309: -3,-61
+            6310: -2,-61
+            6311: -1,-61
+            6854: 25,-62
+            6855: 26,-62
+            6856: 27,-62
+            6857: 28,-62
+            6858: 29,-62
+            6870: 29,-51
+            6871: 30,-51
+            6882: 16,-49
+            6883: 17,-49
+            6884: 18,-49
+            6885: 19,-49
+            6886: 20,-49
+            6887: 21,-49
+            6888: 22,-49
+            6889: 23,-49
+            6890: 24,-49
+            6891: 25,-49
+            6892: 26,-49
+            6893: 27,-49
+            6894: 28,-49
+            6895: 29,-49
+            6896: 30,-49
+            6897: 31,-49
+            6923: 31,-65
+            6924: 30,-65
+            6925: 29,-65
+            6926: 28,-65
+            6927: 27,-65
+            6928: 26,-65
+            6929: 25,-65
+            6930: 24,-65
+            6931: 23,-65
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale180
           decals:
-            2738: 29,-5
-            2739: 28,-5
-            3873: 44,-19
-            3874: 45,-19
-            4103: -16,22
-            4223: -10,31
-            4224: -11,31
-            4225: -12,31
-            4226: -8,32
-            4526: -4,33
-            4534: -6,36
-            4535: -5,36
-            4536: -4,36
-            5468: 5,-20
-            6181: 3,-51
+            2713: 29,-5
+            2714: 28,-5
+            3848: 44,-19
+            3849: 45,-19
+            4078: -16,22
+            4198: -10,31
+            4199: -11,31
+            4200: -12,31
+            4201: -8,32
+            4501: -4,33
+            4509: -6,36
+            4510: -5,36
+            4511: -4,36
+            5443: 5,-20
+            6156: 3,-51
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale180
           decals:
-            6110: 2,-41
-            6111: 8,-41
-            6112: 7,-41
-            6113: 6,-41
-            6114: 5,-41
-            6115: 4,-41
-            6116: 3,-41
-            6117: 9,-41
-            6160: 4,-46
-            6161: 3,-46
-            6162: 2,-46
-            6163: 1,-46
-            6164: 0,-46
-            6165: -1,-46
+            6085: 2,-41
+            6086: 8,-41
+            6087: 7,-41
+            6088: 6,-41
+            6089: 5,-41
+            6090: 4,-41
+            6091: 3,-41
+            6092: 9,-41
+            6135: 4,-46
+            6136: 3,-46
+            6137: 2,-46
+            6138: 1,-46
+            6139: 0,-46
+            6140: -1,-46
         - node:
             color: '#FF924493'
             id: HalfTileOverlayGreyscale180
           decals:
-            5295: 30,-19
+            5270: 30,-19
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale180
           decals:
             813: -28,-5
             814: -27,-5
-            1452: -32,-30
-            1453: -28,-30
-            1454: -34,-27
-            1455: -35,-27
-            1456: -36,-27
-            1616: -26,-27
-            1617: -25,-27
-            1722: -21,-27
-            1723: -20,-27
-            1724: -19,-27
-            1725: -15,-27
-            1726: -14,-27
-            1727: -13,-27
-            1732: -9,-27
-            2048: -6,-27
-            2049: -7,-27
-            2050: -8,-27
-            2836: 34,1
-            2837: 33,1
-            2838: 32,1
-            2839: 31,1
-            2840: 30,1
-            5123: 16,-14
-            5128: 19,-15
-            5692: 39,-24
-            5693: 40,-24
-            5694: 41,-24
-            5701: 20,-24
-            5702: 21,-24
-            5703: 22,-24
-            5704: 23,-24
-            5705: 28,-24
-            5706: 29,-24
-            5707: 33,-24
-            5708: 34,-24
-            5709: 35,-24
-            5710: 16,-24
-            5711: 15,-24
-            5854: 27,-24
+            1427: -32,-30
+            1428: -28,-30
+            1429: -34,-27
+            1430: -35,-27
+            1431: -36,-27
+            1591: -26,-27
+            1592: -25,-27
+            1697: -21,-27
+            1698: -20,-27
+            1699: -19,-27
+            1700: -15,-27
+            1701: -14,-27
+            1702: -13,-27
+            1707: -9,-27
+            2023: -6,-27
+            2024: -7,-27
+            2025: -8,-27
+            2811: 34,1
+            2812: 33,1
+            2813: 32,1
+            2814: 31,1
+            2815: 30,1
+            5098: 16,-14
+            5103: 19,-15
+            5667: 39,-24
+            5668: 40,-24
+            5669: 41,-24
+            5676: 20,-24
+            5677: 21,-24
+            5678: 22,-24
+            5679: 23,-24
+            5680: 28,-24
+            5681: 29,-24
+            5682: 33,-24
+            5683: 34,-24
+            5684: 35,-24
+            5685: 16,-24
+            5686: 15,-24
+            5829: 27,-24
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale270
@@ -6124,19 +6127,19 @@ entities:
             301: 10,6
             302: 9,7
             303: 9,8
-            3739: 36,-13
-            3748: 42,-7
-            3749: 42,-8
-            3750: 42,-9
-            3751: 42,-10
-            3784: 32,-6
-            3785: 32,-7
-            3786: 32,-8
-            3787: 32,-9
-            3788: 32,-10
-            3789: 32,-11
-            4796: 1,48
-            4936: 5,60
+            3714: 36,-13
+            3723: 42,-7
+            3724: 42,-8
+            3725: 42,-9
+            3726: 42,-10
+            3759: 32,-6
+            3760: 32,-7
+            3761: 32,-8
+            3762: 32,-9
+            3763: 32,-10
+            3764: 32,-11
+            4771: 1,48
+            4911: 5,60
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale270
@@ -6150,54 +6153,54 @@ entities:
             50: 1,11
             51: 1,12
             52: 1,13
-            4572: 1,14
-            4573: 1,15
-            4574: 1,16
-            4575: 1,17
-            4576: 1,18
-            4577: 1,19
-            4578: 1,20
-            4579: 1,21
-            4580: 1,22
-            4581: 1,23
-            4582: 1,24
-            4583: 1,25
-            4585: 1,27
-            4586: 1,28
-            4587: 1,29
-            4588: 1,30
-            4589: 1,31
-            4590: 1,32
-            4591: 1,33
-            4592: 1,34
-            4593: 1,35
-            4594: 1,36
-            4595: 1,37
-            4596: 1,38
-            4769: 1,45
-            4770: 1,44
-            4771: 1,43
-            4772: 1,42
-            4773: 1,41
-            4774: 1,40
-            4775: 1,39
-            4776: 1,47
-            4900: 1,51
-            4901: 1,50
-            4902: 1,49
-            4903: 1,48
-            4942: 5,60
+            4547: 1,14
+            4548: 1,15
+            4549: 1,16
+            4550: 1,17
+            4551: 1,18
+            4552: 1,19
+            4553: 1,20
+            4554: 1,21
+            4555: 1,22
+            4556: 1,23
+            4557: 1,24
+            4558: 1,25
+            4560: 1,27
+            4561: 1,28
+            4562: 1,29
+            4563: 1,30
+            4564: 1,31
+            4565: 1,32
+            4566: 1,33
+            4567: 1,34
+            4568: 1,35
+            4569: 1,36
+            4570: 1,37
+            4571: 1,38
+            4744: 1,45
+            4745: 1,44
+            4746: 1,43
+            4747: 1,42
+            4748: 1,41
+            4749: 1,40
+            4750: 1,39
+            4751: 1,47
+            4875: 1,51
+            4876: 1,50
+            4877: 1,49
+            4878: 1,48
+            4917: 5,60
         - node:
             color: '#50BCB193'
             id: HalfTileOverlayGreyscale270
           decals:
-            3018: 29,9
-            3019: 29,10
-            3020: 29,11
-            3021: 29,12
-            3327: 29,13
-            3328: 29,15
-            3329: 29,16
+            2993: 29,9
+            2994: 29,10
+            2995: 29,11
+            2996: 29,12
+            3302: 29,13
+            3303: 29,15
+            3304: 29,16
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale270
@@ -6212,39 +6215,39 @@ entities:
             87: 1,-11
             88: 1,-12
             570: 8,-14
-            2752: 22,-11
-            2753: 22,-10
-            5408: 27,-27
-            5409: 27,-28
-            5410: 27,-29
-            5411: 27,-30
-            5412: 27,-31
-            5778: 27,-26
-            5792: 27,-25
-            5894: 11,-36
-            5895: 14,-36
-            6017: 1,-13
-            6018: 1,-14
-            6019: 1,-15
-            6020: 1,-16
-            6021: 1,-17
-            6022: 1,-18
-            6023: 1,-19
-            6024: 1,-20
-            6025: 1,-21
-            6026: 1,-22
-            6027: 1,-23
-            6028: 1,-24
-            7169: 4,-35
-            7191: 39,-40
-            7194: 41,-38
+            2727: 22,-11
+            2728: 22,-10
+            5383: 27,-27
+            5384: 27,-28
+            5385: 27,-29
+            5386: 27,-30
+            5387: 27,-31
+            5753: 27,-26
+            5767: 27,-25
+            5869: 11,-36
+            5870: 14,-36
+            5992: 1,-13
+            5993: 1,-14
+            5994: 1,-15
+            5995: 1,-16
+            5996: 1,-17
+            5997: 1,-18
+            5998: 1,-19
+            5999: 1,-20
+            6000: 1,-21
+            6001: 1,-22
+            6002: 1,-23
+            6003: 1,-24
+            7144: 4,-35
+            7166: 39,-40
+            7169: 41,-38
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale270
           decals:
-            3091: 32,16
-            3092: 32,17
-            3093: 32,15
+            3066: 32,16
+            3067: 32,17
+            3068: 32,15
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale270
@@ -6253,315 +6256,311 @@ entities:
             871: -31,7
             872: -31,6
             873: -31,5
-            1158: -38,-8
-            1159: -38,-9
-            1160: -38,-10
-            1161: -38,-11
-            1162: -38,-12
-            1163: -38,-13
-            1164: -38,-14
-            7343: -43,-19
+            1157: -38,-8
+            1158: -38,-9
+            1159: -38,-10
+            1160: -38,-11
+            1161: -38,-12
+            1162: -38,-13
+            1163: -38,-14
+            7318: -43,-19
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale270
           decals:
-            1276: -39,-23
-            1298: -40,-26
-            2088: -44,-41
-            2089: -44,-40
-            2090: -44,-39
-            2336: -22,-39
-            2337: -21,-42
-            2339: -21,-48
+            1251: -39,-23
+            1273: -40,-26
+            2063: -44,-41
+            2064: -44,-40
+            2065: -44,-39
+            2311: -22,-39
+            2312: -21,-42
+            2314: -21,-48
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale270
           decals:
-            1227: -32,14
-            1228: -32,15
-            1229: -32,16
-            1230: -32,17
-            2115: -44,-37
-            2116: -44,-36
-            2176: -36,-47
-            2177: -36,-48
-            2224: -32,-50
-            2225: -32,-51
-            2229: -32,-52
-            2601: -36,9
-            2602: -35,11
-            2603: -35,12
-            2612: -35,5
-            2613: -35,4
-            2614: -35,3
-            2615: -35,2
-            2616: -35,1
-            2617: -35,0
-            2618: -35,-1
-            2619: -35,-2
-            2620: -35,-3
-            2621: -35,-4
-            2622: -35,-5
-            2623: -35,-6
-            2624: -35,-7
-            2625: -35,-8
-            2626: -35,-9
-            2627: -35,-10
-            2628: -35,-11
-            2629: -35,-12
-            2630: -35,-13
-            2631: -35,-14
-            2659: -1,-12
-            2660: -1,-14
-            2661: -1,-15
-            2662: -1,-16
-            2663: -1,-17
-            2664: -1,-18
-            2665: -1,-19
-            2666: -1,-20
-            2671: -1,-26
-            2692: -1,13
-            2693: -1,15
-            2694: -1,16
-            2695: -1,17
-            3237: 12,20
-            3238: 12,23
-            3293: 23,25
-            3484: 28,3
-            3485: 28,4
-            3508: 16,6
-            3509: 16,7
-            3510: 16,8
-            3511: 16,9
-            3522: 28,9
-            3523: 28,10
-            3524: 28,11
-            3525: 28,12
-            3537: 28,16
-            3538: 28,17
-            3539: 28,18
-            3540: 28,20
-            3551: 28,22
-            3552: 28,23
-            3553: 28,24
-            3554: 28,25
-            3555: 28,26
-            3556: 28,27
-            3557: 28,28
-            3562: 28,34
-            3563: 28,35
-            3564: 28,36
-            3565: 28,37
-            3566: 28,38
-            3567: 28,39
-            3588: 42,30
-            3589: 42,31
-            3590: 42,32
-            3591: 42,33
-            3596: 42,40
-            3597: 42,41
-            3598: 42,42
-            3599: 42,43
-            3600: 42,44
-            3601: 42,45
-            3602: 42,46
-            3689: 33,-10
-            3690: 33,-9
-            3691: 33,-8
-            3692: 33,-7
-            3707: 35,-3
-            3708: 35,-4
-            3709: 35,-5
-            4028: -17,20
-            4029: -17,19
-            4111: -17,25
-            4112: -17,26
-            4188: -5,30
-            4259: -18,32
-            4260: -18,33
-            4261: -18,34
-            4262: -18,35
-            4291: -21,32
-            4292: -21,33
-            4293: -21,34
-            4294: -21,35
-            4363: -38,38
-            4370: -43,36
-            4371: -43,35
-            4372: -43,34
-            4373: -43,33
-            4374: -43,32
-            4375: -43,31
-            4407: -38,26
-            4408: -38,25
-            4409: -38,24
-            4410: -38,23
-            4411: -38,22
-            4479: -25,33
-            4480: -25,32
-            4481: -25,31
-            4501: -25,27
-            4655: -1,21
-            4656: -1,22
-            4657: -1,23
-            4658: -1,24
-            4659: -1,25
-            4660: -1,26
-            4661: -1,27
-            4662: -1,28
-            4663: -1,29
-            4664: -1,30
-            4665: -1,31
-            4666: -1,32
-            4667: -1,33
-            4668: -1,34
-            4669: -1,35
-            4672: -1,40
-            4673: -1,41
-            4779: -1,42
-            4780: -1,43
-            4781: -1,44
-            4782: -1,45
-            4783: -1,46
-            4784: -1,47
-            5306: 40,-18
-            5307: 40,-17
-            5308: 40,-16
-            6075: -1,-30
-            6076: -1,-31
-            6077: -1,-32
-            6078: -1,-33
-            6079: -1,-34
-            6080: -1,-35
-            6081: -1,-36
-            6082: -1,-37
-            6083: -1,-38
-            6084: -1,-38
-            6085: -1,-39
-            6086: -1,-40
-            6087: -1,-41
-            6088: -1,-42
-            6136: -3,-47
-            6137: -3,-46
-            6328: -8,-60
-            6348: -8,-57
-            6480: 28,19
-            6885: 30,-63
-            6899: 31,-53
-            6900: 31,-52
-            6958: 22,-64
-            6959: 22,-63
-            6960: 22,-62
-            6961: 22,-61
-            6962: 22,-60
-            6963: 22,-59
-            6964: 22,-58
-            6965: 22,-57
-            6966: 22,-56
-            6967: 22,-55
-            7126: 10,-47
-            7127: 10,-46
-            7128: 10,-45
-            7129: 10,-44
-            7130: 10,-43
-            7131: 10,-42
+            2090: -44,-37
+            2091: -44,-36
+            2151: -36,-47
+            2152: -36,-48
+            2199: -32,-50
+            2200: -32,-51
+            2204: -32,-52
+            2576: -36,9
+            2577: -35,11
+            2578: -35,12
+            2587: -35,5
+            2588: -35,4
+            2589: -35,3
+            2590: -35,2
+            2591: -35,1
+            2592: -35,0
+            2593: -35,-1
+            2594: -35,-2
+            2595: -35,-3
+            2596: -35,-4
+            2597: -35,-5
+            2598: -35,-6
+            2599: -35,-7
+            2600: -35,-8
+            2601: -35,-9
+            2602: -35,-10
+            2603: -35,-11
+            2604: -35,-12
+            2605: -35,-13
+            2606: -35,-14
+            2634: -1,-12
+            2635: -1,-14
+            2636: -1,-15
+            2637: -1,-16
+            2638: -1,-17
+            2639: -1,-18
+            2640: -1,-19
+            2641: -1,-20
+            2646: -1,-26
+            2667: -1,13
+            2668: -1,15
+            2669: -1,16
+            2670: -1,17
+            3212: 12,20
+            3213: 12,23
+            3268: 23,25
+            3459: 28,3
+            3460: 28,4
+            3483: 16,6
+            3484: 16,7
+            3485: 16,8
+            3486: 16,9
+            3497: 28,9
+            3498: 28,10
+            3499: 28,11
+            3500: 28,12
+            3512: 28,16
+            3513: 28,17
+            3514: 28,18
+            3515: 28,20
+            3526: 28,22
+            3527: 28,23
+            3528: 28,24
+            3529: 28,25
+            3530: 28,26
+            3531: 28,27
+            3532: 28,28
+            3537: 28,34
+            3538: 28,35
+            3539: 28,36
+            3540: 28,37
+            3541: 28,38
+            3542: 28,39
+            3563: 42,30
+            3564: 42,31
+            3565: 42,32
+            3566: 42,33
+            3571: 42,40
+            3572: 42,41
+            3573: 42,42
+            3574: 42,43
+            3575: 42,44
+            3576: 42,45
+            3577: 42,46
+            3664: 33,-10
+            3665: 33,-9
+            3666: 33,-8
+            3667: 33,-7
+            3682: 35,-3
+            3683: 35,-4
+            3684: 35,-5
+            4003: -17,20
+            4004: -17,19
+            4086: -17,25
+            4087: -17,26
+            4163: -5,30
+            4234: -18,32
+            4235: -18,33
+            4236: -18,34
+            4237: -18,35
+            4266: -21,32
+            4267: -21,33
+            4268: -21,34
+            4269: -21,35
+            4338: -38,38
+            4345: -43,36
+            4346: -43,35
+            4347: -43,34
+            4348: -43,33
+            4349: -43,32
+            4350: -43,31
+            4382: -38,26
+            4383: -38,25
+            4384: -38,24
+            4385: -38,23
+            4386: -38,22
+            4454: -25,33
+            4455: -25,32
+            4456: -25,31
+            4476: -25,27
+            4630: -1,21
+            4631: -1,22
+            4632: -1,23
+            4633: -1,24
+            4634: -1,25
+            4635: -1,26
+            4636: -1,27
+            4637: -1,28
+            4638: -1,29
+            4639: -1,30
+            4640: -1,31
+            4641: -1,32
+            4642: -1,33
+            4643: -1,34
+            4644: -1,35
+            4647: -1,40
+            4648: -1,41
+            4754: -1,42
+            4755: -1,43
+            4756: -1,44
+            4757: -1,45
+            4758: -1,46
+            4759: -1,47
+            5281: 40,-18
+            5282: 40,-17
+            5283: 40,-16
+            6050: -1,-30
+            6051: -1,-31
+            6052: -1,-32
+            6053: -1,-33
+            6054: -1,-34
+            6055: -1,-35
+            6056: -1,-36
+            6057: -1,-37
+            6058: -1,-38
+            6059: -1,-38
+            6060: -1,-39
+            6061: -1,-40
+            6062: -1,-41
+            6063: -1,-42
+            6111: -3,-47
+            6112: -3,-46
+            6303: -8,-60
+            6323: -8,-57
+            6455: 28,19
+            6860: 30,-63
+            6874: 31,-53
+            6875: 31,-52
+            6933: 22,-64
+            6934: 22,-63
+            6935: 22,-62
+            6936: 22,-61
+            6937: 22,-60
+            6938: 22,-59
+            6939: 22,-58
+            6940: 22,-57
+            6941: 22,-56
+            6942: 22,-55
+            7101: 10,-47
+            7102: 10,-46
+            7103: 10,-45
+            7104: 10,-44
+            7105: 10,-43
+            7106: 10,-42
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale270
           decals:
-            2742: 27,-4
-            3875: 43,-16
-            3876: 43,-17
-            3877: 43,-18
-            4210: -13,35
-            4211: -13,34
-            4212: -13,33
-            4213: -13,32
-            4531: -7,39
-            4532: -7,38
-            4533: -7,37
-            4957: -5,58
-            4958: -5,59
-            4959: -5,60
-            4960: -5,61
-            6182: 2,-50
+            2717: 27,-4
+            3850: 43,-16
+            3851: 43,-17
+            3852: 43,-18
+            4185: -13,35
+            4186: -13,34
+            4187: -13,33
+            4188: -13,32
+            4506: -7,39
+            4507: -7,38
+            4508: -7,37
+            4932: -5,58
+            4933: -5,59
+            4934: -5,60
+            4935: -5,61
+            6157: 2,-50
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale270
           decals:
-            6053: 1,-26
-            6054: 1,-27
-            6055: 1,-28
-            6056: 1,-29
-            6057: 1,-30
-            6058: 1,-31
-            6059: 1,-32
-            6060: 1,-33
-            6061: 1,-34
-            6093: 1,-35
-            6094: 1,-36
-            6095: 1,-37
-            6096: 1,-38
-            6097: 1,-39
-            6098: 1,-40
-            6124: 6,-43
-            6125: 6,-44
-            6157: 6,-45
-            6260: 2,-58
+            6028: 1,-26
+            6029: 1,-27
+            6030: 1,-28
+            6031: 1,-29
+            6032: 1,-30
+            6033: 1,-31
+            6034: 1,-32
+            6035: 1,-33
+            6036: 1,-34
+            6068: 1,-35
+            6069: 1,-36
+            6070: 1,-37
+            6071: 1,-38
+            6072: 1,-39
+            6073: 1,-40
+            6099: 6,-43
+            6100: 6,-44
+            6132: 6,-45
+            6235: 2,-58
         - node:
             color: '#FF924493'
             id: HalfTileOverlayGreyscale270
           decals:
-            5294: 31,-20
+            5269: 31,-20
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale270
           decals:
-            1250: -33,-16
-            1459: -33,-34
-            1460: -33,-35
-            1465: -33,-29
-            1466: -33,-28
-            1564: -33,-36
-            1565: -33,-37
-            1566: -33,-38
-            1567: -33,-39
-            1568: -33,-40
-            1569: -33,-41
-            1570: -33,-42
-            1571: -33,-43
-            1572: -33,-44
-            1608: -25,-30
-            1609: -25,-31
-            1733: -10,-25
-            1734: -10,-24
-            1735: -10,-23
-            1736: -10,-22
-            2832: 35,-2
-            2833: 35,-1
-            2834: 35,0
-            2948: 26,10
-            2949: 26,11
-            5119: 14,-15
-            5120: 14,-16
-            5406: 32,-30
-            5407: 32,-31
-            5623: 27,-26
-            5659: 14,-32
-            5660: 14,-31
-            5661: 14,-30
-            5671: 23,-28
-            5672: 23,-27
-            5676: 26,-26
-            5713: 14,-23
-            5714: 14,-22
-            5715: 38,-23
-            5716: 38,-22
-            5717: 38,-21
-            5718: 38,-20
-            5719: 38,-19
-            5722: 38,-15
-            5774: 19,-23
+            1225: -33,-16
+            1434: -33,-34
+            1435: -33,-35
+            1440: -33,-29
+            1441: -33,-28
+            1539: -33,-36
+            1540: -33,-37
+            1541: -33,-38
+            1542: -33,-39
+            1543: -33,-40
+            1544: -33,-41
+            1545: -33,-42
+            1546: -33,-43
+            1547: -33,-44
+            1583: -25,-30
+            1584: -25,-31
+            1708: -10,-25
+            1709: -10,-24
+            1710: -10,-23
+            1711: -10,-22
+            2807: 35,-2
+            2808: 35,-1
+            2809: 35,0
+            2923: 26,10
+            2924: 26,11
+            5094: 14,-15
+            5095: 14,-16
+            5381: 32,-30
+            5382: 32,-31
+            5598: 27,-26
+            5634: 14,-32
+            5635: 14,-31
+            5636: 14,-30
+            5646: 23,-28
+            5647: 23,-27
+            5651: 26,-26
+            5688: 14,-23
+            5689: 14,-22
+            5690: 38,-23
+            5691: 38,-22
+            5692: 38,-21
+            5693: 38,-20
+            5694: 38,-19
+            5697: 38,-15
+            5749: 19,-23
         - node:
             color: '#222222E5'
             id: HalfTileOverlayGreyscale90
@@ -6578,74 +6577,74 @@ entities:
             282: -8,-6
             283: -8,-7
             455: -9,6
-            3740: 38,-13
-            3744: 33,-10
-            3745: 33,-9
-            3746: 33,-8
-            3747: 33,-7
-            3801: 43,-11
-            3802: 43,-10
-            3803: 43,-9
-            3804: 43,-8
-            3805: 43,-7
-            3806: 43,-6
-            4795: 0,48
-            4937: -4,60
+            3715: 38,-13
+            3719: 33,-10
+            3720: 33,-9
+            3721: 33,-8
+            3722: 33,-7
+            3776: 43,-11
+            3777: 43,-10
+            3778: 43,-9
+            3779: 43,-8
+            3780: 43,-7
+            3781: 43,-6
+            4770: 0,48
+            4912: -4,60
         - node:
             color: '#334E6DC8'
             id: HalfTileOverlayGreyscale90
           decals:
-            4675: -12,47
-            4676: -6,44
-            4751: 0,39
-            4752: 0,40
-            4753: 0,41
-            4754: 0,42
-            4755: 0,43
-            4756: 0,44
-            4757: 0,45
-            4758: 0,46
-            4777: 0,47
-            4896: 0,51
-            4897: 0,50
-            4898: 0,49
-            4899: 0,48
-            4904: 1,50
-            4943: -4,60
+            4650: -12,47
+            4651: -6,44
+            4726: 0,39
+            4727: 0,40
+            4728: 0,41
+            4729: 0,42
+            4730: 0,43
+            4731: 0,44
+            4732: 0,45
+            4733: 0,46
+            4752: 0,47
+            4871: 0,51
+            4872: 0,50
+            4873: 0,49
+            4874: 0,48
+            4879: 1,50
+            4918: -4,60
         - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale90
           decals:
             572: 9,-16
-            2702: 21,-3
-            2789: 26,-12
-            5413: 26,-27
-            5414: 26,-28
-            5415: 26,-29
-            5416: 26,-30
-            5417: 26,-31
-            5779: 26,-26
-            5793: 26,-25
+            2677: 21,-3
+            2764: 26,-12
+            5388: 26,-27
+            5389: 26,-28
+            5390: 26,-29
+            5391: 26,-30
+            5392: 26,-31
+            5754: 26,-26
+            5768: 26,-25
         - node:
             color: '#9FED5896'
             id: HalfTileOverlayGreyscale90
           decals:
-            2998: 29,9
-            2999: 29,10
-            3000: 29,11
-            3001: 29,12
-            3086: 29,13
-            3087: 29,15
-            3088: 29,16
-            3113: 37,17
-            3114: 37,16
-            3115: 37,15
-            3289: 18,25
-            4953: 6,58
-            4954: 6,59
-            4955: 6,60
-            4956: 6,61
-            5361: 35,-33
+            2973: 29,9
+            2974: 29,10
+            2975: 29,11
+            2976: 29,12
+            3061: 29,13
+            3062: 29,15
+            3063: 29,16
+            3088: 37,17
+            3089: 37,16
+            3090: 37,15
+            3264: 18,25
+            4928: 6,58
+            4929: 6,59
+            4930: 6,60
+            4931: 6,61
+            5336: 35,-33
         - node:
             color: '#A4610696'
             id: HalfTileOverlayGreyscale90
@@ -6653,196 +6652,192 @@ entities:
             876: -28,7
             883: -28,5
             884: -28,6
-            7346: -41,-21
+            7321: -41,-21
         - node:
             color: '#D381C996'
             id: HalfTileOverlayGreyscale90
           decals:
-            1326: -46,-28
-            2091: -42,-41
-            2092: -42,-40
-            2093: -42,-39
-            2343: -20,-50
-            2401: -20,-53
-            2419: -28,-53
+            1301: -46,-28
+            2066: -42,-41
+            2067: -42,-40
+            2068: -42,-39
+            2318: -20,-50
+            2376: -20,-53
+            2394: -28,-53
         - node:
             color: '#D4D4D428'
             id: HalfTileOverlayGreyscale90
           decals:
-            1223: -36,14
-            1224: -36,15
-            1225: -36,16
-            1226: -36,17
-            2117: -46,-37
-            2118: -46,-36
-            2178: -38,-48
-            2179: -38,-47
-            2226: -33,-52
-            2227: -33,-51
-            2228: -33,-50
-            2598: -33,3
-            2599: -33,4
-            2600: -33,8
-            2632: -33,-7
-            2633: -33,-6
-            2634: -33,-5
-            2635: -33,-4
-            2636: -33,-3
-            2637: -33,-2
-            2673: 2,-23
-            2674: 2,-22
-            2675: 2,-21
-            2676: 2,-20
-            2677: 2,-19
-            2678: 2,-18
-            2679: 2,-17
-            2680: 2,-16
-            2681: 2,-15
-            2682: 2,-14
-            2683: 2,-12
-            2697: 2,15
-            2698: 2,16
-            2699: 2,13
-            3486: 30,4
-            3487: 30,3
-            3495: 36,1
-            3496: 36,0
-            3497: 36,-1
-            3517: 20,9
-            3526: 30,12
-            3527: 30,11
-            3528: 30,10
-            3529: 30,9
-            3532: 30,13
-            3533: 30,14
-            3541: 30,20
-            3547: 30,18
-            3550: 30,25
-            3572: 30,33
-            3573: 30,32
-            3574: 30,31
-            3603: 44,46
-            3604: 44,45
-            3605: 44,44
-            3606: 44,43
-            3607: 44,42
-            3608: 44,41
-            3611: 44,37
-            3612: 44,36
-            3613: 44,35
-            3614: 44,34
-            3617: 44,30
-            3618: 44,29
-            3619: 44,28
-            3620: 44,27
-            3693: 42,-10
-            3694: 42,-9
-            3695: 42,-8
-            3696: 42,-7
-            3710: 34,-3
-            3711: 34,-4
-            3712: 34,-5
-            3997: 2,20
-            4113: -15,25
-            4114: -15,26
-            4145: -24,24
-            4185: -3,28
-            4186: -3,29
-            4187: -3,30
-            4254: -15,35
-            4255: -15,34
-            4256: -15,33
-            4257: -15,32
-            4354: -37,32
-            4355: -37,33
-            4356: -37,34
-            4357: -37,35
-            4358: -37,36
-            4359: -37,37
-            4360: -37,38
-            4400: -36,26
-            4401: -36,25
-            4402: -36,24
-            4403: -36,23
-            4404: -36,22
-            4405: -36,21
-            4406: -36,20
-            4414: -39,22
-            4482: -23,36
-            4483: -23,35
-            4484: -23,34
-            4485: -23,33
-            4486: -23,32
-            4487: -23,31
-            4488: -23,30
-            4636: 2,21
-            4637: 2,22
-            4638: 2,23
-            4639: 2,29
-            4640: 2,30
-            4641: 2,31
-            4642: 2,32
-            4643: 2,33
-            4644: 2,34
-            4645: 2,35
-            4646: 2,36
-            4647: 2,37
-            4648: 2,38
-            4649: 2,39
-            4650: 2,40
-            4651: 2,41
-            4652: 2,42
-            4653: 2,43
-            4654: 2,44
-            5309: 41,-16
-            5310: 41,-17
-            5311: 41,-18
-            6063: 2,-28
-            6064: 2,-29
-            6065: 2,-30
-            6066: 2,-31
-            6067: 2,-32
-            6068: 2,-33
-            6069: 2,-34
-            6070: 2,-35
-            6071: 2,-36
-            6072: 2,-37
-            6073: 2,-38
-            6074: 2,-39
-            6337: 0,-58
-            6338: 0,-57
-            6457: 2,28
-            6459: 2,24
-            6479: 30,19
-            6892: 24,-63
-            6901: 28,-52
-            6902: 28,-53
-            6934: 32,-51
-            6935: 32,-52
-            6936: 32,-53
-            6937: 32,-54
-            6938: 32,-64
-            6939: 32,-63
-            6940: 32,-62
-            6941: 32,-61
-            6942: 32,-60
-            6943: 32,-59
-            6944: 32,-58
-            6945: 32,-57
-            6946: 32,-56
-            7156: 32,-43
-            7157: 32,-44
-            7158: 32,-45
-            7159: 32,-48
-            7160: 32,-47
-            7161: 32,-46
+            2092: -46,-37
+            2093: -46,-36
+            2153: -38,-48
+            2154: -38,-47
+            2201: -33,-52
+            2202: -33,-51
+            2203: -33,-50
+            2573: -33,3
+            2574: -33,4
+            2575: -33,8
+            2607: -33,-7
+            2608: -33,-6
+            2609: -33,-5
+            2610: -33,-4
+            2611: -33,-3
+            2612: -33,-2
+            2648: 2,-23
+            2649: 2,-22
+            2650: 2,-21
+            2651: 2,-20
+            2652: 2,-19
+            2653: 2,-18
+            2654: 2,-17
+            2655: 2,-16
+            2656: 2,-15
+            2657: 2,-14
+            2658: 2,-12
+            2672: 2,15
+            2673: 2,16
+            2674: 2,13
+            3461: 30,4
+            3462: 30,3
+            3470: 36,1
+            3471: 36,0
+            3472: 36,-1
+            3492: 20,9
+            3501: 30,12
+            3502: 30,11
+            3503: 30,10
+            3504: 30,9
+            3507: 30,13
+            3508: 30,14
+            3516: 30,20
+            3522: 30,18
+            3525: 30,25
+            3547: 30,33
+            3548: 30,32
+            3549: 30,31
+            3578: 44,46
+            3579: 44,45
+            3580: 44,44
+            3581: 44,43
+            3582: 44,42
+            3583: 44,41
+            3586: 44,37
+            3587: 44,36
+            3588: 44,35
+            3589: 44,34
+            3592: 44,30
+            3593: 44,29
+            3594: 44,28
+            3595: 44,27
+            3668: 42,-10
+            3669: 42,-9
+            3670: 42,-8
+            3671: 42,-7
+            3685: 34,-3
+            3686: 34,-4
+            3687: 34,-5
+            3972: 2,20
+            4088: -15,25
+            4089: -15,26
+            4120: -24,24
+            4160: -3,28
+            4161: -3,29
+            4162: -3,30
+            4229: -15,35
+            4230: -15,34
+            4231: -15,33
+            4232: -15,32
+            4329: -37,32
+            4330: -37,33
+            4331: -37,34
+            4332: -37,35
+            4333: -37,36
+            4334: -37,37
+            4335: -37,38
+            4375: -36,26
+            4376: -36,25
+            4377: -36,24
+            4378: -36,23
+            4379: -36,22
+            4380: -36,21
+            4381: -36,20
+            4389: -39,22
+            4457: -23,36
+            4458: -23,35
+            4459: -23,34
+            4460: -23,33
+            4461: -23,32
+            4462: -23,31
+            4463: -23,30
+            4611: 2,21
+            4612: 2,22
+            4613: 2,23
+            4614: 2,29
+            4615: 2,30
+            4616: 2,31
+            4617: 2,32
+            4618: 2,33
+            4619: 2,34
+            4620: 2,35
+            4621: 2,36
+            4622: 2,37
+            4623: 2,38
+            4624: 2,39
+            4625: 2,40
+            4626: 2,41
+            4627: 2,42
+            4628: 2,43
+            4629: 2,44
+            5284: 41,-16
+            5285: 41,-17
+            5286: 41,-18
+            6038: 2,-28
+            6039: 2,-29
+            6040: 2,-30
+            6041: 2,-31
+            6042: 2,-32
+            6043: 2,-33
+            6044: 2,-34
+            6045: 2,-35
+            6046: 2,-36
+            6047: 2,-37
+            6048: 2,-38
+            6049: 2,-39
+            6312: 0,-58
+            6313: 0,-57
+            6432: 2,28
+            6434: 2,24
+            6454: 30,19
+            6867: 24,-63
+            6876: 28,-52
+            6877: 28,-53
+            6909: 32,-51
+            6910: 32,-52
+            6911: 32,-53
+            6912: 32,-54
+            6913: 32,-64
+            6914: 32,-63
+            6915: 32,-62
+            6916: 32,-61
+            6917: 32,-60
+            6918: 32,-59
+            6919: 32,-58
+            6920: 32,-57
+            6921: 32,-56
+            7131: 32,-43
+            7132: 32,-44
+            7133: 32,-45
+            7134: 32,-48
+            7135: 32,-47
+            7136: 32,-46
         - node:
             color: '#D4D4D496'
             id: HalfTileOverlayGreyscale90
           decals:
-            2700: 19,-5
-            2701: 24,-3
-            2791: 25,-15
+            2675: 19,-5
+            2676: 24,-3
+            2766: 25,-15
         - node:
             color: '#DE3A3A96'
             id: HalfTileOverlayGreyscale90
@@ -6858,35 +6853,35 @@ entities:
             61: 0,13
             885: -22,4
             890: -20,11
-            2743: 30,-4
-            3878: 44,-16
-            3879: 46,-18
-            3990: 0,18
-            3991: 0,17
-            3992: 0,16
-            3993: 0,15
-            3994: 0,14
-            4537: -3,37
-            4538: -3,38
-            4539: -3,39
-            4555: 0,36
-            4556: 0,35
-            4557: 0,34
-            4558: 0,33
-            4559: 0,32
-            4560: 0,31
-            4561: 0,30
-            4562: 0,29
-            4563: 0,28
-            4564: 0,27
-            4565: 0,26
-            4566: 0,25
-            4567: 0,24
-            4568: 0,23
-            4569: 0,22
-            4570: 0,21
-            4571: 0,20
-            6184: 4,-50
+            2718: 30,-4
+            3853: 44,-16
+            3854: 46,-18
+            3965: 0,18
+            3966: 0,17
+            3967: 0,16
+            3968: 0,15
+            3969: 0,14
+            4512: -3,37
+            4513: -3,38
+            4514: -3,39
+            4530: 0,36
+            4531: 0,35
+            4532: 0,34
+            4533: 0,33
+            4534: 0,32
+            4535: 0,31
+            4536: 0,30
+            4537: 0,29
+            4538: 0,28
+            4539: 0,27
+            4540: 0,26
+            4541: 0,25
+            4542: 0,24
+            4543: 0,23
+            4544: 0,22
+            4545: 0,21
+            4546: 0,20
+            6159: 4,-50
         - node:
             color: '#EFB34196'
             id: HalfTileOverlayGreyscale90
@@ -6900,151 +6895,151 @@ entities:
             95: 0,-10
             96: 0,-11
             97: 0,-12
-            6031: 0,-14
-            6032: 0,-15
-            6033: 0,-16
-            6034: 0,-17
-            6035: 0,-13
-            6036: 0,-18
-            6037: 0,-19
-            6038: 0,-20
-            6039: 0,-21
-            6040: 0,-22
-            6041: 0,-23
-            6042: 0,-24
-            6043: 0,-25
-            6044: 0,-26
-            6045: 0,-27
-            6046: 0,-28
-            6047: 0,-29
-            6048: 0,-30
-            6049: 0,-31
-            6050: 0,-32
-            6051: 0,-33
-            6052: 0,-34
-            6100: 0,-35
-            6101: 0,-36
-            6102: 0,-37
-            6103: 0,-38
-            6104: 0,-39
-            6105: 0,-40
-            6106: 0,-41
-            6126: 5,-43
-            6127: 5,-44
-            6156: 5,-45
-            6167: -2,-47
-            6261: 4,-54
-            6262: 4,-55
-            6263: 4,-56
-            6264: 4,-57
-            6265: 4,-58
-            6266: 4,-59
-            6267: 4,-60
-            6268: 4,-61
+            6006: 0,-14
+            6007: 0,-15
+            6008: 0,-16
+            6009: 0,-17
+            6010: 0,-13
+            6011: 0,-18
+            6012: 0,-19
+            6013: 0,-20
+            6014: 0,-21
+            6015: 0,-22
+            6016: 0,-23
+            6017: 0,-24
+            6018: 0,-25
+            6019: 0,-26
+            6020: 0,-27
+            6021: 0,-28
+            6022: 0,-29
+            6023: 0,-30
+            6024: 0,-31
+            6025: 0,-32
+            6026: 0,-33
+            6027: 0,-34
+            6075: 0,-35
+            6076: 0,-36
+            6077: 0,-37
+            6078: 0,-38
+            6079: 0,-39
+            6080: 0,-40
+            6081: 0,-41
+            6101: 5,-43
+            6102: 5,-44
+            6131: 5,-45
+            6142: -2,-47
+            6236: 4,-54
+            6237: 4,-55
+            6238: 4,-56
+            6239: 4,-57
+            6240: 4,-58
+            6241: 4,-59
+            6242: 4,-60
+            6243: 4,-61
         - node:
             color: '#FFFFFFFF'
             id: HalfTileOverlayGreyscale90
           decals:
-            1251: -35,-16
-            1252: -35,-17
-            1253: -35,-18
-            1457: -35,-34
-            1458: -35,-35
-            1467: -35,-33
-            1484: -31,-27
-            1485: -31,-28
-            1558: -35,-36
-            1559: -35,-37
-            1560: -35,-38
-            1561: -35,-39
-            1562: -35,-40
-            1563: -35,-41
-            1606: -27,-29
-            1607: -27,-28
-            1737: -12,-22
-            1738: -12,-23
-            1739: -12,-24
-            1740: -12,-25
-            2830: 34,-1
-            2831: 34,-2
-            2943: 22,11
-            2944: 22,10
-            5403: 30,-31
-            5404: 30,-30
-            5405: 30,-29
-            5624: 26,-26
-            5649: 12,-20
-            5650: 12,-21
-            5651: 12,-22
-            5652: 12,-23
-            5655: 12,-27
-            5656: 12,-28
-            5657: 12,-29
-            5658: 12,-30
-            5677: 27,-26
-            5723: 36,-15
-            5724: 36,-16
-            5725: 36,-17
-            5726: 36,-18
-            5727: 36,-19
-            5728: 36,-20
-            5729: 36,-21
-            5730: 36,-22
-            5731: 36,-23
-            5775: 17,-23
+            1226: -35,-16
+            1227: -35,-17
+            1228: -35,-18
+            1432: -35,-34
+            1433: -35,-35
+            1442: -35,-33
+            1459: -31,-27
+            1460: -31,-28
+            1533: -35,-36
+            1534: -35,-37
+            1535: -35,-38
+            1536: -35,-39
+            1537: -35,-40
+            1538: -35,-41
+            1581: -27,-29
+            1582: -27,-28
+            1712: -12,-22
+            1713: -12,-23
+            1714: -12,-24
+            1715: -12,-25
+            2805: 34,-1
+            2806: 34,-2
+            2918: 22,11
+            2919: 22,10
+            5378: 30,-31
+            5379: 30,-30
+            5380: 30,-29
+            5599: 26,-26
+            5624: 12,-20
+            5625: 12,-21
+            5626: 12,-22
+            5627: 12,-23
+            5630: 12,-27
+            5631: 12,-28
+            5632: 12,-29
+            5633: 12,-30
+            5652: 27,-26
+            5698: 36,-15
+            5699: 36,-16
+            5700: 36,-17
+            5701: 36,-18
+            5702: 36,-19
+            5703: 36,-20
+            5704: 36,-21
+            5705: 36,-22
+            5706: 36,-23
+            5750: 17,-23
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            1050: -44,6
-            1051: -44,7
-            1154: -43,0
-            2654: -35,11
-            2655: -35,12
-            3124: 32,15
-            3546: 28,16
-            4316: -10,43
-            4787: 3,46
-            5553: 8,-28
+            1049: -44,6
+            1050: -44,7
+            1153: -43,0
+            2629: -35,11
+            2630: -35,12
+            3099: 32,15
+            3521: 28,16
+            4291: -10,43
+            4762: 3,46
+            5528: 8,-28
         - node:
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
             945: -26,10
-            4125: -8,26
-            7024: 16,-40
+            4100: -8,26
+            6999: 16,-40
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            1152: -43,-2
-            1153: -38,-1
-            1631: -22,-20
-            3123: 33,20
-            4786: 3,50
-            5552: 6,-22
+            1151: -43,-2
+            1152: -38,-1
+            1606: -22,-20
+            3098: 33,20
+            4761: 3,50
+            5527: 6,-22
         - node:
             angle: 3.141592653589793 rad
             color: '#FFFFFFFF'
             id: LoadingArea
           decals:
-            1413: -36,-33
-            4271: -17,36
-            4315: -10,39
-            4514: -28,28
-            6978: 19,-49
-            6979: 18,-49
-            6980: 17,-49
-            6981: 16,-49
+            1388: -36,-33
+            4246: -17,36
+            4290: -10,39
+            4489: -28,28
+            6953: 19,-49
+            6954: 18,-49
+            6955: 17,-49
+            6956: 16,-49
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: LoadingAreaGreyscale
           decals:
-            6982: 21,-52
-            6983: 21,-51
+            6957: 21,-52
+            6958: 21,-51
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale
@@ -7056,11 +7051,11 @@ entities:
             308: 5,-10
             309: -1,-10
             312: 11,-4
-            3769: 42,-11
-            3778: 40,-7
-            4794: 0,48
-            4816: 2,49
-            4938: 4,59
+            3744: 42,-11
+            3753: 40,-7
+            4769: 0,48
+            4791: 2,49
+            4913: 4,59
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale
@@ -7071,105 +7066,105 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale
           decals:
-            4931: 1,58
-            4941: 4,59
+            4906: 1,58
+            4916: 4,59
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale
           decals:
-            3366: 40,27
+            3341: 40,27
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale
           decals:
-            5419: 27,-32
-            5829: 26,-25
-            5897: 12,-37
-            5926: 23,-36
-            7188: 40,-39
-            7189: 46,-37
-            7190: 45,-38
-            7249: 6,-14
+            5394: 27,-32
+            5804: 26,-25
+            5872: 12,-37
+            5901: 23,-36
+            7163: 40,-39
+            7164: 46,-37
+            7165: 45,-38
+            7224: 6,-14
         - node:
             color: '#6C6C6C93'
             id: QuarterTileOverlayGreyscale
           decals:
-            2954: 23,9
-            2955: 24,9
-            2956: 25,9
-            2957: 26,9
-            2958: 26,10
-            2959: 26,11
+            2929: 23,9
+            2930: 24,9
+            2931: 25,9
+            2932: 26,9
+            2933: 26,10
+            2934: 26,11
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale
           decals:
-            1035: -42,9
+            1034: -42,9
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale
           decals:
-            7339: -47,-23
-            7350: -48,-18
-            7351: -49,-24
-            7352: -48,-24
+            7314: -47,-23
+            7325: -48,-18
+            7326: -49,-24
+            7327: -48,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale
           decals:
-            1273: -37,-25
-            1277: -38,-23
-            1353: -39,-29
-            1362: -40,-32
-            2340: -20,-46
-            2341: -20,-48
+            1248: -37,-25
+            1252: -38,-23
+            1328: -39,-29
+            1337: -40,-32
+            2315: -20,-46
+            2316: -20,-48
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale
           decals:
             468: -17,2
-            2181: -36,-49
-            2220: -32,-53
-            2236: -34,-53
-            2604: -35,10
-            2606: -36,8
-            2667: -1,-21
-            2668: -1,-27
-            3469: 28,2
-            3521: 28,8
-            3536: 28,15
-            3561: 28,33
-            3587: 42,29
-            3594: 42,36
-            3595: 42,39
-            3998: -1,20
-            4189: -5,29
-            4198: -14,29
-            4199: -17,29
-            4364: -38,37
-            4412: -38,21
-            4476: -25,30
-            4477: -25,36
-            4671: -1,39
-            6894: 30,-64
-            6903: 31,-54
+            2156: -36,-49
+            2195: -32,-53
+            2211: -34,-53
+            2579: -35,10
+            2581: -36,8
+            2642: -1,-21
+            2643: -1,-27
+            3444: 28,2
+            3496: 28,8
+            3511: 28,15
+            3536: 28,33
+            3562: 42,29
+            3569: 42,36
+            3570: 42,39
+            3973: -1,20
+            4164: -5,29
+            4173: -14,29
+            4174: -17,29
+            4339: -38,37
+            4387: -38,21
+            4451: -25,30
+            4452: -25,36
+            4646: -1,39
+            6869: 30,-64
+            6878: 31,-54
         - node:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale
           decals:
-            3892: -17,16
-            3895: -23,14
-            3929: -30,21
-            3931: -26,18
+            3867: -17,16
+            3870: -23,14
+            3904: -30,21
+            3906: -26,18
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale
           decals:
-            1450: -28,-33
-            1612: -25,-32
-            2950: 26,9
-            5121: 14,-17
-            5129: 20,-16
+            1425: -28,-33
+            1587: -25,-32
+            2925: 26,9
+            5096: 14,-17
+            5104: 20,-16
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale180
@@ -7181,9 +7176,9 @@ entities:
             265: 4,-3
             275: -10,-1
             278: 2,11
-            3768: 33,-6
-            3772: 35,-10
-            3795: 38,-12
+            3743: 33,-6
+            3747: 35,-10
+            3770: 38,-12
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale180
@@ -7194,68 +7189,68 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale180
           decals:
-            4674: -12,45
-            4928: 3,61
-            4933: 0,60
-            4934: 2,60
+            4649: -12,45
+            4903: 3,61
+            4908: 0,60
+            4909: 2,60
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale180
           decals:
-            3350: 31,29
+            3325: 31,29
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2703: 23,-7
-            2733: 18,-7
-            2787: 24,-15
-            5925: 23,-35
-            5927: 23,-36
-            5982: 36,-39
-            7186: 47,-41
-            7187: 40,-39
-            7248: 6,-14
+            2678: 23,-7
+            2708: 18,-7
+            2762: 24,-15
+            5900: 23,-35
+            5902: 23,-36
+            5957: 36,-39
+            7161: 47,-41
+            7162: 40,-39
+            7223: 6,-14
         - node:
             color: '#6C6C6C93'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2952: 22,11
-            2953: 22,10
+            2927: 22,11
+            2928: 22,10
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale180
           decals:
-            1034: -39,7
+            1033: -39,7
         - node:
             color: '#9FED5896'
             id: QuarterTileOverlayGreyscale180
           decals:
             535: 12,12
-            2989: 28,8
-            3194: 43,21
-            3236: 12,20
-            3290: 19,25
-            3291: 23,25
-            5360: 36,-29
-            5850: 27,-25
+            2964: 28,8
+            3169: 43,21
+            3211: 12,20
+            3265: 19,25
+            3266: 23,25
+            5335: 36,-29
+            5825: 27,-25
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale180
           decals:
-            7337: -49,-16
-            7338: -47,-23
-            7347: -43,-16
-            7353: -49,-23
-            7355: -45,-23
-            7356: -45,-20
+            7312: -49,-16
+            7313: -47,-23
+            7322: -43,-16
+            7328: -49,-23
+            7330: -45,-23
+            7331: -45,-20
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale180
           decals:
-            1327: -46,-27
-            2417: -30,-52
-            2418: -27,-53
+            1302: -46,-27
+            2392: -30,-52
+            2393: -27,-53
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale180
@@ -7263,36 +7258,36 @@ entities:
             469: -15,-1
             538: 9,-10
             539: 9,-10
-            2119: -46,-35
-            2182: -38,-46
-            2222: -33,-49
-            2234: -35,-52
-            2607: -33,5
-            2609: -33,9
-            2638: -33,-1
-            2639: -33,-1
-            2642: -29,-1
-            2646: -20,-1
-            2696: 2,17
-            3482: 30,5
-            3498: 31,6
-            3534: 30,15
-            3548: 30,22
-            3570: 30,37
-            3571: 30,34
-            3610: 44,38
-            3616: 44,31
-            3623: 40,27
-            3625: 39,26
-            3633: 30,26
-            4172: -15,27
-            4431: -36,28
-            4500: -23,27
-            4778: 2,45
-            6062: 2,-27
-            6460: 2,25
-            6884: 24,-62
-            6905: 28,-51
+            2094: -46,-35
+            2157: -38,-46
+            2197: -33,-49
+            2209: -35,-52
+            2582: -33,5
+            2584: -33,9
+            2613: -33,-1
+            2614: -33,-1
+            2617: -29,-1
+            2621: -20,-1
+            2671: 2,17
+            3457: 30,5
+            3473: 31,6
+            3509: 30,15
+            3523: 30,22
+            3545: 30,37
+            3546: 30,34
+            3585: 44,38
+            3591: 44,31
+            3598: 40,27
+            3600: 39,26
+            3608: 30,26
+            4147: -15,27
+            4406: -36,28
+            4475: -23,27
+            4753: 2,45
+            6037: 2,-27
+            6435: 2,25
+            6859: 24,-62
+            6880: 28,-51
         - node:
             color: '#D4D4D496'
             id: QuarterTileOverlayGreyscale180
@@ -7302,27 +7297,27 @@ entities:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale180
           decals:
-            4222: -9,32
+            4197: -9,32
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale180
           decals:
-            2502: -17,-53
-            6166: -2,-46
-            6214: 0,-53
+            2477: -17,-53
+            6141: -2,-46
+            6189: 0,-53
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale180
           decals:
-            5266: 32,-22
-            5267: 33,-22
+            5241: 32,-22
+            5242: 33,-22
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale180
           decals:
-            1613: -27,-27
-            5132: 18,-15
-            5647: 12,-19
+            1588: -27,-27
+            5107: 18,-15
+            5622: 12,-19
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale270
@@ -7334,9 +7329,9 @@ entities:
             276: 11,-1
             306: 11,5
             313: 5,11
-            3770: 42,-6
-            3773: 40,-10
-            3794: 36,-12
+            3745: 42,-6
+            3748: 40,-10
+            3769: 36,-12
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale270
@@ -7347,79 +7342,79 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale270
           decals:
-            4929: -2,61
-            4932: 1,60
-            4935: -1,60
+            4904: -2,61
+            4907: 1,60
+            4910: -1,60
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale270
           decals:
-            3367: 40,29
+            3342: 40,29
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale270
           decals:
             571: 8,-13
-            2751: 22,-12
-            2788: 25,-15
-            5930: 26,-35
+            2726: 22,-12
+            2763: 25,-15
+            5905: 26,-35
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale270
           decals:
-            1037: -42,7
+            1036: -42,7
         - node:
             color: '#9FED5896'
             id: QuarterTileOverlayGreyscale270
           decals:
-            2997: 30,8
-            5849: 26,-25
+            2972: 30,8
+            5824: 26,-25
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale270
           decals:
-            7354: -45,-24
+            7329: -45,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale270
           decals:
-            2335: -27,-45
-            2440: -27,-56
-            2441: -24,-56
+            2310: -27,-45
+            2415: -27,-56
+            2416: -24,-56
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale270
           decals:
             470: -17,-1
-            2120: -44,-35
-            2180: -36,-46
-            2223: -32,-49
-            2235: -34,-52
-            2641: -31,-1
-            2645: -22,-1
-            2658: -35,6
-            2669: -1,-29
-            2670: -1,-25
-            3483: 28,5
-            3531: 28,13
-            3558: 28,29
-            3592: 42,34
-            3593: 42,37
-            3621: 42,27
-            3626: 37,26
-            3995: -1,18
-            4171: -17,27
-            4432: -38,28
-            4478: -25,34
-            4502: -25,28
-            4670: -1,36
-            6893: 30,-62
-            6904: 31,-51
+            2095: -44,-35
+            2155: -36,-46
+            2198: -32,-49
+            2210: -34,-52
+            2616: -31,-1
+            2620: -22,-1
+            2633: -35,6
+            2644: -1,-29
+            2645: -1,-25
+            3458: 28,5
+            3506: 28,13
+            3533: 28,29
+            3567: 42,34
+            3568: 42,37
+            3596: 42,27
+            3601: 37,26
+            3970: -1,18
+            4146: -17,27
+            4407: -38,28
+            4453: -25,34
+            4477: -25,28
+            4645: -1,36
+            6868: 30,-62
+            6879: 31,-51
         - node:
             color: '#D4D4D496'
             id: QuarterTileOverlayGreyscale270
           decals:
-            5358: 35,-33
+            5333: 35,-33
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale270
@@ -7434,32 +7429,32 @@ entities:
             524: 9,18
             525: 9,17
             526: 10,17
-            2536: -7,-53
+            2511: -7,-53
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale270
           decals:
-            5268: 30,-22
-            5271: 29,-22
-            5272: 28,-22
-            5273: 28,-21
-            5274: 28,-20
-            5275: 28,-19
-            5276: 28,-18
-            5277: 28,-17
-            5278: 28,-16
-            5297: 31,-19
-            5299: 32,-18
-            5301: 33,-17
+            5243: 30,-22
+            5246: 29,-22
+            5247: 28,-22
+            5248: 28,-21
+            5249: 28,-20
+            5250: 28,-19
+            5251: 28,-18
+            5252: 28,-17
+            5253: 28,-16
+            5272: 31,-19
+            5274: 32,-18
+            5276: 33,-17
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale270
           decals:
-            1451: -33,-27
-            2835: 35,1
-            5122: 14,-14
-            5131: 20,-15
-            5648: 14,-19
+            1426: -33,-27
+            2810: 35,1
+            5097: 14,-14
+            5106: 20,-15
+            5623: 14,-19
         - node:
             color: '#222222E5'
             id: QuarterTileOverlayGreyscale90
@@ -7471,11 +7466,11 @@ entities:
             307: 2,-10
             310: -4,-10
             311: -10,-4
-            3771: 33,-11
-            3779: 35,-7
-            4793: 1,48
-            4815: -1,49
-            4939: -3,59
+            3746: 33,-11
+            3754: 35,-7
+            4768: 1,48
+            4790: -1,49
+            4914: -3,59
         - node:
             color: '#222222E6'
             id: QuarterTileOverlayGreyscale90
@@ -7486,88 +7481,88 @@ entities:
             color: '#334E6DC8'
             id: QuarterTileOverlayGreyscale90
           decals:
-            4930: 0,58
-            4940: -3,59
+            4905: 0,58
+            4915: -3,59
         - node:
             color: '#50BCB193'
             id: QuarterTileOverlayGreyscale90
           decals:
-            3349: 31,27
+            3324: 31,27
         - node:
             color: '#52B4E996'
             id: QuarterTileOverlayGreyscale90
           decals:
             536: 9,-10
-            5418: 26,-32
-            5830: 27,-25
-            5931: 26,-35
-            5984: 35,-38
-            7168: 6,-37
-            7195: 41,-41
-            7245: 6,-13
+            5393: 26,-32
+            5805: 27,-25
+            5906: 26,-35
+            5959: 35,-38
+            7143: 6,-37
+            7170: 41,-41
+            7220: 6,-13
         - node:
             color: '#818181FF'
             id: QuarterTileOverlayGreyscale90
           decals:
-            1036: -39,9
+            1035: -39,9
         - node:
             color: '#A4610696'
             id: QuarterTileOverlayGreyscale90
           decals:
-            7357: -41,-24
+            7332: -41,-24
         - node:
             color: '#D381C996'
             id: QuarterTileOverlayGreyscale90
           decals:
-            1272: -39,-24
-            1359: -40,-34
-            2342: -21,-49
-            2399: -21,-51
+            1247: -39,-24
+            1334: -40,-34
+            2317: -21,-49
+            2374: -21,-51
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale90
           decals:
             467: -15,2
-            2183: -38,-49
-            2221: -33,-53
-            2233: -35,-53
-            2608: -33,7
-            2610: -33,2
-            2672: 2,-24
-            3488: 30,2
-            3518: 20,8
-            3530: 30,8
-            3535: 30,17
-            3549: 30,24
-            3568: 30,39
-            3569: 30,36
-            3575: 30,30
-            3586: 40,29
-            3609: 44,40
-            3615: 44,33
-            3996: 2,19
-            4027: -15,20
-            4196: -12,29
-            4197: -15,29
-            4413: -39,21
-            4489: -23,29
-            4785: 2,47
-            6138: 7,-46
-            6139: 8,-47
-            6458: 2,27
-            6891: 24,-64
-            6906: 28,-54
-            7154: 30,-42
+            2158: -38,-49
+            2196: -33,-53
+            2208: -35,-53
+            2583: -33,7
+            2585: -33,2
+            2647: 2,-24
+            3463: 30,2
+            3493: 20,8
+            3505: 30,8
+            3510: 30,17
+            3524: 30,24
+            3543: 30,39
+            3544: 30,36
+            3550: 30,30
+            3561: 40,29
+            3584: 44,40
+            3590: 44,33
+            3971: 2,19
+            4002: -15,20
+            4171: -12,29
+            4172: -15,29
+            4388: -39,21
+            4464: -23,29
+            4760: 2,47
+            6113: 7,-46
+            6114: 8,-47
+            6433: 2,27
+            6866: 24,-64
+            6881: 28,-54
+            7129: 30,-42
         - node:
             color: '#DE3A3A96'
             id: QuarterTileOverlayGreyscale90
           decals:
             887: -20,6
-            3872: 44,-17
-            3889: -19,14
-            3926: -28,25
-            3927: -27,20
-            4221: -9,34
+            3847: 44,-17
+            3864: -19,14
+            3901: -28,25
+            3902: -27,20
+            4196: -9,34
         - node:
             color: '#EFB34196'
             id: QuarterTileOverlayGreyscale90
@@ -7579,46 +7574,46 @@ entities:
             520: 6,18
             521: 6,19
             522: 5,19
-            2556: -5,-45
-            6107: 0,-42
-            6191: 6,-48
+            2531: -5,-45
+            6082: 0,-42
+            6166: 6,-48
         - node:
             color: '#FF924493'
             id: QuarterTileOverlayGreyscale90
           decals:
-            5279: 28,-16
-            5280: 29,-16
-            5281: 30,-16
-            5282: 31,-16
-            5283: 32,-16
-            5284: 33,-16
-            5285: 34,-16
-            5286: 34,-17
-            5287: 34,-18
-            5288: 34,-19
-            5289: 34,-20
-            5290: 34,-21
-            5292: 30,-21
-            5296: 29,-20
-            5298: 31,-19
-            5300: 32,-18
+            5254: 28,-16
+            5255: 29,-16
+            5256: 30,-16
+            5257: 31,-16
+            5258: 32,-16
+            5259: 33,-16
+            5260: 34,-16
+            5261: 34,-17
+            5262: 34,-18
+            5263: 34,-19
+            5264: 34,-20
+            5265: 34,-21
+            5267: 30,-21
+            5271: 29,-20
+            5273: 31,-19
+            5275: 32,-18
         - node:
             color: '#FFFFFFFF'
             id: QuarterTileOverlayGreyscale90
           decals:
-            2951: 22,9
-            5130: 18,-16
+            2926: 22,9
+            5105: 18,-16
         - node:
             color: '#FFFFFFFF'
             id: Remains
           decals:
-            1932: -8,-43
+            1907: -8,-43
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            3326: 30,16
+            3301: 30,16
         - node:
             color: '#FFFFFFFF'
             id: StandClear
@@ -7626,33 +7621,33 @@ entities:
             531: 4,18
             532: 8,18
             533: 5,13
-            3839: 41,-13
-            3860: 46,-13
-            3861: 46,-7
-            3862: 46,-5
-            3887: 46,-15
-            6491: 11,-66
-            6492: 12,-66
-            6493: 13,-66
-            6530: 4,-70
-            6663: -4,-70
+            3814: 41,-13
+            3835: 46,-13
+            3836: 46,-7
+            3837: 46,-5
+            3862: 46,-15
+            6466: 11,-66
+            6467: 12,-66
+            6468: 13,-66
+            6505: 4,-70
+            6638: -4,-70
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: StandClear
           decals:
-            3418: 46,32
-            3419: 46,39
-            3840: 44,-12
-            3841: 44,-5
+            3393: 46,32
+            3394: 46,39
+            3815: 44,-12
+            3816: 44,-5
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            3782: 39,-7
-            3783: 38,-7
-            3816: 32,-5
-            4814: 2,50
+            3757: 39,-7
+            3758: 38,-7
+            3791: 32,-5
+            4789: 2,50
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale
@@ -7663,75 +7658,75 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            5478: 8,-19
+            5453: 8,-19
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            2996: 30,6
-            3234: 12,17
+            2971: 30,6
+            3209: 12,17
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            7348: -47,-18
+            7323: -47,-18
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            2605: -36,10
-            3512: 16,10
-            3520: 27,8
-            3698: 33,-6
-            4251: -18,36
-            4288: -21,36
-            4361: -38,39
-            4369: -43,37
-            5303: 40,-15
-            6347: -8,-56
-            7132: 10,-41
+            2580: -36,10
+            3487: 16,10
+            3495: 27,8
+            3673: 33,-6
+            4226: -18,36
+            4263: -21,36
+            4336: -38,39
+            4344: -43,37
+            5278: 40,-15
+            6322: -8,-56
+            7107: 10,-41
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
             889: -22,8
-            2735: 27,-3
-            3870: 43,-15
-            3896: -23,16
-            3928: -28,19
-            4100: -17,23
-            4518: -5,34
-            4541: -7,40
-            5465: 4,-19
-            6180: 2,-49
+            2710: 27,-3
+            3845: 43,-15
+            3871: -23,16
+            3903: -28,19
+            4075: -17,23
+            4493: -5,34
+            4516: -7,40
+            5440: 4,-19
+            6155: 2,-49
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            4887: 3,61
-            6123: 6,-42
-            6168: -1,-47
-            6213: -4,-51
+            4862: 3,61
+            6098: 6,-42
+            6143: -1,-47
+            6188: -4,-51
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
-            1447: -28,-32
-            1448: -33,-33
-            1615: -25,-29
-            1718: -21,-29
-            2051: -7,-29
-            5662: 14,-29
-            5673: 23,-26
-            5688: 41,-26
-            5720: 38,-18
+            1422: -28,-32
+            1423: -33,-33
+            1590: -25,-29
+            1693: -21,-29
+            2026: -7,-29
+            5637: 14,-29
+            5648: 23,-26
+            5663: 41,-26
+            5695: 38,-18
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3774: 36,-10
-            3775: 37,-10
-            3800: 43,-12
+            3749: 36,-10
+            3750: 37,-10
+            3775: 43,-12
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale180
@@ -7742,46 +7737,46 @@ entities:
             color: '#334E6DC8'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            4677: -4,43
+            4652: -4,43
         - node:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            2786: 22,-15
-            5480: 10,-20
-            5981: 36,-40
+            2761: 22,-15
+            5455: 10,-20
+            5956: 36,-40
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3111: 37,14
-            3292: 21,25
-            5359: 36,-28
+            3086: 37,14
+            3267: 21,25
+            5334: 36,-28
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
             878: -28,4
-            7336: -42,-17
+            7311: -42,-17
         - node:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            2087: -42,-42
-            2334: -29,-45
+            2062: -42,-42
+            2309: -29,-45
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            3481: 31,5
-            3624: 40,26
-            3688: 42,-11
-            4144: -24,23
-            4184: -3,27
-            4249: -15,31
-            5304: 41,-19
-            6932: 32,-49
-            6947: 32,-65
+            3456: 31,5
+            3599: 40,26
+            3663: 42,-11
+            4119: -24,23
+            4159: -3,27
+            4224: -15,31
+            5279: 41,-19
+            6907: 32,-49
+            6922: 32,-65
         - node:
             color: '#D4D4D496'
             id: ThreeQuarterTileOverlayGreyscale180
@@ -7792,49 +7787,49 @@ entities:
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
             888: -20,7
-            2737: 30,-5
-            3869: 46,-19
-            3891: -17,14
-            3930: -25,20
-            4101: -15,22
-            4215: -9,31
-            4216: -7,32
-            4517: -3,33
-            4542: -3,36
-            5466: 6,-20
-            6178: 4,-51
+            2712: 30,-5
+            3844: 46,-19
+            3866: -17,14
+            3905: -25,20
+            4076: -15,22
+            4190: -9,31
+            4191: -7,32
+            4492: -3,33
+            4517: -3,36
+            5441: 6,-20
+            6153: 4,-51
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            2503: -16,-54
-            2504: -13,-53
-            2537: -7,-54
-            6159: 5,-46
-            6211: -3,-54
+            2478: -16,-54
+            2479: -13,-53
+            2512: -7,-54
+            6134: 5,-46
+            6186: -3,-54
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale180
           decals:
-            1445: -31,-30
-            1573: -35,-42
-            1614: -27,-30
-            1719: -24,-27
-            1730: -12,-27
-            1731: -18,-27
-            2054: -4,-27
-            5653: 12,-24
-            5690: 36,-24
-            5698: 17,-24
-            5699: 24,-24
-            5700: 30,-24
+            1420: -31,-30
+            1548: -35,-42
+            1589: -27,-30
+            1694: -24,-27
+            1705: -12,-27
+            1706: -18,-27
+            2029: -4,-27
+            5628: 12,-24
+            5665: 36,-24
+            5673: 17,-24
+            5674: 24,-24
+            5675: 30,-24
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3776: 39,-10
-            3777: 38,-10
-            3790: 32,-12
+            3751: 39,-10
+            3752: 38,-10
+            3765: 32,-12
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale270
@@ -7845,12 +7840,12 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            5481: 8,-20
+            5456: 8,-20
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3094: 32,14
+            3069: 32,14
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale270
@@ -7860,69 +7855,69 @@ entities:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            2086: -44,-42
-            2332: -25,-45
+            2061: -44,-42
+            2307: -25,-45
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            3480: 27,5
-            3687: 33,-11
-            4030: -17,18
-            4248: -18,31
-            4287: -21,31
-            5305: 40,-19
-            6089: -1,-43
-            6329: -8,-61
-            6957: 22,-65
+            3455: 27,5
+            3662: 33,-11
+            4005: -17,18
+            4223: -18,31
+            4262: -21,31
+            5280: 40,-19
+            6064: -1,-43
+            6304: -8,-61
+            6932: 22,-65
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            2734: 27,-5
-            3871: 43,-19
-            3888: -20,14
-            3932: -25,16
-            4102: -17,22
-            4214: -13,31
-            4516: -5,33
-            4540: -7,36
-            5467: 4,-20
-            6177: 2,-51
+            2709: 27,-5
+            3846: 43,-19
+            3863: -20,14
+            3907: -25,16
+            4077: -17,22
+            4189: -13,31
+            4491: -5,33
+            4515: -7,36
+            5442: 4,-20
+            6152: 2,-51
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            2534: -6,-51
-            6099: 1,-41
-            6158: 6,-46
-            6176: 7,-47
-            6212: -1,-53
+            2509: -6,-51
+            6074: 1,-41
+            6133: 6,-46
+            6151: 7,-47
+            6187: -1,-53
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale270
           decals:
-            1249: -33,-17
-            1446: -29,-30
-            1449: -33,-30
-            1486: -29,-27
-            1720: -22,-27
-            1728: -16,-27
-            1729: -10,-27
-            5691: 38,-24
-            5695: 32,-24
-            5696: 26,-24
-            5697: 19,-24
-            5712: 14,-24
-            5721: 38,-16
+            1224: -33,-17
+            1421: -29,-30
+            1424: -33,-30
+            1461: -29,-27
+            1695: -22,-27
+            1703: -16,-27
+            1704: -10,-27
+            5666: 38,-24
+            5670: 32,-24
+            5671: 26,-24
+            5672: 19,-24
+            5687: 14,-24
+            5696: 38,-16
         - node:
             color: '#222222E5'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            3780: 36,-7
-            3781: 37,-7
-            3807: 43,-5
-            4813: -1,50
+            3755: 36,-7
+            3756: 37,-7
+            3782: 43,-5
+            4788: -1,50
         - node:
             color: '#222222E6'
             id: ThreeQuarterTileOverlayGreyscale90
@@ -7933,393 +7928,394 @@ entities:
             color: '#52B4E996'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            2750: 22,-13
-            5479: 10,-19
-            5983: 32,-37
+            2725: 22,-13
+            5454: 10,-19
+            5958: 32,-37
         - node:
             color: '#9FED5896'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
             534: 12,15
-            2965: 28,6
-            3112: 37,18
-            3193: 42,23
-            3235: 12,22
-            3288: 18,27
+            2940: 28,6
+            3087: 37,18
+            3168: 42,23
+            3210: 12,22
+            3263: 18,27
         - node:
             color: '#A4610696'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            7340: -49,-21
-            7341: -49,-22
+            7315: -49,-21
+            7316: -49,-22
         - node:
             color: '#D381C996'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            2345: -20,-49
+            2320: -20,-49
         - node:
             color: '#D4D4D428'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            3494: 36,2
-            3516: 20,10
-            3519: 21,8
-            3585: 40,30
-            3697: 42,-6
-            4143: -24,25
-            4250: -15,36
-            4362: -37,39
-            5302: 41,-15
-            6339: 0,-56
-            6933: 32,-50
-            7152: 30,-41
-            7153: 32,-42
+            3469: 36,2
+            3491: 20,10
+            3494: 21,8
+            3560: 40,30
+            3672: 42,-6
+            4118: -24,25
+            4225: -15,36
+            4337: -37,39
+            5277: 41,-15
+            6314: 0,-56
+            6908: 32,-50
+            7127: 30,-41
+            7128: 32,-42
         - node:
             color: '#DE3A3A96'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            2736: 30,-3
-            3867: 44,-15
-            3868: 46,-17
-            3968: -33,20
-            4099: -15,23
-            4217: -7,34
-            4219: -9,35
-            4519: -3,34
-            4543: -3,40
-            5464: 6,-19
-            6179: 4,-49
+            2711: 30,-3
+            3842: 44,-15
+            3843: 46,-17
+            3943: -33,20
+            4074: -15,23
+            4192: -7,34
+            4194: -9,35
+            4494: -3,34
+            4518: -3,40
+            5439: 6,-19
+            6154: 4,-49
         - node:
             color: '#EFB34196'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            4886: -2,61
-            6122: 5,-42
+            4861: -2,61
+            6097: 5,-42
         - node:
             color: '#FFFFFFFF'
             id: ThreeQuarterTileOverlayGreyscale90
           decals:
-            1717: -23,-29
-            2045: -9,-29
-            2829: 34,0
-            5654: 12,-26
-            5689: 39,-26
+            1692: -23,-29
+            2020: -9,-29
+            2804: 34,0
+            5629: 12,-26
+            5664: 39,-26
         - node:
             color: '#FFFFFFFF'
             id: WarnBox
           decals:
-            1061: -37,8
-            1062: -37,9
-            1063: -37,10
-            1116: -37,-2
-            1401: -33,-26
-            1402: -34,-26
-            1403: -35,-26
-            4115: -14,26
-            4116: -11,26
-            4117: -5,26
-            4831: 1,53
-            4832: 0,53
-            5157: 18,-19
-            5158: 17,-19
-            5352: 47,-32
-            5578: 20,-26
-            5853: 23,-29
-            5858: 11,-31
+            1060: -37,8
+            1061: -37,9
+            1062: -37,10
+            1115: -37,-2
+            1376: -33,-26
+            1377: -34,-26
+            1378: -35,-26
+            4090: -14,26
+            4091: -11,26
+            4092: -5,26
+            4806: 1,53
+            4807: 0,53
+            5132: 18,-19
+            5133: 17,-19
+            5327: 47,-32
+            5553: 20,-26
+            5828: 23,-29
+            5833: 11,-31
+            7538: -29,-13
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
             id: WarnBox
           decals:
-            2108: -45,-44
-            2110: -48,-35
+            2083: -45,-44
+            2085: -48,-35
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNE
           decals:
             502: 4,17
             837: -29,-7
-            1238: -33,16
-            1405: -34,-28
-            1414: -36,-33
-            1636: -21,-21
-            2164: -36,-46
-            2209: -34,-52
-            2213: -32,-49
-            2319: -80,-51
-            2320: -79,-52
-            3138: 35,17
-            3146: 36,13
-            3170: 40,17
-            3415: 44,26
-            4329: -28,32
-            4386: -40,30
-            4617: 5,39
-            4620: 8,39
-            4621: 8,42
-            4622: 5,42
-            5557: 9,-28
-            6151: 0,-48
-            6285: 2,-59
-            6321: -1,-57
-            6598: 8,-69
-            6605: -5,-69
-            6620: -1,-73
-            6628: -1,-74
-            6655: 7,-74
-            6846: 27,-51
-            7019: 36,-47
-            7066: 31,-43
-            7067: 29,-42
-            7080: 14,-43
-            7272: 30,-55
-            7465: -1,-57
-            7555: 14,-58
+            1380: -34,-28
+            1389: -36,-33
+            1611: -21,-21
+            2139: -36,-46
+            2184: -34,-52
+            2188: -32,-49
+            2294: -80,-51
+            2295: -79,-52
+            3113: 35,17
+            3121: 36,13
+            3145: 40,17
+            3390: 44,26
+            4304: -28,32
+            4361: -40,30
+            4592: 5,39
+            4595: 8,39
+            4596: 8,42
+            4597: 5,42
+            5532: 9,-28
+            6126: 0,-48
+            6260: 2,-59
+            6296: -1,-57
+            6573: 8,-69
+            6580: -5,-69
+            6595: -1,-73
+            6603: -1,-74
+            6630: 7,-74
+            6821: 27,-51
+            6994: 36,-47
+            7041: 31,-43
+            7042: 29,-42
+            7055: 14,-43
+            7247: 30,-55
+            7440: -1,-57
+            7530: 14,-58
+            7540: -28,-12
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerNW
           decals:
-            1168: -45,-10
-            1237: -35,16
-            1404: -35,-28
-            1637: -25,-21
-            2208: -35,-52
-            2214: -33,-49
-            2317: -82,-51
-            2318: -83,-52
-            3137: 34,17
-            3141: 38,17
-            3145: 32,13
-            3414: 42,26
-            4618: 7,39
-            4619: 4,39
-            4623: 4,42
-            4624: 7,42
-            5332: 46,-31
-            5558: 5,-28
-            6150: -3,-48
-            6322: -7,-57
-            6325: 0,-59
-            6383: -16,-58
-            6595: 5,-69
-            6604: -8,-69
-            6621: 1,-73
-            6629: 1,-74
-            6635: -7,-74
-            6845: 20,-51
-            6863: 24,-55
-            7088: 12,-43
-            7100: 11,-42
-            7464: -7,-57
-            7558: 12,-58
+            1167: -45,-10
+            1379: -35,-28
+            1612: -25,-21
+            2183: -35,-52
+            2189: -33,-49
+            2292: -82,-51
+            2293: -83,-52
+            3112: 34,17
+            3116: 38,17
+            3120: 32,13
+            3389: 42,26
+            4593: 7,39
+            4594: 4,39
+            4598: 4,42
+            4599: 7,42
+            5307: 46,-31
+            5533: 5,-28
+            6125: -3,-48
+            6297: -7,-57
+            6300: 0,-59
+            6358: -16,-58
+            6570: 5,-69
+            6579: -8,-69
+            6596: 1,-73
+            6604: 1,-74
+            6610: -7,-74
+            6820: 20,-51
+            6838: 24,-55
+            7063: 12,-43
+            7075: 11,-42
+            7439: -7,-57
+            7533: 12,-58
+            7542: -30,-12
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSE
           decals:
-            1071: -44,8
-            1177: -39,-13
-            1236: -33,14
-            1406: -34,-30
-            1635: -21,-25
-            2170: -36,-49
-            2215: -32,-53
-            2230: -34,-53
-            2231: -34,-53
-            2315: -80,-55
-            2316: -79,-54
-            3136: 35,15
-            3150: 32,18
-            3155: 36,19
-            4608: 6,35
-            4616: 5,38
-            4627: 8,41
-            4628: 5,41
-            5003: 5,72
-            5560: 9,-22
-            6144: 4,-45
-            6149: 0,-49
-            6277: 2,-57
-            6284: 2,-61
-            6320: -1,-60
-            6597: 8,-71
-            6606: -5,-71
-            6651: 6,-77
-            6654: 7,-75
-            6860: 27,-54
-            7036: 29,-40
-            7037: 21,-40
-            7061: 31,-48
-            7091: 14,-47
-            7281: 30,-61
-            7545: 37,-47
-            7556: 14,-60
+            1070: -44,8
+            1176: -39,-13
+            1381: -34,-30
+            1610: -21,-25
+            2145: -36,-49
+            2190: -32,-53
+            2205: -34,-53
+            2206: -34,-53
+            2290: -80,-55
+            2291: -79,-54
+            3111: 35,15
+            3125: 32,18
+            3130: 36,19
+            4583: 6,35
+            4591: 5,38
+            4602: 8,41
+            4603: 5,41
+            4978: 5,72
+            5535: 9,-22
+            6119: 4,-45
+            6124: 0,-49
+            6252: 2,-57
+            6259: 2,-61
+            6295: -1,-60
+            6572: 8,-71
+            6581: -5,-71
+            6626: 6,-77
+            6629: 7,-75
+            6835: 27,-54
+            7011: 29,-40
+            7012: 21,-40
+            7036: 31,-48
+            7066: 14,-47
+            7256: 30,-61
+            7520: 37,-47
+            7531: 14,-60
+            7541: -28,-14
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSW
           decals:
             507: 7,19
             881: -30,8
-            1235: -35,14
-            1407: -35,-30
-            1634: -25,-25
-            1788: -21,-32
-            2216: -33,-53
-            2232: -35,-53
-            2313: -82,-55
-            2314: -83,-54
-            3135: 34,15
-            3142: 38,14
-            3153: 34,19
-            3157: 38,19
-            4340: -28,36
-            4615: 7,38
-            4625: 4,41
-            4626: 7,41
-            5002: -3,72
-            5331: 46,-33
-            5559: 5,-22
-            6142: -2,-45
-            6143: 2,-45
-            6148: -3,-49
-            6319: -7,-60
-            6366: -16,-59
-            6385: -16,-56
-            6596: 5,-71
-            6607: -8,-71
-            6636: -7,-75
-            6639: -6,-77
-            6844: 20,-52
-            6856: 22,-54
-            6868: 24,-61
-            7025: 17,-40
-            7079: 12,-47
-            7101: 11,-48
-            7535: 34,-42
-            7557: 12,-60
+            1382: -35,-30
+            1609: -25,-25
+            1763: -21,-32
+            2191: -33,-53
+            2207: -35,-53
+            2288: -82,-55
+            2289: -83,-54
+            3110: 34,15
+            3117: 38,14
+            3128: 34,19
+            3132: 38,19
+            4315: -28,36
+            4590: 7,38
+            4600: 4,41
+            4601: 7,41
+            4977: -3,72
+            5306: 46,-33
+            5534: 5,-22
+            6117: -2,-45
+            6118: 2,-45
+            6123: -3,-49
+            6294: -7,-60
+            6341: -16,-59
+            6360: -16,-56
+            6571: 5,-71
+            6582: -8,-71
+            6611: -7,-75
+            6614: -6,-77
+            6819: 20,-52
+            6831: 22,-54
+            6843: 24,-61
+            7000: 17,-40
+            7054: 12,-47
+            7076: 11,-48
+            7510: 34,-42
+            7532: 12,-60
+            7539: -30,-14
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNE
           decals:
             836: -31,-7
-            1222: -33,-15
-            1266: -32,-21
-            1397: -36,-27
-            1523: -33,-42
-            1835: -7,-25
-            2324: -79,-53
-            2325: -80,-52
-            6378: -12,-58
-            6615: -5,-73
-            6984: 32,-53
-            7069: 29,-43
-            7554: 36,-43
+            1221: -33,-15
+            1241: -32,-21
+            1372: -36,-27
+            1498: -33,-42
+            1810: -7,-25
+            2299: -79,-53
+            2300: -80,-52
+            6353: -12,-58
+            6590: -5,-73
+            6959: 32,-53
+            7044: 29,-43
+            7529: 36,-43
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallNW
           decals:
-            1129: -40,3
-            1174: -42,-9
-            1396: -29,-21
-            1842: -1,-25
-            2326: -82,-52
-            6323: -7,-58
-            6381: -14,-58
-            6594: 5,-70
-            6625: 5,-73
-            7470: -7,-58
+            1128: -40,3
+            1173: -42,-9
+            1371: -29,-21
+            1817: -1,-25
+            2301: -82,-52
+            6298: -7,-58
+            6356: -14,-58
+            6569: 5,-70
+            6600: 5,-73
+            7445: -7,-58
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSE
           decals:
-            1067: -44,12
-            1221: -33,-11
-            1522: -33,-37
-            1834: -7,-21
-            2136: -42,-35
-            2322: -80,-54
-            2323: -79,-53
-            4613: 4,38
-            6283: 2,-53
-            6374: -10,-59
-            6573: -5,-65
-            6653: 6,-75
-            7162: 32,-48
-            7549: 37,-44
+            1066: -44,12
+            1220: -33,-11
+            1497: -33,-37
+            1809: -7,-21
+            2111: -42,-35
+            2297: -80,-54
+            2298: -79,-53
+            4588: 4,38
+            6258: 2,-53
+            6349: -10,-59
+            6548: -5,-65
+            6628: 6,-75
+            7137: 32,-48
+            7524: 37,-44
         - node:
             color: '#FFFFFFFF'
             id: WarnCornerSmallSW
           decals:
-            1151: -40,-5
-            1843: -1,-21
-            2105: -43,-43
-            2321: -82,-54
-            4614: 8,38
-            6324: -7,-59
-            6370: -12,-59
-            6583: 5,-65
-            6593: 5,-70
-            6637: -6,-75
-            6854: 22,-52
-            7469: -7,-59
+            1150: -40,-5
+            1818: -1,-21
+            2080: -43,-43
+            2296: -82,-54
+            4589: 8,38
+            6299: -7,-59
+            6345: -12,-59
+            6558: 5,-65
+            6568: 5,-70
+            6612: -6,-75
+            6829: 22,-52
+            7444: -7,-59
         - node:
             color: '#FFFFFFFF'
             id: WarnEndE
           decals:
-            1633: -23,-19
-            2312: -77,-53
-            5860: 6,-29
-            6805: 22,-50
-            7477: -2,-70
+            1608: -23,-19
+            2287: -77,-53
+            5835: 6,-29
+            6780: 22,-50
+            7452: -2,-70
         - node:
             color: '#FFFFFFFF'
             id: WarnEndN
           decals:
-            1113: -37,-3
-            1117: -37,3
-            5074: -5,77
+            1112: -37,-3
+            1116: -37,3
+            5049: -5,77
         - node:
             color: '#FFFFFFFF'
             id: WarnEndS
           decals:
-            1112: -37,-5
-            1118: -37,-1
-            2064: -3,-27
-            4611: 4,37
-            4612: 8,37
-            5075: -5,76
+            1111: -37,-5
+            1117: -37,-1
+            2039: -3,-27
+            4586: 4,37
+            4587: 8,37
+            5050: -5,76
         - node:
             color: '#FFFFFFFF'
             id: WarnEndW
           decals:
-            1416: -29,-28
-            1632: -24,-19
-            2247: -44,-53
-            5859: 5,-29
-            6806: 20,-50
+            1391: -29,-28
+            1607: -24,-19
+            2222: -44,-53
+            5834: 5,-29
+            6781: 20,-50
         - node:
             color: '#FFFFFFFF'
             id: WarnFull
           decals:
-            996: -32,11
-            997: -32,12
-            1183: -39,-7
-            1256: -32,-14
-            1257: -32,-13
-            1258: -31,-20
-            1259: -30,-20
-            1352: -50,-27
-            1528: -32,-40
-            1529: -32,-39
-            1530: -32,-38
-            1836: -2,-23
-            1837: -2,-22
-            1838: -2,-24
-            2137: -41,-37
-            2138: -41,-36
-            6985: 33,-49
-            6986: 33,-50
-            6987: 33,-51
-            6988: 33,-52
+            995: -32,11
+            996: -32,12
+            1182: -39,-7
+            1231: -32,-14
+            1232: -32,-13
+            1233: -31,-20
+            1234: -30,-20
+            1327: -50,-27
+            1503: -32,-40
+            1504: -32,-39
+            1505: -32,-38
+            1811: -2,-23
+            1812: -2,-22
+            1813: -2,-24
+            2112: -41,-37
+            2113: -41,-36
+            6960: 33,-49
+            6961: 33,-50
+            6962: 33,-51
+            6963: 33,-52
         - node:
             color: '#FFFFFFFF'
             id: WarnLineE
@@ -8336,152 +8332,151 @@ entities:
             833: -31,-5
             834: -31,-4
             835: -31,-3
-            998: -33,10
-            999: -33,11
-            1000: -33,12
-            1068: -44,11
-            1069: -44,10
-            1070: -44,9
-            1114: -37,-4
-            1122: -37,2
-            1123: -37,1
-            1124: -37,0
-            1178: -39,-12
-            1179: -39,-11
-            1180: -39,-10
-            1181: -39,-9
-            1182: -39,-8
-            1218: -33,-14
-            1219: -33,-13
-            1220: -33,-12
-            1240: -33,15
-            1246: -35,15
-            1408: -34,-29
-            1415: -36,-34
-            1524: -33,-41
-            1525: -33,-40
-            1526: -33,-39
-            1527: -33,-38
-            1638: -21,-22
-            1639: -21,-23
-            1640: -21,-24
-            1790: -23,-34
-            1791: -23,-32
-            1792: -23,-33
-            1793: -23,-31
-            1794: -21,-34
-            1795: -21,-33
-            1797: -20,-33
-            1827: -7,-24
-            1828: -7,-23
-            1829: -7,-22
-            2130: -43,-30
-            2131: -43,-31
-            2134: -42,-37
-            2135: -42,-36
-            2165: -36,-47
-            2171: -36,-48
-            2217: -32,-52
-            2218: -32,-51
-            2219: -32,-50
-            2253: -27,-49
-            2254: -27,-48
-            2255: -27,-47
-            3139: 35,16
-            3151: 32,19
-            3152: 32,20
-            3158: 30,16
-            3416: 46,32
-            3421: 46,39
-            3542: 30,15
-            3543: 30,14
-            3544: 30,17
-            3545: 30,13
-            4284: -13,38
-            4285: -13,39
-            4286: -13,40
-            4387: -40,29
-            4388: -40,28
-            4629: 8,38
-            4738: 13,46
-            4739: 13,47
-            4740: 11,46
-            4741: 11,47
-            5041: 6,80
-            5042: 6,79
-            5043: 6,78
-            5044: 6,77
-            5045: 6,76
-            5046: 6,75
-            5047: 6,74
-            5083: -5,74
-            5084: -5,75
-            5085: -5,78
-            5086: -5,79
-            5087: -5,80
-            5088: -8,79
-            5133: 14,-17
-            5134: 14,-16
-            5135: 14,-15
-            5136: 14,-14
-            5564: 11,-24
-            5565: 11,-25
-            5566: 11,-25
-            5567: 11,-26
-            6278: 2,-56
-            6279: 2,-55
-            6280: 2,-54
-            6286: 2,-60
-            6311: -1,-59
-            6312: -1,-58
-            6375: -10,-60
-            6379: -12,-57
-            6570: -5,-68
-            6571: -5,-67
-            6572: -5,-66
-            6603: 8,-70
-            6612: -5,-70
-            6614: -5,-72
-            6652: 6,-76
-            6861: 27,-53
-            6862: 27,-52
-            6871: 30,-60
-            6872: 30,-59
-            6873: 30,-58
-            6874: 30,-57
-            6875: 30,-56
-            6989: 32,-49
-            6990: 32,-50
-            6991: 32,-51
-            6992: 32,-52
-            7062: 31,-47
-            7063: 31,-46
-            7064: 31,-45
-            7065: 31,-44
-            7102: 14,-46
-            7103: 14,-45
-            7105: 14,-44
-            7466: -1,-58
-            7467: -1,-59
-            7546: 37,-46
-            7547: 37,-45
-            7550: 38,-44
-            7551: 38,-43
-            7561: 14,-59
+            997: -33,10
+            998: -33,11
+            999: -33,12
+            1067: -44,11
+            1068: -44,10
+            1069: -44,9
+            1113: -37,-4
+            1121: -37,2
+            1122: -37,1
+            1123: -37,0
+            1177: -39,-12
+            1178: -39,-11
+            1179: -39,-10
+            1180: -39,-9
+            1181: -39,-8
+            1217: -33,-14
+            1218: -33,-13
+            1219: -33,-12
+            1383: -34,-29
+            1390: -36,-34
+            1499: -33,-41
+            1500: -33,-40
+            1501: -33,-39
+            1502: -33,-38
+            1613: -21,-22
+            1614: -21,-23
+            1615: -21,-24
+            1765: -23,-34
+            1766: -23,-32
+            1767: -23,-33
+            1768: -23,-31
+            1769: -21,-34
+            1770: -21,-33
+            1772: -20,-33
+            1802: -7,-24
+            1803: -7,-23
+            1804: -7,-22
+            2105: -43,-30
+            2106: -43,-31
+            2109: -42,-37
+            2110: -42,-36
+            2140: -36,-47
+            2146: -36,-48
+            2192: -32,-52
+            2193: -32,-51
+            2194: -32,-50
+            2228: -27,-49
+            2229: -27,-48
+            2230: -27,-47
+            3114: 35,16
+            3126: 32,19
+            3127: 32,20
+            3133: 30,16
+            3391: 46,32
+            3396: 46,39
+            3517: 30,15
+            3518: 30,14
+            3519: 30,17
+            3520: 30,13
+            4259: -13,38
+            4260: -13,39
+            4261: -13,40
+            4362: -40,29
+            4363: -40,28
+            4604: 8,38
+            4713: 13,46
+            4714: 13,47
+            4715: 11,46
+            4716: 11,47
+            5016: 6,80
+            5017: 6,79
+            5018: 6,78
+            5019: 6,77
+            5020: 6,76
+            5021: 6,75
+            5022: 6,74
+            5058: -5,74
+            5059: -5,75
+            5060: -5,78
+            5061: -5,79
+            5062: -5,80
+            5063: -8,79
+            5108: 14,-17
+            5109: 14,-16
+            5110: 14,-15
+            5111: 14,-14
+            5539: 11,-24
+            5540: 11,-25
+            5541: 11,-25
+            5542: 11,-26
+            6253: 2,-56
+            6254: 2,-55
+            6255: 2,-54
+            6261: 2,-60
+            6286: -1,-59
+            6287: -1,-58
+            6350: -10,-60
+            6354: -12,-57
+            6545: -5,-68
+            6546: -5,-67
+            6547: -5,-66
+            6578: 8,-70
+            6587: -5,-70
+            6589: -5,-72
+            6627: 6,-76
+            6836: 27,-53
+            6837: 27,-52
+            6846: 30,-60
+            6847: 30,-59
+            6848: 30,-58
+            6849: 30,-57
+            6850: 30,-56
+            6964: 32,-49
+            6965: 32,-50
+            6966: 32,-51
+            6967: 32,-52
+            7037: 31,-47
+            7038: 31,-46
+            7039: 31,-45
+            7040: 31,-44
+            7077: 14,-46
+            7078: 14,-45
+            7080: 14,-44
+            7441: -1,-58
+            7442: -1,-59
+            7521: 37,-46
+            7522: 37,-45
+            7525: 38,-44
+            7526: 38,-43
+            7536: 14,-59
+            7543: -28,-13
         - node:
             color: '#FFFFFFFF'
             id: WarnLineGreyscaleE
           decals:
-            4320: -27,40
-            4321: -27,39
-            4322: -27,38
+            4295: -27,40
+            4296: -27,39
+            4297: -27,38
         - node:
             color: '#FFFFFFFF'
             id: WarnLineGreyscaleW
           decals:
-            4317: -21,38
-            4318: -21,39
-            4319: -21,40
+            4292: -21,38
+            4293: -21,39
+            4294: -21,40
         - node:
             color: '#FFFFFFFF'
             id: WarnLineN
@@ -8493,201 +8488,200 @@ entities:
             508: 10,19
             879: -28,8
             880: -29,8
-            1064: -41,12
-            1065: -42,12
-            1066: -43,12
-            1148: -41,-5
-            1149: -42,-5
-            1150: -43,-5
-            1175: -41,-13
-            1176: -40,-13
-            1184: -43,-13
-            1185: -44,-13
-            1186: -45,-13
-            1239: -34,14
-            1245: -34,16
-            1641: -22,-25
-            1642: -23,-25
-            1643: -24,-25
-            1656: -22,-17
-            1657: -23,-17
-            1658: -24,-17
-            1659: -25,-17
-            1830: -6,-21
-            1831: -5,-21
-            1832: -4,-21
-            1833: -3,-21
-            2172: -37,-49
-            2173: -38,-49
-            2248: -43,-53
-            2249: -42,-53
-            2328: -81,-55
-            2331: -78,-53
-            3154: 35,19
-            3842: 40,-10
-            3843: 39,-10
-            3844: 38,-10
-            3845: 37,-10
-            3846: 36,-10
-            3847: 35,-10
-            3857: 46,-13
-            3858: 46,-7
-            3859: 46,-5
-            3886: 46,-15
-            4077: -13,22
-            4078: -12,22
-            4079: -10,22
-            4080: -9,22
-            4081: -8,22
-            4082: -7,22
-            4083: -6,22
-            4084: -4,22
-            4085: -3,22
-            4336: -31,36
-            4337: -30,36
-            4338: -29,36
-            4339: -27,36
-            4421: -40,24
-            4422: -41,24
-            4423: -42,24
-            4424: -43,24
-            4609: 5,35
-            4610: 4,35
-            4631: 4,44
-            4632: 5,44
-            4633: 6,44
-            4634: 7,44
-            4635: 8,44
-            4980: 2,52
-            4981: 1,52
-            4982: 0,52
-            4983: -1,52
-            4988: 2,58
-            4989: -1,58
-            4992: 3,72
-            4993: 2,72
-            4994: 1,72
-            4995: 0,72
-            4996: -1,72
-            5258: 34,-15
-            5259: 33,-15
-            5260: 32,-15
-            5261: 31,-15
-            5262: 30,-15
-            5263: 29,-15
-            5264: 28,-15
-            5335: 47,-33
-            5561: 8,-22
-            5562: 7,-22
-            5563: 6,-22
-            6145: 3,-45
-            6146: 0,-45
-            6147: -1,-45
-            6152: -1,-49
-            6153: -2,-49
-            6281: 4,-53
-            6282: 3,-53
-            6305: -8,-59
-            6306: -6,-60
-            6307: -5,-60
-            6308: -4,-60
-            6309: -3,-60
-            6310: -2,-60
-            6367: -15,-59
-            6368: -14,-59
-            6369: -13,-59
-            6372: -9,-59
-            6386: -15,-56
-            6387: -14,-56
-            6388: -13,-56
-            6389: -12,-56
-            6390: -11,-56
-            6391: -10,-56
-            6392: -21,-60
-            6393: -20,-60
-            6394: -19,-60
-            6395: -18,-60
-            6494: 14,-67
-            6495: 13,-67
-            6496: 12,-67
-            6497: 11,-67
-            6498: 10,-67
-            6574: -4,-65
-            6575: -3,-65
-            6576: -2,-65
-            6577: -1,-65
-            6578: 0,-65
-            6579: 1,-65
-            6580: 2,-65
-            6581: 3,-65
-            6582: 4,-65
-            6590: 4,-70
-            6591: 3,-70
-            6592: 2,-70
-            6601: 6,-71
-            6602: 7,-71
-            6608: -7,-71
-            6609: -6,-71
-            6627: 0,-74
-            6640: -5,-77
-            6641: -4,-77
-            6642: -3,-77
-            6643: -2,-77
-            6644: -1,-77
-            6645: 0,-77
-            6646: 1,-77
-            6647: 2,-77
-            6648: 3,-77
-            6649: 4,-77
-            6650: 5,-77
-            6807: 21,-50
-            6853: 21,-52
-            6857: 23,-54
-            6858: 25,-54
-            6859: 26,-54
-            6869: 27,-61
-            6870: 29,-61
-            7017: 35,-42
-            7018: 36,-42
-            7026: 18,-40
-            7027: 19,-40
-            7028: 20,-40
-            7029: 22,-40
-            7030: 23,-40
-            7031: 24,-40
-            7032: 25,-40
-            7033: 26,-40
-            7034: 27,-40
-            7035: 28,-40
-            7043: 12,-48
-            7044: 14,-48
-            7045: 15,-48
-            7046: 16,-48
-            7047: 17,-48
-            7048: 18,-48
-            7049: 19,-48
-            7050: 20,-48
-            7051: 21,-48
-            7052: 22,-48
-            7053: 23,-48
-            7054: 24,-48
-            7055: 25,-48
-            7056: 26,-48
-            7057: 27,-48
-            7058: 28,-48
-            7059: 29,-48
-            7060: 30,-48
-            7104: 13,-48
-            7114: 13,-47
-            7275: 24,-54
-            7278: 25,-61
-            7279: 26,-61
-            7280: 28,-61
-            7468: -4,-60
-            7478: -3,-70
-            7479: -4,-70
-            7548: 38,-44
-            7559: 13,-60
+            1063: -41,12
+            1064: -42,12
+            1065: -43,12
+            1147: -41,-5
+            1148: -42,-5
+            1149: -43,-5
+            1174: -41,-13
+            1175: -40,-13
+            1183: -43,-13
+            1184: -44,-13
+            1185: -45,-13
+            1616: -22,-25
+            1617: -23,-25
+            1618: -24,-25
+            1631: -22,-17
+            1632: -23,-17
+            1633: -24,-17
+            1634: -25,-17
+            1805: -6,-21
+            1806: -5,-21
+            1807: -4,-21
+            1808: -3,-21
+            2147: -37,-49
+            2148: -38,-49
+            2223: -43,-53
+            2224: -42,-53
+            2303: -81,-55
+            2306: -78,-53
+            3129: 35,19
+            3817: 40,-10
+            3818: 39,-10
+            3819: 38,-10
+            3820: 37,-10
+            3821: 36,-10
+            3822: 35,-10
+            3832: 46,-13
+            3833: 46,-7
+            3834: 46,-5
+            3861: 46,-15
+            4052: -13,22
+            4053: -12,22
+            4054: -10,22
+            4055: -9,22
+            4056: -8,22
+            4057: -7,22
+            4058: -6,22
+            4059: -4,22
+            4060: -3,22
+            4311: -31,36
+            4312: -30,36
+            4313: -29,36
+            4314: -27,36
+            4396: -40,24
+            4397: -41,24
+            4398: -42,24
+            4399: -43,24
+            4584: 5,35
+            4585: 4,35
+            4606: 4,44
+            4607: 5,44
+            4608: 6,44
+            4609: 7,44
+            4610: 8,44
+            4955: 2,52
+            4956: 1,52
+            4957: 0,52
+            4958: -1,52
+            4963: 2,58
+            4964: -1,58
+            4967: 3,72
+            4968: 2,72
+            4969: 1,72
+            4970: 0,72
+            4971: -1,72
+            5233: 34,-15
+            5234: 33,-15
+            5235: 32,-15
+            5236: 31,-15
+            5237: 30,-15
+            5238: 29,-15
+            5239: 28,-15
+            5310: 47,-33
+            5536: 8,-22
+            5537: 7,-22
+            5538: 6,-22
+            6120: 3,-45
+            6121: 0,-45
+            6122: -1,-45
+            6127: -1,-49
+            6128: -2,-49
+            6256: 4,-53
+            6257: 3,-53
+            6280: -8,-59
+            6281: -6,-60
+            6282: -5,-60
+            6283: -4,-60
+            6284: -3,-60
+            6285: -2,-60
+            6342: -15,-59
+            6343: -14,-59
+            6344: -13,-59
+            6347: -9,-59
+            6361: -15,-56
+            6362: -14,-56
+            6363: -13,-56
+            6364: -12,-56
+            6365: -11,-56
+            6366: -10,-56
+            6367: -21,-60
+            6368: -20,-60
+            6369: -19,-60
+            6370: -18,-60
+            6469: 14,-67
+            6470: 13,-67
+            6471: 12,-67
+            6472: 11,-67
+            6473: 10,-67
+            6549: -4,-65
+            6550: -3,-65
+            6551: -2,-65
+            6552: -1,-65
+            6553: 0,-65
+            6554: 1,-65
+            6555: 2,-65
+            6556: 3,-65
+            6557: 4,-65
+            6565: 4,-70
+            6566: 3,-70
+            6567: 2,-70
+            6576: 6,-71
+            6577: 7,-71
+            6583: -7,-71
+            6584: -6,-71
+            6602: 0,-74
+            6615: -5,-77
+            6616: -4,-77
+            6617: -3,-77
+            6618: -2,-77
+            6619: -1,-77
+            6620: 0,-77
+            6621: 1,-77
+            6622: 2,-77
+            6623: 3,-77
+            6624: 4,-77
+            6625: 5,-77
+            6782: 21,-50
+            6828: 21,-52
+            6832: 23,-54
+            6833: 25,-54
+            6834: 26,-54
+            6844: 27,-61
+            6845: 29,-61
+            6992: 35,-42
+            6993: 36,-42
+            7001: 18,-40
+            7002: 19,-40
+            7003: 20,-40
+            7004: 22,-40
+            7005: 23,-40
+            7006: 24,-40
+            7007: 25,-40
+            7008: 26,-40
+            7009: 27,-40
+            7010: 28,-40
+            7018: 12,-48
+            7019: 14,-48
+            7020: 15,-48
+            7021: 16,-48
+            7022: 17,-48
+            7023: 18,-48
+            7024: 19,-48
+            7025: 20,-48
+            7026: 21,-48
+            7027: 22,-48
+            7028: 23,-48
+            7029: 24,-48
+            7030: 25,-48
+            7031: 26,-48
+            7032: 27,-48
+            7033: 28,-48
+            7034: 29,-48
+            7035: 30,-48
+            7079: 13,-48
+            7089: 13,-47
+            7250: 24,-54
+            7253: 25,-61
+            7254: 26,-61
+            7255: 28,-61
+            7443: -4,-60
+            7453: -3,-70
+            7454: -4,-70
+            7523: 38,-44
+            7534: 13,-60
+            7544: -29,-14
         - node:
             color: '#FFFFFFFF'
             id: WarnLineS
@@ -8699,110 +8693,109 @@ entities:
             456: -10,4
             457: -10,5
             839: -24,-7
-            1115: -37,-4
-            1119: -37,0
-            1120: -37,1
-            1121: -37,2
-            1125: -40,4
-            1147: -40,-6
-            1242: -35,15
-            1243: -33,15
-            1349: -49,-28
-            1350: -49,-27
-            1351: -49,-26
-            1409: -35,-29
-            1644: -25,-24
-            1645: -25,-23
-            1646: -25,-22
-            1789: -21,-31
-            1798: -20,-33
-            1799: -19,-34
-            1800: -19,-33
-            1801: -19,-32
-            1802: -19,-31
-            1839: -1,-22
-            1840: -1,-23
-            1841: -1,-24
-            2104: -43,-44
-            2132: -45,-30
-            2133: -45,-31
-            2210: -33,-52
-            2211: -33,-51
-            2212: -33,-50
-            2329: -83,-53
-            3140: 34,16
-            3143: 38,15
-            3144: 38,16
-            3156: 34,20
-            3417: 46,32
-            3420: 46,39
-            4281: -18,38
-            4282: -18,39
-            4283: -18,40
-            4341: -29,37
-            4342: -29,38
-            4343: -29,39
-            4606: 8,35
-            4607: 8,34
-            4630: 4,38
-            4736: 13,46
-            4737: 13,47
-            5034: 7,74
-            5035: 7,75
-            5036: 7,76
-            5037: 7,77
-            5038: 7,78
-            5039: 7,79
-            5040: 7,80
-            5076: -4,74
-            5077: -4,75
-            5078: -4,76
-            5079: -4,78
-            5080: -4,79
-            5081: -4,80
-            5082: -4,77
-            5137: 18,-17
-            5138: 18,-16
-            5139: 18,-15
-            5140: 18,-14
-            5333: 46,-32
-            5568: 11,-26
-            5569: 11,-25
-            5570: 11,-24
-            6326: 0,-60
-            6327: 0,-61
-            6363: -16,-62
-            6364: -16,-61
-            6365: -16,-60
-            6371: -12,-60
-            6380: -14,-57
-            6384: -16,-57
-            6584: 5,-66
-            6585: 5,-67
-            6586: 5,-68
-            6613: -8,-70
-            6626: 5,-72
-            6638: -6,-76
-            6855: 22,-53
-            6864: 24,-56
-            6865: 24,-57
-            6866: 24,-58
-            6867: 24,-60
-            7106: 11,-47
-            7107: 11,-46
-            7108: 11,-45
-            7109: 11,-44
-            7110: 11,-43
-            7111: 12,-44
-            7112: 12,-45
-            7113: 12,-46
-            7268: 24,-59
-            7494: 5,-70
-            7541: 34,-44
-            7542: 34,-45
-            7543: 34,-43
-            7544: 34,-46
-            7560: 12,-59
+            1114: -37,-4
+            1118: -37,0
+            1119: -37,1
+            1120: -37,2
+            1124: -40,4
+            1146: -40,-6
+            1324: -49,-28
+            1325: -49,-27
+            1326: -49,-26
+            1384: -35,-29
+            1619: -25,-24
+            1620: -25,-23
+            1621: -25,-22
+            1764: -21,-31
+            1773: -20,-33
+            1774: -19,-34
+            1775: -19,-33
+            1776: -19,-32
+            1777: -19,-31
+            1814: -1,-22
+            1815: -1,-23
+            1816: -1,-24
+            2079: -43,-44
+            2107: -45,-30
+            2108: -45,-31
+            2185: -33,-52
+            2186: -33,-51
+            2187: -33,-50
+            2304: -83,-53
+            3115: 34,16
+            3118: 38,15
+            3119: 38,16
+            3131: 34,20
+            3392: 46,32
+            3395: 46,39
+            4256: -18,38
+            4257: -18,39
+            4258: -18,40
+            4316: -29,37
+            4317: -29,38
+            4318: -29,39
+            4581: 8,35
+            4582: 8,34
+            4605: 4,38
+            4711: 13,46
+            4712: 13,47
+            5009: 7,74
+            5010: 7,75
+            5011: 7,76
+            5012: 7,77
+            5013: 7,78
+            5014: 7,79
+            5015: 7,80
+            5051: -4,74
+            5052: -4,75
+            5053: -4,76
+            5054: -4,78
+            5055: -4,79
+            5056: -4,80
+            5057: -4,77
+            5112: 18,-17
+            5113: 18,-16
+            5114: 18,-15
+            5115: 18,-14
+            5308: 46,-32
+            5543: 11,-26
+            5544: 11,-25
+            5545: 11,-24
+            6301: 0,-60
+            6302: 0,-61
+            6338: -16,-62
+            6339: -16,-61
+            6340: -16,-60
+            6346: -12,-60
+            6355: -14,-57
+            6359: -16,-57
+            6559: 5,-66
+            6560: 5,-67
+            6561: 5,-68
+            6588: -8,-70
+            6601: 5,-72
+            6613: -6,-76
+            6830: 22,-53
+            6839: 24,-56
+            6840: 24,-57
+            6841: 24,-58
+            6842: 24,-60
+            7081: 11,-47
+            7082: 11,-46
+            7083: 11,-45
+            7084: 11,-44
+            7085: 11,-43
+            7086: 12,-44
+            7087: 12,-45
+            7088: 12,-46
+            7243: 24,-59
+            7469: 5,-70
+            7516: 34,-44
+            7517: 34,-45
+            7518: 34,-43
+            7519: 34,-46
+            7535: 12,-59
+            7546: -30,-13
         - node:
             color: '#FFFFFFFF'
             id: WarnLineW
@@ -8818,434 +8811,433 @@ entities:
             829: -25,-4
             830: -24,-4
             831: -30,-7
-            1126: -41,3
-            1127: -42,3
-            1128: -43,3
-            1169: -44,-10
-            1170: -43,-10
-            1171: -45,-9
-            1172: -44,-9
-            1173: -43,-9
-            1241: -34,16
-            1244: -34,14
-            1264: -31,-21
-            1265: -30,-21
-            1398: -35,-27
-            1399: -34,-27
-            1400: -33,-27
-            1647: -24,-21
-            1648: -23,-21
-            1649: -22,-21
-            1823: -3,-25
-            1824: -4,-25
-            1825: -5,-25
-            1826: -6,-25
-            2166: -37,-46
-            2167: -38,-46
-            2250: -43,-53
-            2251: -42,-53
-            2327: -81,-51
-            2330: -78,-53
-            3147: 35,13
-            3148: 34,13
-            3149: 33,13
-            3410: 28,41
-            3411: 29,41
-            3412: 30,41
-            3413: 43,26
-            3848: 35,-7
-            3849: 36,-7
-            3850: 37,-7
-            3851: 38,-7
-            3852: 39,-7
-            3853: 40,-7
-            3854: 46,-5
-            3855: 46,-7
-            3856: 46,-13
-            3885: 46,-15
-            4046: -3,20
-            4047: -4,20
-            4048: -5,20
-            4049: -6,20
-            4050: -7,20
-            4051: -8,20
-            4052: -9,20
-            4053: -10,20
-            4054: -11,20
-            4055: -12,20
-            4056: -13,20
-            4057: -14,20
-            4118: -13,26
-            4119: -12,26
-            4120: -10,26
-            4121: -9,26
-            4122: -6,26
-            4123: -4,26
-            4124: -3,26
-            4126: -8,26
-            4127: -7,26
-            4141: -20,26
-            4142: -21,26
-            4330: -29,32
-            4331: -30,32
-            4332: -31,32
-            4333: -31,36
-            4334: -30,36
-            4335: -29,36
-            4389: -41,30
-            4390: -42,30
-            4391: -43,30
-            4978: -1,53
-            4979: 2,53
-            4997: -1,69
-            4998: 0,69
-            4999: 1,69
-            5000: 2,69
-            5001: 3,69
-            5048: -1,82
-            5049: 0,82
-            5050: 1,82
-            5051: 2,82
-            5052: 3,82
-            5334: 47,-31
-            5554: 6,-28
-            5555: 7,-28
-            5556: 8,-28
-            6154: -2,-48
-            6155: -1,-48
-            6313: -2,-57
-            6314: -3,-57
-            6315: -4,-57
-            6316: -5,-57
-            6317: -6,-57
-            6318: -8,-58
-            6373: -9,-58
-            6376: -10,-58
-            6377: -11,-58
-            6382: -15,-58
-            6396: -18,-62
-            6397: -19,-62
-            6398: -20,-62
-            6399: -21,-62
-            6499: 14,-66
-            6500: 13,-66
-            6501: 12,-66
-            6502: 11,-66
-            6503: 10,-66
-            6587: 4,-70
-            6588: 3,-70
-            6589: 2,-70
-            6599: 7,-69
-            6600: 6,-69
-            6610: -6,-69
-            6611: -7,-69
-            6616: -4,-73
-            6617: -3,-73
-            6618: -2,-73
-            6619: 0,-73
-            6622: 2,-73
-            6623: 3,-73
-            6624: 4,-73
-            6630: -2,-74
-            6631: -3,-74
-            6632: -4,-74
-            6633: -5,-74
-            6634: -6,-74
-            6656: 6,-74
-            6657: 5,-74
-            6658: 4,-74
-            6659: 3,-74
-            6660: 2,-74
-            6808: 21,-50
-            6847: 21,-51
-            6848: 22,-51
-            6849: 24,-51
-            6850: 23,-51
-            6851: 25,-51
-            6852: 26,-51
-            6876: 27,-55
-            6877: 26,-55
-            6878: 25,-55
-            7020: 35,-47
-            7021: 34,-47
-            7068: 30,-43
-            7081: 28,-42
-            7082: 27,-42
-            7083: 26,-42
-            7084: 25,-42
-            7085: 24,-42
-            7086: 23,-42
-            7087: 22,-42
-            7089: 20,-42
-            7090: 21,-42
-            7092: 19,-42
-            7093: 18,-42
-            7094: 17,-42
-            7095: 16,-42
-            7096: 15,-42
-            7097: 14,-42
-            7098: 13,-42
-            7099: 12,-42
-            7115: 13,-43
-            7121: 14,-49
-            7122: 13,-49
-            7123: 12,-49
-            7124: 12,-49
-            7125: 10,-49
-            7269: 28,-55
-            7270: 29,-55
-            7458: -7,-57
-            7459: -6,-57
-            7460: -5,-57
-            7461: -4,-57
-            7462: -3,-57
-            7463: -2,-57
-            7475: -4,-70
-            7476: -3,-70
-            7552: 38,-43
-            7553: 37,-43
-            7562: 13,-58
+            1125: -41,3
+            1126: -42,3
+            1127: -43,3
+            1168: -44,-10
+            1169: -43,-10
+            1170: -45,-9
+            1171: -44,-9
+            1172: -43,-9
+            1239: -31,-21
+            1240: -30,-21
+            1373: -35,-27
+            1374: -34,-27
+            1375: -33,-27
+            1622: -24,-21
+            1623: -23,-21
+            1624: -22,-21
+            1798: -3,-25
+            1799: -4,-25
+            1800: -5,-25
+            1801: -6,-25
+            2141: -37,-46
+            2142: -38,-46
+            2225: -43,-53
+            2226: -42,-53
+            2302: -81,-51
+            2305: -78,-53
+            3122: 35,13
+            3123: 34,13
+            3124: 33,13
+            3385: 28,41
+            3386: 29,41
+            3387: 30,41
+            3388: 43,26
+            3823: 35,-7
+            3824: 36,-7
+            3825: 37,-7
+            3826: 38,-7
+            3827: 39,-7
+            3828: 40,-7
+            3829: 46,-5
+            3830: 46,-7
+            3831: 46,-13
+            3860: 46,-15
+            4021: -3,20
+            4022: -4,20
+            4023: -5,20
+            4024: -6,20
+            4025: -7,20
+            4026: -8,20
+            4027: -9,20
+            4028: -10,20
+            4029: -11,20
+            4030: -12,20
+            4031: -13,20
+            4032: -14,20
+            4093: -13,26
+            4094: -12,26
+            4095: -10,26
+            4096: -9,26
+            4097: -6,26
+            4098: -4,26
+            4099: -3,26
+            4101: -8,26
+            4102: -7,26
+            4116: -20,26
+            4117: -21,26
+            4305: -29,32
+            4306: -30,32
+            4307: -31,32
+            4308: -31,36
+            4309: -30,36
+            4310: -29,36
+            4364: -41,30
+            4365: -42,30
+            4366: -43,30
+            4953: -1,53
+            4954: 2,53
+            4972: -1,69
+            4973: 0,69
+            4974: 1,69
+            4975: 2,69
+            4976: 3,69
+            5023: -1,82
+            5024: 0,82
+            5025: 1,82
+            5026: 2,82
+            5027: 3,82
+            5309: 47,-31
+            5529: 6,-28
+            5530: 7,-28
+            5531: 8,-28
+            6129: -2,-48
+            6130: -1,-48
+            6288: -2,-57
+            6289: -3,-57
+            6290: -4,-57
+            6291: -5,-57
+            6292: -6,-57
+            6293: -8,-58
+            6348: -9,-58
+            6351: -10,-58
+            6352: -11,-58
+            6357: -15,-58
+            6371: -18,-62
+            6372: -19,-62
+            6373: -20,-62
+            6374: -21,-62
+            6474: 14,-66
+            6475: 13,-66
+            6476: 12,-66
+            6477: 11,-66
+            6478: 10,-66
+            6562: 4,-70
+            6563: 3,-70
+            6564: 2,-70
+            6574: 7,-69
+            6575: 6,-69
+            6585: -6,-69
+            6586: -7,-69
+            6591: -4,-73
+            6592: -3,-73
+            6593: -2,-73
+            6594: 0,-73
+            6597: 2,-73
+            6598: 3,-73
+            6599: 4,-73
+            6605: -2,-74
+            6606: -3,-74
+            6607: -4,-74
+            6608: -5,-74
+            6609: -6,-74
+            6631: 6,-74
+            6632: 5,-74
+            6633: 4,-74
+            6634: 3,-74
+            6635: 2,-74
+            6783: 21,-50
+            6822: 21,-51
+            6823: 22,-51
+            6824: 24,-51
+            6825: 23,-51
+            6826: 25,-51
+            6827: 26,-51
+            6851: 27,-55
+            6852: 26,-55
+            6853: 25,-55
+            6995: 35,-47
+            6996: 34,-47
+            7043: 30,-43
+            7056: 28,-42
+            7057: 27,-42
+            7058: 26,-42
+            7059: 25,-42
+            7060: 24,-42
+            7061: 23,-42
+            7062: 22,-42
+            7064: 20,-42
+            7065: 21,-42
+            7067: 19,-42
+            7068: 18,-42
+            7069: 17,-42
+            7070: 16,-42
+            7071: 15,-42
+            7072: 14,-42
+            7073: 13,-42
+            7074: 12,-42
+            7090: 13,-43
+            7096: 14,-49
+            7097: 13,-49
+            7098: 12,-49
+            7099: 12,-49
+            7100: 10,-49
+            7244: 28,-55
+            7245: 29,-55
+            7433: -7,-57
+            7434: -6,-57
+            7435: -5,-57
+            7436: -4,-57
+            7437: -3,-57
+            7438: -2,-57
+            7450: -4,-70
+            7451: -3,-70
+            7527: 38,-43
+            7528: 37,-43
+            7537: 13,-58
+            7545: -29,-12
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNe
           decals:
-            3173: 39,5
-            3176: 38,4
-            3177: 37,5
+            3148: 39,5
+            3151: 38,4
+            3152: 37,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerNw
           decals:
-            3183: 41,5
-            3408: 25,35
+            3158: 41,5
+            3383: 25,35
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinCornerSw
           decals:
-            2862: 33,9
+            2837: 33,9
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndS
           decals:
-            2861: 31,9
-            3172: 39,4
+            2836: 31,9
+            3147: 39,4
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinEndW
           decals:
-            3171: 38,5
+            3146: 38,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerNe
           decals:
-            3178: 37,4
-            3179: 38,2
-            4735: 6,46
+            3153: 37,4
+            3154: 38,2
+            4710: 6,46
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerNw
           decals:
-            3182: 41,2
-            3184: 43,5
-            4734: 9,46
+            3157: 41,2
+            3159: 43,5
+            4709: 9,46
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinInnerSw
           decals:
-            3174: 39,5
+            3149: 39,5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineE
           decals:
-            3175: 38,3
-            4730: 6,47
-            4731: 6,48
-            4732: 6,49
-            4733: 6,50
-            7529: 40,36
-            7530: 40,37
+            3150: 38,3
+            4705: 6,47
+            4706: 6,48
+            4707: 6,49
+            4708: 6,50
+            7504: 40,36
+            7505: 40,37
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineN
           decals:
-            3180: 39,2
-            3181: 40,2
-            3185: 42,5
-            3409: 26,35
-            4728: 8,46
-            4729: 7,46
-            7520: 32,37
-            7521: 33,37
-            7522: 35,37
-            7523: 37,37
-            7524: 39,37
-            7525: 40,37
-            7526: 36,37
-            7533: 34,37
-            7534: 38,37
+            3155: 39,2
+            3156: 40,2
+            3160: 42,5
+            3384: 26,35
+            4703: 8,46
+            4704: 7,46
+            7495: 32,37
+            7496: 33,37
+            7497: 35,37
+            7498: 37,37
+            7499: 39,37
+            7500: 40,37
+            7501: 36,37
+            7508: 34,37
+            7509: 38,37
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineS
           decals:
-            2863: 34,9
-            2864: 35,9
-            4717: -3,54
-            4718: -4,54
-            4719: -5,54
-            4720: -6,54
-            4721: -7,54
-            4722: -8,54
-            4723: -9,54
-            5312: 44,-22
-            5313: 43.996502,-21.948832
-            5314: 43.996502,-21.99856
-            5315: 43.996502,-21.973696
-            7513: 32,36
-            7514: 33,36
-            7515: 35,36
-            7516: 36,36
-            7517: 37,36
-            7518: 39,36
-            7519: 40,36
-            7531: 34,36
-            7532: 38,36
+            2838: 34,9
+            2839: 35,9
+            4692: -3,54
+            4693: -4,54
+            4694: -5,54
+            4695: -6,54
+            4696: -7,54
+            4697: -8,54
+            4698: -9,54
+            5287: 44,-22
+            5288: 43.996502,-21.948832
+            5289: 43.996502,-21.99856
+            5290: 43.996502,-21.973696
+            7488: 32,36
+            7489: 33,36
+            7490: 35,36
+            7491: 36,36
+            7492: 37,36
+            7493: 39,36
+            7494: 40,36
+            7506: 34,36
+            7507: 38,36
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineW
           decals:
-            2859: 31,11
-            2860: 31,10
-            3186: 41,3
-            3187: 41,4
-            3188: 43,6
-            3189: 43,7
-            3190: 43,8
-            3191: 43,9
-            4724: 9,50
-            4725: 9,49
-            4726: 9,48
-            4727: 9,47
-            7527: 32,37
-            7528: 32,36
-            7536: -11,-3
-            7537: -11,-4
-            7538: -11,-5
-            7539: -11,-7
-            7540: -11,-6
+            2834: 31,11
+            2835: 31,10
+            3161: 41,3
+            3162: 41,4
+            3163: 43,6
+            3164: 43,7
+            3165: 43,8
+            3166: 43,9
+            4699: 9,50
+            4700: 9,49
+            4701: 9,48
+            4702: 9,47
+            7502: 32,37
+            7503: 32,36
+            7511: -11,-3
+            7512: -11,-4
+            7513: -11,-5
+            7514: -11,-7
+            7515: -11,-6
         - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: clown
           decals:
-            7297: 4.776539,-35.340748
+            7272: 4.776539,-35.340748
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF00005A'
             id: footprint
           decals:
-            5093: 12.790892,-10.743357
+            5068: 12.790892,-10.743357
         - node:
             cleanable: True
             angle: -3.141592653589793 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5881: 36.792473,-23.683962
-            5882: 37.137463,-23.28303
-            5883: 36.792473,-22.95669
-            5884: 37.146786,-22.70494
-            5885: 36.78315,-22.359953
-            5886: 37.165436,-22.07091
-            5887: 36.820446,-21.753893
+            5856: 36.792473,-23.683962
+            5857: 37.137463,-23.28303
+            5858: 36.792473,-22.95669
+            5859: 37.146786,-22.70494
+            5860: 36.78315,-22.359953
+            5861: 37.165436,-22.07091
+            5862: 36.820446,-21.753893
         - node:
             cleanable: True
             angle: -1.5707963267948966 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5870: 11.844839,-26.264587
-            5871: 11.6490345,-25.956896
-            5877: 3.9564643,-24.88426
-            5878: 4.4226646,-25.247896
-            5879: 4.8702173,-24.88426
-            5880: 5.205881,-25.25722
+            5845: 11.844839,-26.264587
+            5846: 11.6490345,-25.956896
+            5852: 3.9564643,-24.88426
+            5853: 4.4226646,-25.247896
+            5854: 4.8702173,-24.88426
+            5855: 5.205881,-25.25722
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000C7'
             id: footprint
           decals:
-            5872: 12.857773,-20.710676
-            5873: 13.156141,-21.074314
-            5874: 12.8204775,-21.465921
-            5875: 13.128169,-21.801586
-            5876: 12.8204775,-22.239815
+            5847: 12.857773,-20.710676
+            5848: 13.156141,-21.074314
+            5849: 12.8204775,-21.465921
+            5850: 13.128169,-21.801586
+            5851: 12.8204775,-22.239815
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000FF'
             id: footprint
           decals:
-            5096: 12.800216,-9.782984
-            5097: 13.201148,-10.081352
-            5098: 12.800216,-10.333101
+            5071: 12.800216,-9.782984
+            5072: 13.201148,-10.081352
+            5073: 12.800216,-10.333101
         - node:
             color: '#FFFFFFFF'
             id: rune1
           decals:
             458: -16,6
-            2782: 28,-7
+            2757: 28,-7
         - node:
             color: '#FFFFFFFF'
             id: rune2
           decals:
-            2783: 29,-7
+            2758: 29,-7
         - node:
             color: '#FFFFFFFF'
             id: rune3
           decals:
-            2784: 28,-8
+            2759: 28,-8
         - node:
             color: '#FFFFFFFF'
             id: rune4
           decals:
-            2785: 29,-8
+            2760: 29,-8
         - node:
             cleanable: True
             angle: -4.71238898038469 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5890: 9.984598,-26.331085
+            5865: 9.984598,-26.331085
         - node:
             cleanable: True
             angle: -3.141592653589793 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5888: 37.17476,-21.101212
-            5889: 36.811123,-21.063915
+            5863: 37.17476,-21.101212
+            5864: 36.811123,-21.063915
         - node:
             cleanable: True
             angle: -1.5707963267948966 rad
             color: '#FF0000C7'
             id: thinline
           decals:
-            5891: 10.031219,-25.930153
+            5866: 10.031219,-25.930153
         - node:
             cleanable: True
             color: '#FF0000FF'
             id: thinline
           decals:
-            5095: 13.210472,-9.009092
+            5070: 13.210472,-9.009092
         - node:
             cleanable: True
             angle: 3.141592653589793 rad
             color: '#FF0000FF'
             id: thinline
           decals:
-            5094: 12.781568,-8.962471
+            5069: 12.781568,-8.962471
     - type: GridAtmosphere
       version: 2
       data:
@@ -9457,7 +9449,7 @@ entities:
           -8,3:
             0: 53710
           -9,3:
-            0: 65295
+            0: 65519
           -8,4:
             0: 53469
           -7,0:
@@ -9491,7 +9483,7 @@ entities:
           -8,-4:
             0: 61152
           -8,-3:
-            0: 61679
+            0: 61678
           -9,-3:
             0: 65262
           -9,-2:
@@ -9844,7 +9836,7 @@ entities:
           -11,2:
             0: 65535
           -11,3:
-            0: 32655
+            0: 32527
           -11,4:
             0: 57599
           -10,1:
@@ -9852,11 +9844,11 @@ entities:
           -10,2:
             0: 32767
           -10,3:
-            0: 26127
+            0: 26383
           -10,4:
-            0: 61542
+            0: 61670
           -9,4:
-            0: 61695
+            0: 62719
           -13,4:
             1: 252
           -12,7:
@@ -11649,7 +11641,6 @@ entities:
       - 11448
       - 11449
       - 11455
-      - 11456
       - 14778
       - 14985
       - 517
@@ -11711,10 +11702,14 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 11452
+      - 16420
       - 14984
       - 14780
       - 520
+      - 20344
+      - 19731
+      - 19733
+      - 19735
   - uid: 25
     components:
     - type: Transform
@@ -12399,6 +12394,8 @@ entities:
       - 14973
       - 14845
       - 557
+    - type: WiresPanel
+      open: True
   - uid: 69
     components:
     - type: Transform
@@ -13394,7 +13391,6 @@ entities:
       - 11247
       - 11248
       - 11249
-      - 11452
       - 11450
       - 11449
       - 11448
@@ -13747,11 +13743,6 @@ entities:
       parent: 2
 - proto: AirlockCommandLocked
   entities:
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -31.5,-11.5
-      parent: 2
   - uid: 182
     components:
     - type: Transform
@@ -13951,12 +13942,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -34.5,19.5
-      parent: 2
-  - uid: 15970
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -37.5,19.5
       parent: 2
   - uid: 24012
     components:
@@ -14606,13 +14591,6 @@ entities:
     - type: Transform
       pos: 14.5,17.5
       parent: 2
-- proto: AirlockMaintCargoLocked
-  entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: -40.5,13.5
-      parent: 2
 - proto: AirlockMaintChemLocked
   entities:
   - uid: 310
@@ -14997,6 +14975,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -23.5,16.5
       parent: 2
+    - type: Door
+      secondsUntilStateChange: -1376.7728
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 381
     components:
     - type: Transform
@@ -15026,7 +15010,7 @@ entities:
       pos: 34.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -63111.37
+      secondsUntilStateChange: -65995.96
       state: Opening
   - uid: 386
     components:
@@ -15076,6 +15060,23 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-12.5
+      parent: 2
+  - uid: 9271
+    components:
+    - type: Transform
+      pos: -36.5,17.5
+      parent: 2
+  - uid: 19734
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -39.5,14.5
+      parent: 2
+  - uid: 20364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,18.5
       parent: 2
 - proto: AirlockMaintMedLocked
   entities:
@@ -15314,6 +15315,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -35.5,-8.5
       parent: 2
+    - type: Door
+      secondsUntilStateChange: -1778.8046
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 434
     components:
     - type: Transform
@@ -16884,6 +16891,14 @@ entities:
     - type: Transform
       pos: 11.5,-56.5
       parent: 2
+  - uid: 9185
+    components:
+    - type: MetaData
+      name: Vault APC
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -31.5,-13.5
+      parent: 2
 - proto: APCConstructed
   entities:
   - uid: 689
@@ -18088,6 +18103,20 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-53.5
+      parent: 2
+- proto: BenchColorfulComfy
+  entities:
+  - uid: 17523
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -35.5,14.5
+      parent: 2
+  - uid: 20358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -35.5,15.5
       parent: 2
 - proto: BenchPewLeft
   entities:
@@ -29986,11 +30015,6 @@ entities:
     - type: Transform
       pos: -34.5,14.5
       parent: 2
-  - uid: 3243
-    components:
-    - type: Transform
-      pos: -33.5,14.5
-      parent: 2
   - uid: 3244
     components:
     - type: Transform
@@ -35386,11 +35410,6 @@ entities:
     - type: Transform
       pos: -33.5,-8.5
       parent: 2
-  - uid: 4350
-    components:
-    - type: Transform
-      pos: -32.5,-11.5
-      parent: 2
   - uid: 4351
     components:
     - type: Transform
@@ -36786,6 +36805,26 @@ entities:
     - type: Transform
       pos: -13.5,-5.5
       parent: 2
+  - uid: 9270
+    components:
+    - type: Transform
+      pos: -34.5,17.5
+      parent: 2
+  - uid: 9272
+    components:
+    - type: Transform
+      pos: -38.5,15.5
+      parent: 2
+  - uid: 9275
+    components:
+    - type: Transform
+      pos: -38.5,14.5
+      parent: 2
+  - uid: 9300
+    components:
+    - type: Transform
+      pos: -37.5,17.5
+      parent: 2
   - uid: 9367
     components:
     - type: Transform
@@ -36806,10 +36845,70 @@ entities:
     - type: Transform
       pos: 39.5,33.5
       parent: 2
+  - uid: 16427
+    components:
+    - type: Transform
+      pos: -35.5,17.5
+      parent: 2
+  - uid: 16473
+    components:
+    - type: Transform
+      pos: -36.5,17.5
+      parent: 2
+  - uid: 16476
+    components:
+    - type: Transform
+      pos: -38.5,16.5
+      parent: 2
+  - uid: 16649
+    components:
+    - type: Transform
+      pos: -28.5,-14.5
+      parent: 2
+  - uid: 17302
+    components:
+    - type: Transform
+      pos: -38.5,17.5
+      parent: 2
   - uid: 17857
     components:
     - type: Transform
       pos: 35.5,36.5
+      parent: 2
+  - uid: 22451
+    components:
+    - type: Transform
+      pos: 40.5,-43.5
+      parent: 2
+  - uid: 22522
+    components:
+    - type: Transform
+      pos: 41.5,-43.5
+      parent: 2
+  - uid: 23137
+    components:
+    - type: Transform
+      pos: 42.5,-43.5
+      parent: 2
+  - uid: 23138
+    components:
+    - type: Transform
+      pos: 43.5,-43.5
+      parent: 2
+  - uid: 23222
+    components:
+    - type: Transform
+      pos: 44.5,-43.5
+      parent: 2
+  - uid: 23230
+    components:
+    - type: Transform
+      pos: 45.5,-43.5
+      parent: 2
+  - uid: 23460
+    components:
+    - type: Transform
+      pos: 46.5,-43.5
       parent: 2
   - uid: 23908
     components:
@@ -36920,6 +37019,26 @@ entities:
     components:
     - type: Transform
       pos: 38.5,40.5
+      parent: 2
+  - uid: 24220
+    components:
+    - type: Transform
+      pos: -30.5,-12.5
+      parent: 2
+  - uid: 24221
+    components:
+    - type: Transform
+      pos: -30.5,-13.5
+      parent: 2
+  - uid: 24222
+    components:
+    - type: Transform
+      pos: -31.5,-13.5
+      parent: 2
+  - uid: 24225
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -44776,6 +44895,11 @@ entities:
       parent: 2
 - proto: CableMV
   entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -31.5,-13.5
+      parent: 2
   - uid: 304
     components:
     - type: Transform
@@ -50561,10 +50685,100 @@ entities:
     - type: Transform
       pos: -18.5,6.5
       parent: 2
+  - uid: 9376
+    components:
+    - type: Transform
+      pos: -33.5,-18.5
+      parent: 2
+  - uid: 9418
+    components:
+    - type: Transform
+      pos: -33.5,-12.5
+      parent: 2
+  - uid: 10155
+    components:
+    - type: Transform
+      pos: -33.5,-13.5
+      parent: 2
   - uid: 10730
     components:
     - type: Transform
       pos: -18.5,5.5
+      parent: 2
+  - uid: 15970
+    components:
+    - type: Transform
+      pos: -33.5,-22.5
+      parent: 2
+  - uid: 16422
+    components:
+    - type: Transform
+      pos: -33.5,-11.5
+      parent: 2
+  - uid: 16425
+    components:
+    - type: Transform
+      pos: -33.5,-14.5
+      parent: 2
+  - uid: 18223
+    components:
+    - type: Transform
+      pos: -32.5,-11.5
+      parent: 2
+  - uid: 18224
+    components:
+    - type: Transform
+      pos: -33.5,-17.5
+      parent: 2
+  - uid: 18371
+    components:
+    - type: Transform
+      pos: -33.5,-19.5
+      parent: 2
+  - uid: 18377
+    components:
+    - type: Transform
+      pos: -33.5,-20.5
+      parent: 2
+  - uid: 18378
+    components:
+    - type: Transform
+      pos: -33.5,-21.5
+      parent: 2
+  - uid: 19212
+    components:
+    - type: Transform
+      pos: -31.5,-11.5
+      parent: 2
+  - uid: 19213
+    components:
+    - type: Transform
+      pos: -33.5,-16.5
+      parent: 2
+  - uid: 19276
+    components:
+    - type: Transform
+      pos: -30.5,-12.5
+      parent: 2
+  - uid: 19538
+    components:
+    - type: Transform
+      pos: -30.5,-13.5
+      parent: 2
+  - uid: 22440
+    components:
+    - type: Transform
+      pos: -30.5,-11.5
+      parent: 2
+  - uid: 22449
+    components:
+    - type: Transform
+      pos: -33.5,-15.5
+      parent: 2
+  - uid: 24007
+    components:
+    - type: Transform
+      pos: -32.5,-22.5
       parent: 2
   - uid: 24019
     components:
@@ -57897,6 +58111,11 @@ entities:
     - type: Transform
       pos: 9.5,60.5
       parent: 2
+  - uid: 11456
+    components:
+    - type: Transform
+      pos: -39.5,14.5
+      parent: 2
   - uid: 11675
     components:
     - type: Transform
@@ -57927,6 +58146,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -46.5,22.5
       parent: 2
+  - uid: 18653
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,17.5
+      parent: 2
   - uid: 19609
     components:
     - type: Transform
@@ -57938,6 +58163,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -46.5,23.5
+      parent: 2
+  - uid: 20366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,16.5
       parent: 2
   - uid: 20860
     components:
@@ -57955,6 +58186,18 @@ entities:
     components:
     - type: Transform
       pos: 42.5,-46.5
+      parent: 2
+  - uid: 24212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,15.5
+      parent: 2
+  - uid: 24213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -37.5,14.5
       parent: 2
 - proto: CellRechargerCircuitboard
   entities:
@@ -59258,8 +59501,11 @@ entities:
   - uid: 8799
     components:
     - type: Transform
-      pos: -35.437805,17.56227
+      pos: -26.472324,-11.292385
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 8800
     components:
     - type: Transform
@@ -59945,6 +60191,11 @@ entities:
     - type: Transform
       pos: -17.5,4.5
       parent: 2
+  - uid: 16650
+    components:
+    - type: Transform
+      pos: -37.5,14.5
+      parent: 2
   - uid: 24014
     components:
     - type: Transform
@@ -60570,6 +60821,31 @@ entities:
       rot: 3.141592653589793 rad
       pos: 15.477132,33.43828
       parent: 2
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: This decreases your speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        - message: >-
+            It provides the following protection:
+
+            - [color=yellow]Blunt[/color] damage reduced by [color=lightblue]50%[/color].
+
+            - [color=yellow]Slash[/color] damage reduced by [color=lightblue]50%[/color].
+
+            - [color=yellow]Piercing[/color] damage reduced by [color=lightblue]40%[/color].
+
+            - [color=yellow]Heat[/color] damage reduced by [color=lightblue]50%[/color].
+          priority: 0
+          component: Armor
+        title: null
 - proto: ClothingOuterArmorReflective
   entities:
   - uid: 9004
@@ -61664,11 +61940,6 @@ entities:
     - type: Transform
       pos: -25.5,-33.5
       parent: 2
-  - uid: 9185
-    components:
-    - type: Transform
-      pos: -21.5,-16.5
-      parent: 2
   - uid: 9186
     components:
     - type: Transform
@@ -62242,53 +62513,6 @@ entities:
     - type: DeviceLinkSink
       links:
       - 20118
-  - uid: 9268
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -38.5,14.5
-      parent: 2
-  - uid: 9269
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -37.5,14.5
-      parent: 2
-  - uid: 9270
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -37.5,15.5
-      parent: 2
-    - type: ApcPowerReceiver
-      needsPower: False
-  - uid: 9271
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -37.5,16.5
-      parent: 2
-  - uid: 9272
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -37.5,17.5
-      parent: 2
-  - uid: 9273
-    components:
-    - type: Transform
-      pos: -38.5,17.5
-      parent: 2
-  - uid: 9274
-    components:
-    - type: Transform
-      pos: -38.5,16.5
-      parent: 2
-  - uid: 9275
-    components:
-    - type: Transform
-      pos: -38.5,15.5
-      parent: 2
   - uid: 9276
     components:
     - type: Transform
@@ -62523,18 +62747,17 @@ entities:
       parent: 2
 - proto: CrateCommandSecure
   entities:
-  - uid: 9300
-    components:
-    - type: Transform
-      pos: -29.5,-10.5
-      parent: 2
   - uid: 9301
     components:
     - type: Transform
-      pos: -34.5,17.5
+      anchored: True
+      pos: -26.5,-14.5
       parent: 2
-    - type: Lock
-      locked: False
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      fixedRotation: False
+      bodyType: Static
     - type: Fixtures
       fixtures:
         fix1:
@@ -62549,6 +62772,8 @@ entities:
           - Impassable
           - LowImpassable
           layer:
+          - TableLayer
+          - LowImpassable
           - BulletImpassable
           - Opaque
           density: 50
@@ -62556,10 +62781,36 @@ entities:
           restitution: 0
           friction: 0.4
     - type: EntityStorage
-      open: True
-      removedMasks: 20
-    - type: PlaceableSurface
-      isPlaceable: True
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.147
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 15725
+          - 20060
+          - 15724
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: CrateEmergencyRadiation
   entities:
   - uid: 9302
@@ -62642,8 +62893,14 @@ entities:
   - uid: 9310
     components:
     - type: Transform
-      pos: -35.5,15.5
+      anchored: True
+      pos: -30.5,-10.5
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      fixedRotation: False
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -62873,7 +63130,7 @@ entities:
   - uid: 9341
     components:
     - type: Transform
-      pos: -29.5,-4.5
+      pos: -27.996693,-4.587304
       parent: 2
 - proto: CrateHydroponicsSeedsMedicinal
   entities:
@@ -63096,8 +63353,14 @@ entities:
   - uid: 9357
     components:
     - type: Transform
-      pos: -31.5,15.5
+      anchored: True
+      pos: -29.5,-14.5
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      fixedRotation: False
+      bodyType: Static
     - type: EntityStorage
       air:
         volume: 200
@@ -63211,10 +63474,10 @@ entities:
       parent: 2
 - proto: CrewMonitoringServer
   entities:
-  - uid: 9376
+  - uid: 16421
     components:
     - type: Transform
-      pos: -32.5,17.5
+      pos: 4.5,40.5
       parent: 2
     - type: SingletonDeviceNetServer
       active: False
@@ -63628,10 +63891,9 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconCryosleep
   entities:
-  - uid: 9418
+  - uid: 9466
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 33.5,23.5
       parent: 2
 - proto: DefaultStationBeaconDetectiveRoom
@@ -63819,6 +64081,13 @@ entities:
     - type: Transform
       pos: -16.5,-23.5
       parent: 2
+- proto: DefaultStationBeaconReporter
+  entities:
+  - uid: 16477
+    components:
+    - type: Transform
+      pos: 17.5,22.5
+      parent: 2
 - proto: DefaultStationBeaconRND
   entities:
   - uid: 9444
@@ -63966,10 +64235,10 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconVault
   entities:
-  - uid: 9466
+  - uid: 19211
     components:
     - type: Transform
-      pos: -33.5,16.5
+      pos: -28.5,-13.5
       parent: 2
 - proto: DefaultStationBeaconWardensOffice
   entities:
@@ -64100,6 +64369,12 @@ entities:
       parent: 2
 - proto: DisposalBend
   entities:
+  - uid: 4350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -32.5,16.5
+      parent: 2
   - uid: 9488
     components:
     - type: Transform
@@ -65023,6 +65298,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-52.5
+      parent: 2
+  - uid: 10674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -32.5,11.5
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
@@ -67974,12 +68255,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -31.5,11.5
       parent: 2
-  - uid: 10155
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,11.5
-      parent: 2
   - uid: 10156
     components:
     - type: Transform
@@ -69736,6 +70011,26 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 35.5,36.5
       parent: 2
+  - uid: 24216
+    components:
+    - type: Transform
+      pos: -32.5,15.5
+      parent: 2
+  - uid: 24217
+    components:
+    - type: Transform
+      pos: -32.5,14.5
+      parent: 2
+  - uid: 24218
+    components:
+    - type: Transform
+      pos: -32.5,13.5
+      parent: 2
+  - uid: 24219
+    components:
+    - type: Transform
+      pos: -32.5,12.5
+      parent: 2
 - proto: DisposalPipeBroken
   entities:
   - uid: 10459
@@ -70196,6 +70491,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 10.5,11.5
       parent: 2
+  - uid: 17303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,16.5
+      parent: 2
   - uid: 24125
     components:
     - type: Transform
@@ -70598,6 +70899,11 @@ entities:
     - type: Transform
       pos: 33.5,-36.5
       parent: 2
+  - uid: 20361
+    components:
+    - type: Transform
+      pos: -31.5,16.5
+      parent: 2
   - uid: 24126
     components:
     - type: Transform
@@ -70894,25 +71200,37 @@ entities:
   - uid: 10661
     components:
     - type: Transform
-      pos: -35.58466,17.12171
+      pos: -26.543598,-11.8619995
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: DrinkGildlagerGlass
   entities:
   - uid: 10662
     components:
     - type: Transform
-      pos: -35.689552,16.660172
+      pos: -26.718597,-12.387363
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 10663
     components:
     - type: Transform
-      pos: -35.52172,16.765066
+      pos: -26.243595,-12.024612
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 10664
     components:
     - type: Transform
-      pos: -35.395847,16.660172
+      pos: -26.318596,-12.399872
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: DrinkGinBottleFull
   entities:
   - uid: 1055
@@ -70954,13 +71272,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: DrinkGoldenCup
-  entities:
-  - uid: 10674
-    components:
-    - type: Transform
-      pos: -31.409832,17.016815
-      parent: 2
 - proto: DrinkGrapeCan
   entities:
   - uid: 10675
@@ -71156,6 +71467,12 @@ entities:
       parent: 2
 - proto: EmergencyLight
   entities:
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,15.5
+      parent: 2
   - uid: 934
     components:
     - type: Transform
@@ -71771,11 +72088,6 @@ entities:
     - type: Transform
       pos: -28.5,13.5
       parent: 2
-  - uid: 10815
-    components:
-    - type: Transform
-      pos: -33.5,17.5
-      parent: 2
   - uid: 10816
     components:
     - type: Transform
@@ -71937,8 +72249,19 @@ entities:
   - uid: 10847
     components:
     - type: Transform
-      pos: 5.429473,44.565796
+      pos: 5.439494,44.58101
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 11032
+    components:
+    - type: Transform
+      parent: 10855
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
 - proto: EncryptionKeyMedical
   entities:
   - uid: 10849
@@ -72769,11 +73092,6 @@ entities:
     - type: Transform
       pos: 5.5,27.5
       parent: 2
-  - uid: 10996
-    components:
-    - type: Transform
-      pos: -35.5,14.5
-      parent: 2
   - uid: 10997
     components:
     - type: Transform
@@ -72808,6 +73126,11 @@ entities:
     components:
     - type: Transform
       pos: 44.5,-20.5
+      parent: 2
+  - uid: 11452
+    components:
+    - type: Transform
+      pos: -30.5,-12.5
       parent: 2
 - proto: filingCabinetTallRandom
   entities:
@@ -73098,7 +73421,6 @@ entities:
       - 11247
       - 11248
       - 11249
-      - 11452
       - 11450
       - 11449
       - 11448
@@ -73117,7 +73439,6 @@ entities:
       - 11448
       - 11449
       - 11455
-      - 11456
   - uid: 11027
     components:
     - type: Transform
@@ -73174,18 +73495,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -31.5,13.5
       parent: 2
-    - type: DeviceList
-      devices:
-      - 11452
-  - uid: 11032
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -39.5,14.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 11456
   - uid: 11033
     components:
     - type: Transform
@@ -76546,12 +76855,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.5,6.5
       parent: 2
-  - uid: 11452
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,13.5
-      parent: 2
   - uid: 11453
     components:
     - type: Transform
@@ -76569,12 +76872,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,5.5
-      parent: 2
-  - uid: 11456
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -40.5,13.5
       parent: 2
   - uid: 11457
     components:
@@ -76922,6 +77219,38 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 37
+  - uid: 16420
+    components:
+    - type: Transform
+      pos: -34.5,13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24
+  - uid: 19731
+    components:
+    - type: Transform
+      pos: -32.5,13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24
+  - uid: 19733
+    components:
+    - type: Transform
+      pos: -33.5,18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24
+  - uid: 19735
+    components:
+    - type: Transform
+      pos: -36.5,17.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24
   - uid: 19907
     components:
     - type: Transform
@@ -76930,6 +77259,14 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 123
+  - uid: 20344
+    components:
+    - type: Transform
+      pos: -33.5,13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 24
   - uid: 24111
     components:
     - type: Transform
@@ -77234,13 +77571,6 @@ entities:
     - type: Transform
       pos: 26.666939,19.03567
       parent: 2
-- proto: FoodBoxPizzaFilled
-  entities:
-  - uid: 11557
-    components:
-    - type: Transform
-      pos: -29.677326,-14.227869
-      parent: 2
 - proto: FoodBurgerCheese
   entities:
   - uid: 11559
@@ -77275,8 +77605,11 @@ entities:
   - uid: 11563
     components:
     - type: Transform
-      pos: -33.507736,17.583248
+      pos: -27.456097,-10.304483
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: FoodCakeClownSlice
   entities:
   - uid: 11564
@@ -77445,13 +77778,6 @@ entities:
     components:
     - type: Transform
       pos: -8.392583,56.64848
-      parent: 2
-- proto: FoodTartGapple
-  entities:
-  - uid: 11590
-    components:
-    - type: Transform
-      pos: -31.47277,16.555275
       parent: 2
 - proto: FoodTinPeachesMaint
   entities:
@@ -77749,10 +78075,16 @@ entities:
       color: '#8800FFFF'
   - uid: 11721
     components:
+    - type: MetaData
+      name: Burn Chamber Mix
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 37.5,-42.5
       parent: 2
+    - type: GasMixer
+      inletTwoConcentration: 0.038000047
+      inletOneConcentration: 0.96199995
+      targetPressure: 4500
 - proto: GasMixerFlipped
   entities:
   - uid: 11636
@@ -98800,38 +99132,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 21770
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 43.5,-43.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FFA500FF'
-  - uid: 21771
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 44.5,-43.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FFA500FF'
-  - uid: 21772
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 45.5,-43.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FFA500FF'
-  - uid: 21776
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 46.5,-43.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FFA500FF'
   - uid: 24043
     components:
     - type: Transform
@@ -102019,6 +102319,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 40.5,-42.5
       parent: 2
+    - type: GasPressurePump
+      targetPressure: 4500
   - uid: 14720
     components:
     - type: Transform
@@ -102197,6 +102499,8 @@ entities:
       color: '#FF00BFFF'
   - uid: 14743
     components:
+    - type: MetaData
+      name: Waste Valve
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.5,-56.5
@@ -104790,13 +105094,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
-- proto: Gateway
-  entities:
-  - uid: 15064
-    components:
-    - type: Transform
-      pos: -27.5,-11.5
-      parent: 2
 - proto: GeigerCounter
   entities:
   - uid: 15065
@@ -104887,6 +105184,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-58.5
+      parent: 2
+  - uid: 11590
+    components:
+    - type: Transform
+      pos: -40.5,13.5
       parent: 2
   - uid: 15079
     components:
@@ -107889,29 +108191,11 @@ entities:
       parent: 2
 - proto: GunSafePistolMk58
   entities:
-  - uid: 15636
+  - uid: 16423
     components:
     - type: Transform
-      pos: -31.5,14.5
+      pos: -26.5,-10.5
       parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
 - proto: Handcuffs
   entities:
   - uid: 15637
@@ -108006,6 +108290,8 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 45.5,-44.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
   - uid: 14710
     components:
     - type: Transform
@@ -108020,6 +108306,16 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 44.5,-44.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
+  - uid: 15636
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 46.5,-43.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
   - uid: 15653
     components:
     - type: Transform
@@ -108068,6 +108364,30 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -12.5,-70.5
       parent: 2
+  - uid: 15668
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 45.5,-43.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
+  - uid: 15742
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 44.5,-43.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
+  - uid: 15852
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 43.5,-43.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FFA500FF'
   - uid: 23178
     components:
     - type: Transform
@@ -108115,11 +108435,6 @@ entities:
     - type: Transform
       pos: -4.5,81.5
       parent: 2
-  - uid: 15668
-    components:
-    - type: Transform
-      pos: -33.5,13.5
-      parent: 2
   - uid: 15669
     components:
     - type: Transform
@@ -108149,6 +108464,11 @@ entities:
     components:
     - type: Transform
       pos: 1.5,81.5
+      parent: 2
+  - uid: 20026
+    components:
+    - type: Transform
+      pos: -31.5,-11.5
       parent: 2
 - proto: Holoprojector
   entities:
@@ -108420,15 +108740,23 @@ entities:
   - uid: 15724
     components:
     - type: Transform
-      pos: -34.5,17.5
-      parent: 2
+      parent: 9301
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: IngotSilver
   entities:
   - uid: 15725
     components:
     - type: Transform
-      pos: -34.5,17.5
-      parent: 2
+      parent: 9301
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: IntercomAll
   entities:
   - uid: 15726
@@ -108525,11 +108853,6 @@ entities:
     components:
     - type: Transform
       pos: -43.5,-6.5
-      parent: 2
-  - uid: 15742
-    components:
-    - type: Transform
-      pos: -30.5,-9.5
       parent: 2
   - uid: 15743
     components:
@@ -108635,6 +108958,11 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-49.5
+      parent: 2
+  - uid: 18631
+    components:
+    - type: Transform
+      pos: -30.5,-9.5
       parent: 2
 - proto: IntercomCommon
   entities:
@@ -109146,12 +109474,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,13.5
-      parent: 2
-  - uid: 15852
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,18.5
       parent: 2
   - uid: 15853
     components:
@@ -110126,6 +110448,13 @@ entities:
         - 0
         - 0
         - 0
+- proto: LockerFreezerVaultFilled
+  entities:
+  - uid: 10815
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
+      parent: 2
 - proto: LockerHeadOfPersonnelFilled
   entities:
   - uid: 15983
@@ -110769,6 +111098,11 @@ entities:
       parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
+  - uid: 11557
+    components:
+    - type: Transform
+      pos: -35.5,16.5
+      parent: 2
   - uid: 16057
     components:
     - type: Transform
@@ -110954,6 +111288,12 @@ entities:
     components:
     - type: Transform
       pos: 7.5,-37.5
+      parent: 2
+  - uid: 19210
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,17.5
       parent: 2
 - proto: Matchbox
   entities:
@@ -111762,10 +112102,10 @@ entities:
       parent: 2
 - proto: NuclearBomb
   entities:
-  - uid: 16227
+  - uid: 18606
     components:
     - type: Transform
-      pos: -33.5,15.5
+      pos: -28.5,-12.5
       parent: 2
 - proto: OperatingTable
   entities:
@@ -112804,8 +113144,11 @@ entities:
   - uid: 16397
     components:
     - type: Transform
-      pos: -31.654495,17.071499
+      pos: -26.568596,-12.937746
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: PlasmaCanister
   entities:
   - uid: 908
@@ -112941,46 +113284,6 @@ entities:
     components:
     - type: Transform
       pos: -23.665382,-13.840267
-      parent: 2
-  - uid: 16420
-    components:
-    - type: Transform
-      pos: -38.5,14.5
-      parent: 2
-  - uid: 16421
-    components:
-    - type: Transform
-      pos: -37.5,14.5
-      parent: 2
-  - uid: 16422
-    components:
-    - type: Transform
-      pos: -37.5,15.5
-      parent: 2
-  - uid: 16423
-    components:
-    - type: Transform
-      pos: -37.5,16.5
-      parent: 2
-  - uid: 16424
-    components:
-    - type: Transform
-      pos: -37.5,17.5
-      parent: 2
-  - uid: 16425
-    components:
-    - type: Transform
-      pos: -38.5,17.5
-      parent: 2
-  - uid: 16426
-    components:
-    - type: Transform
-      pos: -38.5,16.5
-      parent: 2
-  - uid: 16427
-    components:
-    - type: Transform
-      pos: -38.5,15.5
       parent: 2
   - uid: 16428
     components:
@@ -113234,6 +113537,14 @@ entities:
     - type: Transform
       pos: 36.5,38.5
       parent: 2
+- proto: PosterLegitSafetyMothBoH
+  entities:
+  - uid: 10996
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -36.5,13.5
+      parent: 2
 - proto: PosterLegitSafetyMothDelam
   entities:
   - uid: 16472
@@ -113243,11 +113554,6 @@ entities:
       parent: 2
 - proto: PosterLegitSafetyMothEpi
   entities:
-  - uid: 16473
-    components:
-    - type: Transform
-      pos: -36.5,17.5
-      parent: 2
   - uid: 16474
     components:
     - type: Transform
@@ -113258,20 +113564,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,19.5
-      parent: 2
-- proto: PosterLegitSafetyMothHardhat
-  entities:
-  - uid: 16476
-    components:
-    - type: Transform
-      pos: -36.5,14.5
-      parent: 2
-- proto: PosterLegitSafetyMothMeth
-  entities:
-  - uid: 16477
-    components:
-    - type: Transform
-      pos: -37.5,18.5
       parent: 2
 - proto: PottedPlant0
   entities:
@@ -113631,6 +113923,11 @@ entities:
     - type: Transform
       pos: 34.5,-9.5
       parent: 2
+  - uid: 24215
+    components:
+    - type: Transform
+      pos: -32.5,17.5
+      parent: 2
 - proto: PottedPlantRandomPlastic
   entities:
   - uid: 16544
@@ -113956,6 +114253,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-2.5
+      parent: 2
+  - uid: 16426
+    components:
+    - type: Transform
+      pos: -37.5,17.5
       parent: 2
   - uid: 16600
     components:
@@ -114310,23 +114612,6 @@ entities:
     - type: DeviceLinkSink
       links:
       - 18422
-  - uid: 16649
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,-14.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18425
-  - uid: 16650
-    components:
-    - type: Transform
-      pos: -29.5,-10.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18425
   - uid: 16651
     components:
     - type: Transform
@@ -117046,6 +117331,17 @@ entities:
     - type: Transform
       pos: 40.5,37.5
       parent: 2
+  - uid: 24223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -28.5,-14.5
+      parent: 2
+  - uid: 24224
+    components:
+    - type: Transform
+      pos: -28.5,-10.5
+      parent: 2
 - proto: PoweredlightEmpty
   entities:
   - uid: 16987
@@ -118240,6 +118536,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 11.5,-60.5
       parent: 2
+  - uid: 9273
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,17.5
+      parent: 2
   - uid: 17163
     components:
     - type: Transform
@@ -118993,24 +119295,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -42.5,3.5
-      parent: 2
-  - uid: 17302
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-10.5
-      parent: 2
-  - uid: 17303
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-11.5
-      parent: 2
-  - uid: 17304
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-12.5
       parent: 2
   - uid: 17305
     components:
@@ -120026,12 +120310,6 @@ entities:
     - type: Transform
       pos: -43.5,7.5
       parent: 2
-  - uid: 17482
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -29.5,-13.5
-      parent: 2
   - uid: 17483
     components:
     - type: Transform
@@ -120217,6 +120495,11 @@ entities:
     - type: Transform
       pos: 39.5,-37.5
       parent: 2
+  - uid: 20125
+    components:
+    - type: Transform
+      pos: -34.5,18.5
+      parent: 2
 - proto: RandomPosterContraband
   entities:
   - uid: 17508
@@ -120295,11 +120578,6 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-11.5
-      parent: 2
-  - uid: 17523
-    components:
-    - type: Transform
-      pos: -25.5,-9.5
       parent: 2
   - uid: 17524
     components:
@@ -120395,6 +120673,11 @@ entities:
     components:
     - type: Transform
       pos: 13.5,34.5
+      parent: 2
+  - uid: 20282
+    components:
+    - type: Transform
+      pos: -32.5,18.5
       parent: 2
   - uid: 24138
     components:
@@ -120843,6 +121126,11 @@ entities:
     - type: Transform
       pos: -8.5,-24.5
       parent: 2
+  - uid: 20362
+    components:
+    - type: Transform
+      pos: -31.5,14.5
+      parent: 2
   - uid: 24123
     components:
     - type: Transform
@@ -120850,6 +121138,11 @@ entities:
       parent: 2
 - proto: RandomVendingSnacks
   entities:
+  - uid: 9274
+    components:
+    - type: Transform
+      pos: -31.5,15.5
+      parent: 2
   - uid: 17632
     components:
     - type: Transform
@@ -123887,6 +124180,11 @@ entities:
     - type: Transform
       pos: -13.482822,-61.38449
       parent: 2
+  - uid: 19732
+    components:
+    - type: Transform
+      pos: 4.486205,-29.35262
+      parent: 2
 - proto: SheetPlasteel1
   entities:
   - uid: 18190
@@ -124111,26 +124409,6 @@ entities:
     - type: DeviceLinkSink
       links:
       - 18344
-  - uid: 18223
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-12.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18378
-      - 18377
-  - uid: 18224
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-13.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18378
-      - 18377
   - uid: 18225
     components:
     - type: Transform
@@ -125653,30 +125931,6 @@ entities:
         - Pressed: Toggle
         18228:
         - Pressed: Toggle
-  - uid: 18377
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.5,-10.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        18223:
-        - Pressed: Toggle
-        18224:
-        - Pressed: Toggle
-  - uid: 18378
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -31.5,-10.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        18223:
-        - Pressed: Toggle
-        18224:
-        - Pressed: Toggle
   - uid: 18379
     components:
     - type: Transform
@@ -126328,9 +126582,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        16650:
-        - Status: Toggle
-        16649:
+        invalid:
         - Status: Toggle
   - uid: 18426
     components:
@@ -128272,16 +128524,6 @@ entities:
     - type: Transform
       pos: 10.5,-7.5
       parent: 2
-  - uid: 18605
-    components:
-    - type: Transform
-      pos: -32.5,13.5
-      parent: 2
-  - uid: 18606
-    components:
-    - type: Transform
-      pos: -34.5,18.5
-      parent: 2
   - uid: 18607
     components:
     - type: Transform
@@ -128382,6 +128624,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 4.5,-71.5
       parent: 2
+  - uid: 24211
+    components:
+    - type: Transform
+      pos: -31.5,-12.5
+      parent: 2
 - proto: SignSecurity
   entities:
   - uid: 18626
@@ -128415,16 +128662,6 @@ entities:
       parent: 2
 - proto: SignShock
   entities:
-  - uid: 18631
-    components:
-    - type: Transform
-      pos: -34.5,13.5
-      parent: 2
-  - uid: 18632
-    components:
-    - type: Transform
-      pos: -32.5,18.5
-      parent: 2
   - uid: 18633
     components:
     - type: Transform
@@ -128440,6 +128677,11 @@ entities:
     components:
     - type: Transform
       pos: 5.5,45.5
+      parent: 2
+  - uid: 24210
+    components:
+    - type: Transform
+      pos: -31.5,-10.5
       parent: 2
 - proto: SignSmoking
   entities:
@@ -131084,6 +131326,11 @@ entities:
     - type: Transform
       pos: 32.5,33.5
       parent: 2
+  - uid: 24214
+    components:
+    - type: Transform
+      pos: -35.5,15.5
+      parent: 2
 - proto: SpawnPointPrisoner
   entities:
   - uid: 19071
@@ -131938,29 +132185,6 @@ entities:
       parent: 2
 - proto: SteelBench
   entities:
-  - uid: 19210
-    components:
-    - type: Transform
-      pos: -30.5,-10.5
-      parent: 2
-  - uid: 19211
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -28.5,-14.5
-      parent: 2
-  - uid: 19212
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,-14.5
-      parent: 2
-  - uid: 19213
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,-14.5
-      parent: 2
   - uid: 19214
     components:
     - type: Transform
@@ -132622,22 +132846,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -26.5,-11.5
       parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraCommand
-      nameSet: True
-      id: Portal
-  - uid: 19323
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,15.5
-      parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraCommand
-      nameSet: True
-      id: Vault
   - uid: 19324
     components:
     - type: Transform
@@ -134719,18 +134927,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -42.5,-7.5
       parent: 2
-  - uid: 19537
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,-14.5
-      parent: 2
-  - uid: 19538
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -29.5,-14.5
-      parent: 2
   - uid: 19539
     components:
     - type: Transform
@@ -135447,6 +135643,11 @@ entities:
     - type: Transform
       pos: 14.5,-62.5
       parent: 2
+  - uid: 17304
+    components:
+    - type: Transform
+      pos: -35.5,16.5
+      parent: 2
 - proto: TableFancyBlack
   entities:
   - uid: 24098
@@ -135761,11 +135962,28 @@ entities:
       parent: 2
 - proto: TableReinforced
   entities:
+  - uid: 15270
+    components:
+    - type: Transform
+      pos: -27.5,-10.5
+      parent: 2
+  - uid: 16227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-11.5
+      parent: 2
   - uid: 17567
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -35.5,23.5
+      parent: 2
+  - uid: 19537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-14.5
       parent: 2
   - uid: 19719
     components:
@@ -135833,31 +136051,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -36.5,6.5
-      parent: 2
-  - uid: 19731
-    components:
-    - type: Transform
-      pos: -31.5,17.5
-      parent: 2
-  - uid: 19732
-    components:
-    - type: Transform
-      pos: -31.5,16.5
-      parent: 2
-  - uid: 19733
-    components:
-    - type: Transform
-      pos: -35.5,17.5
-      parent: 2
-  - uid: 19734
-    components:
-    - type: Transform
-      pos: -35.5,16.5
-      parent: 2
-  - uid: 19735
-    components:
-    - type: Transform
-      pos: -33.5,17.5
       parent: 2
   - uid: 19736
     components:
@@ -136726,6 +136919,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 44.5,33.5
+      parent: 2
+  - uid: 24208
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-12.5
+      parent: 2
+  - uid: 24209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-13.5
       parent: 2
 - proto: TableReinforcedGlass
   entities:
@@ -137649,6 +137854,7 @@ entities:
           occludes: True
           ents:
           - 10856
+          - 11032
         machine_board: !type:Container
           showEnts: False
           occludes: True
@@ -137871,8 +138077,12 @@ entities:
   - uid: 20060
     components:
     - type: Transform
-      pos: -34.5,17.5
-      parent: 2
+      parent: 9301
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: ToolboxMechanicalFilled
   entities:
   - uid: 15966
@@ -138593,8 +138803,11 @@ entities:
   - uid: 20135
     components:
     - type: Transform
-      pos: -31.47277,17.56227
+      pos: -26.269924,-13.444998
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 20136
     components:
     - type: Transform
@@ -138726,6 +138939,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-6.5
+      parent: 2
+  - uid: 16424
+    components:
+    - type: Transform
+      pos: -31.5,17.5
       parent: 2
   - uid: 20157
     components:
@@ -138965,6 +139183,13 @@ entities:
     - type: Transform
       pos: -22.5,-16.5
       parent: 2
+- proto: VendingMachineRobotics
+  entities:
+  - uid: 22450
+    components:
+    - type: Transform
+      pos: -24.5,-16.5
+      parent: 2
 - proto: VendingMachineSalvage
   entities:
   - uid: 20196
@@ -139084,6 +139309,11 @@ entities:
       parent: 2
 - proto: VendingMachineTankDispenserEVA
   entities:
+  - uid: 18632
+    components:
+    - type: Transform
+      pos: -29.5,-10.5
+      parent: 2
   - uid: 20215
     components:
     - type: Transform
@@ -139138,6 +139368,11 @@ entities:
       parent: 2
 - proto: VendingMachineVendomat
   entities:
+  - uid: 9268
+    components:
+    - type: Transform
+      pos: -21.5,-16.5
+      parent: 2
   - uid: 20225
     components:
     - type: Transform
@@ -139364,6 +139599,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.5,43.5
       parent: 2
+  - uid: 9269
+    components:
+    - type: Transform
+      pos: -31.5,13.5
+      parent: 2
   - uid: 13407
     components:
     - type: Transform
@@ -139381,12 +139621,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -37.5,20.5
-      parent: 2
-  - uid: 15270
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -36.5,18.5
       parent: 2
   - uid: 15533
     components:
@@ -139426,11 +139660,31 @@ entities:
     - type: Transform
       pos: 7.5,23.5
       parent: 2
+  - uid: 18391
+    components:
+    - type: Transform
+      pos: -31.5,-9.5
+      parent: 2
+  - uid: 18477
+    components:
+    - type: Transform
+      pos: -31.5,-12.5
+      parent: 2
+  - uid: 18605
+    components:
+    - type: Transform
+      pos: -31.5,-13.5
+      parent: 2
   - uid: 19818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -36.5,20.5
+      parent: 2
+  - uid: 20028
+    components:
+    - type: Transform
+      pos: -30.5,-9.5
       parent: 2
   - uid: 20256
     components:
@@ -139586,12 +139840,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -24.5,-15.5
-      parent: 2
-  - uid: 20282
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-15.5
       parent: 2
   - uid: 20283
     components:
@@ -139916,12 +140164,6 @@ entities:
     - type: Transform
       pos: -22.5,4.5
       parent: 2
-  - uid: 20344
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,13.5
-      parent: 2
   - uid: 20345
     components:
     - type: Transform
@@ -139933,16 +140175,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -30.5,14.5
-      parent: 2
-  - uid: 20347
-    components:
-    - type: Transform
-      pos: -32.5,13.5
-      parent: 2
-  - uid: 20348
-    components:
-    - type: Transform
-      pos: -34.5,13.5
       parent: 2
   - uid: 20349
     components:
@@ -139994,50 +140226,10 @@ entities:
     - type: Transform
       pos: -30.5,18.5
       parent: 2
-  - uid: 20358
-    components:
-    - type: Transform
-      pos: -31.5,18.5
-      parent: 2
-  - uid: 20359
-    components:
-    - type: Transform
-      pos: -32.5,18.5
-      parent: 2
-  - uid: 20360
-    components:
-    - type: Transform
-      pos: -33.5,18.5
-      parent: 2
-  - uid: 20361
-    components:
-    - type: Transform
-      pos: -34.5,18.5
-      parent: 2
-  - uid: 20362
-    components:
-    - type: Transform
-      pos: -35.5,18.5
-      parent: 2
-  - uid: 20364
-    components:
-    - type: Transform
-      pos: -36.5,17.5
-      parent: 2
-  - uid: 20365
-    components:
-    - type: Transform
-      pos: -36.5,16.5
-      parent: 2
-  - uid: 20366
-    components:
-    - type: Transform
-      pos: -36.5,15.5
-      parent: 2
   - uid: 20367
     components:
     - type: Transform
-      pos: -36.5,14.5
+      pos: -27.5,-9.5
       parent: 2
   - uid: 20368
     components:
@@ -140072,8 +140264,7 @@ entities:
   - uid: 20373
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -39.5,14.5
+      pos: -28.5,-9.5
       parent: 2
   - uid: 20374
     components:
@@ -147819,6 +148010,21 @@ entities:
     - type: Transform
       pos: 41.5,-45.5
       parent: 2
+  - uid: 21770
+    components:
+    - type: Transform
+      pos: -29.5,-9.5
+      parent: 2
+  - uid: 21771
+    components:
+    - type: Transform
+      pos: -25.5,-10.5
+      parent: 2
+  - uid: 21772
+    components:
+    - type: Transform
+      pos: -25.5,-11.5
+      parent: 2
   - uid: 21773
     components:
     - type: Transform
@@ -147833,6 +148039,11 @@ entities:
     components:
     - type: Transform
       pos: 39.5,-47.5
+      parent: 2
+  - uid: 21776
+    components:
+    - type: Transform
+      pos: -25.5,-13.5
       parent: 2
   - uid: 21777
     components:
@@ -150276,6 +150487,36 @@ entities:
     - type: Transform
       pos: -1.5,49.5
       parent: 2
+  - uid: 22436
+    components:
+    - type: Transform
+      pos: -26.5,-9.5
+      parent: 2
+  - uid: 22437
+    components:
+    - type: Transform
+      pos: -25.5,-14.5
+      parent: 2
+  - uid: 22438
+    components:
+    - type: Transform
+      pos: -25.5,-15.5
+      parent: 2
+  - uid: 22439
+    components:
+    - type: Transform
+      pos: -31.5,-10.5
+      parent: 2
+  - uid: 22447
+    components:
+    - type: Transform
+      pos: -25.5,-9.5
+      parent: 2
+  - uid: 22448
+    components:
+    - type: Transform
+      pos: -25.5,-12.5
+      parent: 2
   - uid: 23126
     components:
     - type: Transform
@@ -150491,6 +150732,11 @@ entities:
     - type: Transform
       pos: 38.5,31.5
       parent: 2
+  - uid: 17482
+    components:
+    - type: Transform
+      pos: -32.5,18.5
+      parent: 2
   - uid: 17849
     components:
     - type: Transform
@@ -150514,11 +150760,46 @@ entities:
       rot: 3.141592653589793 rad
       pos: 31.5,43.5
       parent: 2
+  - uid: 19323
+    components:
+    - type: Transform
+      pos: -31.5,18.5
+      parent: 2
   - uid: 19795
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 35.5,38.5
+      parent: 2
+  - uid: 20027
+    components:
+    - type: Transform
+      pos: -36.5,18.5
+      parent: 2
+  - uid: 20347
+    components:
+    - type: Transform
+      pos: -36.5,15.5
+      parent: 2
+  - uid: 20348
+    components:
+    - type: Transform
+      pos: -36.5,14.5
+      parent: 2
+  - uid: 20359
+    components:
+    - type: Transform
+      pos: -35.5,18.5
+      parent: 2
+  - uid: 20360
+    components:
+    - type: Transform
+      pos: -36.5,16.5
+      parent: 2
+  - uid: 20365
+    components:
+    - type: Transform
+      pos: -34.5,18.5
       parent: 2
   - uid: 22212
     components:
@@ -151651,31 +151932,6 @@ entities:
     - type: Transform
       pos: -17.5,-10.5
       parent: 2
-  - uid: 22436
-    components:
-    - type: Transform
-      pos: -25.5,-14.5
-      parent: 2
-  - uid: 22437
-    components:
-    - type: Transform
-      pos: -25.5,-13.5
-      parent: 2
-  - uid: 22438
-    components:
-    - type: Transform
-      pos: -25.5,-12.5
-      parent: 2
-  - uid: 22439
-    components:
-    - type: Transform
-      pos: -25.5,-11.5
-      parent: 2
-  - uid: 22440
-    components:
-    - type: Transform
-      pos: -25.5,-10.5
-      parent: 2
   - uid: 22441
     components:
     - type: Transform
@@ -151705,31 +151961,6 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-1.5
-      parent: 2
-  - uid: 22447
-    components:
-    - type: Transform
-      pos: -27.5,-9.5
-      parent: 2
-  - uid: 22448
-    components:
-    - type: Transform
-      pos: -28.5,-9.5
-      parent: 2
-  - uid: 22449
-    components:
-    - type: Transform
-      pos: -29.5,-9.5
-      parent: 2
-  - uid: 22450
-    components:
-    - type: Transform
-      pos: -30.5,-9.5
-      parent: 2
-  - uid: 22451
-    components:
-    - type: Transform
-      pos: -31.5,-9.5
       parent: 2
   - uid: 22452
     components:
@@ -152126,11 +152357,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -45.5,-13.5
-      parent: 2
-  - uid: 22522
-    components:
-    - type: Transform
-      pos: -31.5,-10.5
       parent: 2
   - uid: 22523
     components:
@@ -155941,11 +156167,6 @@ entities:
     - type: Transform
       pos: -22.5,-10.5
       parent: 2
-  - uid: 23222
-    components:
-    - type: Transform
-      pos: -25.5,-9.5
-      parent: 2
   - uid: 23223
     components:
     - type: Transform
@@ -155980,11 +156201,6 @@ entities:
     components:
     - type: Transform
       pos: -21.5,-1.5
-      parent: 2
-  - uid: 23230
-    components:
-    - type: Transform
-      pos: -26.5,-9.5
       parent: 2
   - uid: 23231
     components:
@@ -157015,11 +157231,10 @@ entities:
       parent: 2
 - proto: WarpPointVault
   entities:
-  - uid: 24007
+  - uid: 15064
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,15.5
+      pos: -28.5,-13.5
       parent: 2
 - proto: WashingMachineFilledClothes
   entities:
@@ -157489,11 +157704,6 @@ entities:
     - type: Transform
       pos: -42.5,-27.5
       parent: 2
-  - uid: 23460
-    components:
-    - type: Transform
-      pos: -24.5,-16.5
-      parent: 2
   - uid: 23461
     components:
     - type: Transform
@@ -157553,6 +157763,11 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-18.5
+      parent: 2
+  - uid: 23969
+    components:
+    - type: Transform
+      pos: -27.5,-18.5
       parent: 2
   - uid: 24037
     components:
@@ -157713,7 +157928,7 @@ entities:
       links:
       - 20116
     - type: Door
-      secondsUntilStateChange: -199403.67
+      secondsUntilStateChange: -202288.25
       state: Opening
   - uid: 23498
     components:
@@ -158321,6 +158536,11 @@ entities:
       parent: 2
 - proto: Window
   entities:
+  - uid: 3243
+    components:
+    - type: Transform
+      pos: -40.5,13.5
+      parent: 2
   - uid: 23597
     components:
     - type: Transform

--- a/Resources/Maps/Floof/radstation.yml
+++ b/Resources/Maps/Floof/radstation.yml
@@ -25,6 +25,7 @@ tilemap:
   80: FloorShuttleWhite
   84: FloorSteel
   85: FloorSteelCheckerDark
+  7: FloorSteelDirty
   92: FloorSteelMono
   96: FloorTechMaint
   97: FloorTechMaint2
@@ -75,11 +76,11 @@ entities:
           version: 6
         -1,0:
           ind: -1,0
-          tiles: VAAAAAADVAAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAABVAAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAACYAAAAAAAAQAAAAAAVAAAAAACVAAAAAADVAAAAAADVAAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAACYAAAAAAAAQAAAAAAVAAAAAAAVAAAAAADVAAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAACVAAAAAACVAAAAAADVAAAAAAAVAAAAAABVAAAAAACVAAAAAADVAAAAAAAYAAAAAAAAQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAABMAAAAAADMAAAAAADMAAAAAAAMAAAAAACVAAAAAABVAAAAAABVAAAAAAAYAAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAVAAAAAADVAAAAAABVAAAAAACMAAAAAADMAAAAAACMAAAAAADVAAAAAAAVAAAAAABVAAAAAAAVAAAAAABBgAAAAAAcQAAAAAABgAAAAAABgAAAAAABgAAAAAABgAAAAAAVAAAAAABVAAAAAACVAAAAAABVAAAAAACMAAAAAABMAAAAAADMAAAAAACcQAAAAAAcQAAAAAAVAAAAAACBgAAAAAAcQAAAAAABgAAAAAABgAAAAAABgAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAABMAAAAAAAMAAAAAACMAAAAAADMAAAAAACMAAAAAADVAAAAAAABgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAADMAAAAAADMAAAAAABMAAAAAABMAAAAAABVAAAAAADcQAAAAAAcQAAAAAAbgAAAAAAbgAAAAACbgAAAAAAbgAAAAADbgAAAAAAbgAAAAACVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAADMAAAAAABMAAAAAAAVAAAAAADbgAAAAABcQAAAAAAbgAAAAABbgAAAAACbgAAAAADbgAAAAAAbgAAAAACcQAAAAAAVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAMAAAAAADVAAAAAADbgAAAAADcQAAAAAAbgAAAAAAbgAAAAACbgAAAAACbgAAAAABbgAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAAAbgAAAAADbgAAAAACbgAAAAACbgAAAAAAbgAAAAABbgAAAAACbgAAAAABcQAAAAAAPAAAAAAAPAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAACVAAAAAACbgAAAAACcQAAAAAAbgAAAAAAbgAAAAAAbgAAAAACbgAAAAACbgAAAAACcQAAAAAAPAAAAAAAPAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAbgAAAAAAbgAAAAACbgAAAAABbgAAAAACbgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABbgAAAAABbgAAAAACcQAAAAAAVAAAAAABcQAAAAAAVAAAAAABbgAAAAACbgAAAAACbgAAAAAAbgAAAAACbgAAAAACVAAAAAACcQAAAAAAbgAAAAACbgAAAAACbgAAAAADbgAAAAAAbgAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADbgAAAAACbgAAAAADbgAAAAACbgAAAAABbgAAAAAAVAAAAAADbgAAAAABbgAAAAAAbgAAAAABbgAAAAAAbgAAAAABbgAAAAACcQAAAAAAVAAAAAAB
+          tiles: VAAAAAADVAAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAABVAAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAACYAAAAAAAAQAAAAAAVAAAAAACVAAAAAADVAAAAAADVAAAAAAAVAAAAAADVAAAAAABVAAAAAABVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAACYAAAAAAAAQAAAAAAVAAAAAAAVAAAAAADVAAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAACVAAAAAACVAAAAAADVAAAAAAAVAAAAAABVAAAAAACVAAAAAADVAAAAAAAYAAAAAAAAQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAABMAAAAAADMAAAAAADMAAAAAAAMAAAAAACVAAAAAABVAAAAAABVAAAAAAAYAAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAABgAAAAAAVAAAAAADVAAAAAABVAAAAAACMAAAAAADMAAAAAACMAAAAAADVAAAAAAAVAAAAAABVAAAAAAAVAAAAAABVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAABgAAAAAAVAAAAAABVAAAAAACVAAAAAABVAAAAAACMAAAAAABMAAAAAADMAAAAAACcQAAAAAAcQAAAAAAVAAAAAACVQAAAAAAcQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAABMAAAAAAAMAAAAAACMAAAAAADMAAAAAACMAAAAAADVAAAAAAAVQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAADMAAAAAADMAAAAAABMAAAAAABMAAAAAABVAAAAAADcQAAAAAAcQAAAAAAbgAAAAAAbgAAAAACbgAAAAAAbgAAAAADbgAAAAAAbgAAAAACVAAAAAACVAAAAAAAVAAAAAADVAAAAAACVAAAAAADMAAAAAABMAAAAAAAVAAAAAADbgAAAAABcQAAAAAAbgAAAAABbgAAAAACbgAAAAADbgAAAAAAbgAAAAACcQAAAAAAVAAAAAABVAAAAAADVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAMAAAAAADVAAAAAADbgAAAAADcQAAAAAAbgAAAAAAbgAAAAACbgAAAAACbgAAAAABbgAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAAAbgAAAAADbgAAAAACbgAAAAACbgAAAAAAbgAAAAABbgAAAAACbgAAAAABcQAAAAAAPAAAAAAAPAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAACVAAAAAACbgAAAAACcQAAAAAAbgAAAAAAbgAAAAAAbgAAAAACbgAAAAACbgAAAAACcQAAAAAAPAAAAAAAPAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAbgAAAAAAbgAAAAACbgAAAAABbgAAAAACbgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABbgAAAAABbgAAAAACcQAAAAAAVAAAAAABcQAAAAAAVAAAAAABbgAAAAACbgAAAAACbgAAAAAAbgAAAAACbgAAAAACVAAAAAACcQAAAAAAbgAAAAACbgAAAAACbgAAAAADbgAAAAAAbgAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADbgAAAAACbgAAAAADbgAAAAACbgAAAAABbgAAAAAAVAAAAAADbgAAAAABbgAAAAAAbgAAAAABbgAAAAAAbgAAAAABbgAAAAACcQAAAAAAVAAAAAAB
           version: 6
         -2,0:
           ind: -2,0
-          tiles: VAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAABVAAAAAAAVAAAAAAAVAAAAAADVAAAAAAAVAAAAAABVAAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAAAVAAAAAABVAAAAAAAVAAAAAACVAAAAAACVAAAAAAAVAAAAAACVAAAAAABVAAAAAAAVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAAAVAAAAAAAVAAAAAABVAAAAAAAVAAAAAACVAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAABVAAAAAAAVAAAAAAAVAAAAAAAVAAAAAACVAAAAAADVAAAAAABVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAABcQAAAAAAVAAAAAABVAAAAAABVAAAAAABcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABgAAAAAABgAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAABVAAAAAACcQAAAAAAVAAAAAABVAAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABgAAAAAABgAAAAAAVAAAAAAAVAAAAAACGwAAAAABGwAAAAAAVAAAAAADcQAAAAAAVAAAAAABVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAABgAAAAAABgAAAAAAcQAAAAAAVAAAAAACGwAAAAADGwAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAABgAAAAAABgAAAAAAcQAAAAAAVAAAAAABGwAAAAAAGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABbgAAAAABVAAAAAADcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAACbgAAAAABVAAAAAACVAAAAAACcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAbgAAAAACbgAAAAACVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAbgAAAAAAbgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAAAVAAAAAABGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAJgAAAAAAVAAAAAACcQAAAAAAVAAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAA
+          tiles: VAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAABVAAAAAAAVAAAAAAAVAAAAAADVAAAAAAAVAAAAAABVAAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAAAVAAAAAABVAAAAAAAVAAAAAACVAAAAAACVAAAAAAAVAAAAAACVAAAAAABVAAAAAAAVAAAAAADVAAAAAACVAAAAAAAVAAAAAADVAAAAAADVAAAAAACVAAAAAAAVAAAAAAAVAAAAAABVAAAAAAAVAAAAAACVAAAAAAAVAAAAAABVAAAAAABVAAAAAADVAAAAAACVAAAAAABVAAAAAAAVAAAAAAAVAAAAAAAVAAAAAACVAAAAAADVAAAAAABVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAABVAAAAAABcQAAAAAAVAAAAAABVAAAAAABVAAAAAABcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAABVAAAAAACcQAAAAAAVAAAAAABVAAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVQAAAAAAVQAAAAAAVAAAAAAAVAAAAAACGwAAAAABGwAAAAAAVAAAAAADcQAAAAAAVAAAAAABVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAVAAAAAACGwAAAAADGwAAAAADVAAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAVAAAAAABGwAAAAAAGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAABbgAAAAABVAAAAAADcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAbgAAAAACbgAAAAABVAAAAAACVAAAAAACcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAcQAAAAAAVAAAAAADcQAAAAAAbgAAAAACbgAAAAACVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAbgAAAAAAbgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAAAVAAAAAABGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAJgAAAAAAVAAAAAACcQAAAAAAVAAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAA
           version: 6
         -2,-1:
           ind: -2,-1
@@ -91,7 +92,7 @@ entities:
           version: 6
         0,1:
           ind: 0,1
-          tiles: VAAAAAACVAAAAAABVAAAAAADcQAAAAAAGwAAAAACGwAAAAACGwAAAAADGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAVAAAAAAAVAAAAAADVAAAAAADcQAAAAAAGwAAAAABGwAAAAAAGwAAAAACGwAAAAACcQAAAAAAGwAAAAADGwAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAGwAAAAADVAAAAAACVAAAAAACVAAAAAACGwAAAAAAGwAAAAADGwAAAAADGwAAAAAAGwAAAAADGwAAAAABGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABVAAAAAAAVAAAAAABVAAAAAACcQAAAAAAGwAAAAADGwAAAAACGwAAAAABGwAAAAADcQAAAAAAGwAAAAADGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAVQAAAAAAVAAAAAABVAAAAAADVAAAAAACcQAAAAAAcQAAAAAAVAAAAAADVAAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVQAAAAAAVAAAAAADVAAAAAAAVAAAAAACcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAJAAAAAAAVAAAAAACVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAJAAAAAAAVAAAAAADVAAAAAAAVAAAAAADcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAABGwAAAAABGwAAAAAAcQAAAAAAEQAAAAAFbgAAAAACbgAAAAAAbgAAAAABcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAADcQAAAAAAGwAAAAADJAAAAAAAJAAAAAAAJAAAAAACGwAAAAADcQAAAAAAEQAAAAAGbgAAAAADEQAAAAAEbgAAAAADbgAAAAAAcQAAAAAAVAAAAAACVAAAAAACVAAAAAAAGwAAAAADGwAAAAAAJAAAAAABJAAAAAACJAAAAAADGwAAAAABcQAAAAAAbgAAAAAAbgAAAAACEQAAAAABbgAAAAACEQAAAAADcQAAAAAAVAAAAAACVAAAAAADVAAAAAAAcQAAAAAAGwAAAAADGwAAAAADGwAAAAADGwAAAAAAGwAAAAABcQAAAAAAbgAAAAABEQAAAAABbgAAAAACbgAAAAADbgAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAADYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAVAAAAAACVAAAAAACVAAAAAABcQAAAAAAYQAAAAAAYQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAABVAAAAAACVAAAAAACcQAAAAAAYQAAAAAAYQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
+          tiles: VAAAAAACVAAAAAABVAAAAAADcQAAAAAAGwAAAAACGwAAAAACGwAAAAADGwAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAAAVAAAAAAAVAAAAAADVAAAAAADcQAAAAAAGwAAAAABGwAAAAAAGwAAAAACGwAAAAACcQAAAAAAGwAAAAADGwAAAAAAcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAGwAAAAADVAAAAAACVAAAAAACVAAAAAACGwAAAAAAGwAAAAADGwAAAAADGwAAAAAAGwAAAAADGwAAAAABGwAAAAACGwAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAGwAAAAABVAAAAAAAVAAAAAABVAAAAAACcQAAAAAAGwAAAAADGwAAAAACGwAAAAABGwAAAAADcQAAAAAAGwAAAAADGwAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAABwAAAAAAVAAAAAABVAAAAAADVAAAAAACcQAAAAAAcQAAAAAAVAAAAAADVAAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAABwAAAAAAVAAAAAADVAAAAAAAVAAAAAACcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAABwAAAAAAVAAAAAACVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACcQAAAAAAcQAAAAAABwAAAAAAVAAAAAADVAAAAAAAVAAAAAADcQAAAAAAGwAAAAAAGwAAAAAAGwAAAAABGwAAAAABGwAAAAAAcQAAAAAAEQAAAAAFbgAAAAACbgAAAAAAbgAAAAABcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAADcQAAAAAAGwAAAAADJAAAAAAAJAAAAAAAJAAAAAACGwAAAAADcQAAAAAAEQAAAAAGbgAAAAADEQAAAAAEbgAAAAADbgAAAAAAcQAAAAAAVAAAAAACVAAAAAACVAAAAAAAGwAAAAADGwAAAAAAJAAAAAABJAAAAAACJAAAAAADGwAAAAABcQAAAAAAbgAAAAAAbgAAAAACEQAAAAABbgAAAAACEQAAAAADcQAAAAAAVAAAAAACVAAAAAADVAAAAAAAcQAAAAAAGwAAAAADGwAAAAADGwAAAAADGwAAAAAAGwAAAAABcQAAAAAAbgAAAAABEQAAAAABbgAAAAACbgAAAAADbgAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAADYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAYQAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAVAAAAAACVAAAAAACVAAAAAABcQAAAAAAYQAAAAAAYQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAAAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAAAAAABVAAAAAACVAAAAAACcQAAAAAAYQAAAAAAYQAAAAAAYAAAAAAAYAAAAAAAYAAAAAAAcQAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAcAAAAAAA
           version: 6
         1,-1:
           ind: 1,-1
@@ -215,7 +216,7 @@ entities:
           version: 6
         1,1:
           ind: 1,1
-          tiles: GwAAAAABGwAAAAAAcQAAAAAAZAAAAAAAZAAAAAADZAAAAAABZAAAAAADZAAAAAACZAAAAAACZAAAAAACZAAAAAABcQAAAAAAVAAAAAABVAAAAAACVAAAAAABVAAAAAAAGwAAAAABGwAAAAADcQAAAAAAZAAAAAADZAAAAAAAZAAAAAACZAAAAAACZAAAAAADZAAAAAACZAAAAAABZAAAAAAAcQAAAAAAVAAAAAADVAAAAAAAVAAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAZAAAAAABZAAAAAABZAAAAAABZAAAAAADZAAAAAABZAAAAAADZAAAAAAAZAAAAAABcQAAAAAAVAAAAAABVAAAAAABVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAACZAAAAAADZAAAAAACZAAAAAABZAAAAAACZAAAAAABcQAAAAAAVAAAAAACVAAAAAABVAAAAAADcQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAcQAAAAAAKgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAABVAAAAAAAcQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAACcQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAVQAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAVAAAAAADVAAAAAACVAAAAAACVAAAAAADcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAADVAAAAAADcQAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAABcQAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACVAAAAAADVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAACVAAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAACGwAAAAABGwAAAAAAGwAAAAAAGwAAAAABVAAAAAADcQAAAAAAVAAAAAACVAAAAAACVAAAAAADVAAAAAADVAAAAAACcQAAAAAAGwAAAAADGwAAAAABGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVAAAAAAAcQAAAAAAVAAAAAADVAAAAAADVAAAAAAAVAAAAAAAVAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAADGwAAAAADGwAAAAAAGwAAAAACGwAAAAADGwAAAAACVAAAAAAAVAAAAAABVAAAAAABVAAAAAACVAAAAAADcQAAAAAA
+          tiles: GwAAAAABGwAAAAAAcQAAAAAAZAAAAAAAZAAAAAADZAAAAAABZAAAAAADZAAAAAACZAAAAAACZAAAAAACZAAAAAABcQAAAAAAVAAAAAABVAAAAAACVAAAAAABVAAAAAAAGwAAAAABGwAAAAADcQAAAAAAZAAAAAADZAAAAAAAZAAAAAACZAAAAAACZAAAAAADZAAAAAACZAAAAAABZAAAAAAAcQAAAAAAVAAAAAADVAAAAAAAVAAAAAAAcQAAAAAAGwAAAAACGwAAAAAAcQAAAAAAZAAAAAABZAAAAAABZAAAAAABZAAAAAADZAAAAAABZAAAAAADZAAAAAAAZAAAAAABcQAAAAAAVAAAAAABVAAAAAABVAAAAAACcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAZAAAAAACZAAAAAADZAAAAAACZAAAAAABZAAAAAACZAAAAAABcQAAAAAAVAAAAAACVAAAAAABVAAAAAADcQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAcQAAAAAAcQAAAAAAKgAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAABVAAAAAAAcQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAcQAAAAAAcQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAVAAAAAAAVAAAAAACVAAAAAACcQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAcQAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAKgAAAAAAcQAAAAAAVAAAAAADVAAAAAACVAAAAAACVAAAAAADcQAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAADVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAABVAAAAAACVAAAAAADVAAAAAADcQAAAAAAVAAAAAADVAAAAAACVAAAAAADcQAAAAAAcQAAAAAAVAAAAAABVAAAAAAAVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAADVAAAAAADVAAAAAABcQAAAAAAVAAAAAABVAAAAAADVAAAAAADVAAAAAABcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAACVAAAAAADVAAAAAABVAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAVAAAAAAAVAAAAAABVAAAAAACVAAAAAAAcQAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAACGwAAAAABGwAAAAAAGwAAAAAAGwAAAAABVAAAAAADcQAAAAAAVAAAAAACVAAAAAACVAAAAAADVAAAAAADVAAAAAACcQAAAAAAGwAAAAADGwAAAAABGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAGwAAAAAAVAAAAAAAcQAAAAAAVAAAAAADVAAAAAADVAAAAAAAVAAAAAAAVAAAAAAAcQAAAAAAGwAAAAACGwAAAAABGwAAAAABGwAAAAADGwAAAAADGwAAAAAAGwAAAAACGwAAAAADGwAAAAACVAAAAAAAVAAAAAABVAAAAAABVAAAAAACVAAAAAADcQAAAAAA
           version: 6
         2,1:
           ind: 2,1
@@ -1033,6 +1034,7 @@ entities:
             7471: -38,22
             7472: -38,21
             7554: 20,-12
+            7555: -38,39
         - node:
             angle: 1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -1104,6 +1106,8 @@ entities:
             5524: 8,-22
             5826: 32,-23
             5827: 30,-23
+            7556: -13,6
+            7557: -18,4
         - node:
             color: '#DE3A3AFF'
             id: BoxGreyscale
@@ -11472,6 +11476,13 @@ entities:
     - type: Transform
       pos: -16.5,8.5
       parent: 2
+    - type: DeviceList
+      devices:
+      - 24245
+      - 24246
+      - 24257
+      - 24258
+      - 24259
   - uid: 6
     components:
     - type: Transform
@@ -14671,16 +14682,6 @@ entities:
     - type: Transform
       pos: 10.5,8.5
       parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
-  - uid: 324
-    components:
-    - type: Transform
-      pos: -18.5,6.5
-      parent: 2
   - uid: 326
     components:
     - type: Transform
@@ -14976,7 +14977,7 @@ entities:
       pos: -23.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1376.7728
+      secondsUntilStateChange: -3040.622
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15010,7 +15011,7 @@ entities:
       pos: 34.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -65995.96
+      secondsUntilStateChange: -67659.81
       state: Opening
   - uid: 386
     components:
@@ -15061,6 +15062,12 @@ entities:
     - type: Transform
       pos: -16.5,-12.5
       parent: 2
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,24.5
+      parent: 2
   - uid: 9271
     components:
     - type: Transform
@@ -15101,6 +15108,13 @@ entities:
     components:
     - type: Transform
       pos: 27.5,-33.5
+      parent: 2
+- proto: AirlockMaintReporterLocked
+  entities:
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -18.5,6.5
       parent: 2
 - proto: AirlockMaintRnDLocked
   entities:
@@ -15282,6 +15296,13 @@ entities:
     - type: Transform
       pos: -22.5,7.5
       parent: 2
+- proto: AirlockReporterLocked
+  entities:
+  - uid: 7608
+    components:
+    - type: Transform
+      pos: -15.5,3.5
+      parent: 2
 - proto: AirlockResearchDirectorLocked
   entities:
   - uid: 429
@@ -15316,7 +15337,7 @@ entities:
       pos: -35.5,-8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1778.8046
+      secondsUntilStateChange: -3442.6538
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15593,13 +15614,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -23.5,26.5
-      parent: 2
-- proto: AirlockServiceLocked
-  entities:
-  - uid: 480
-    components:
-    - type: Transform
-      pos: 17.5,24.5
       parent: 2
 - proto: AirlockTheatreLocked
   entities:
@@ -16350,6 +16364,15 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12214
+  - uid: 24257
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
 - proto: AltarSpawner
   entities:
   - uid: 605
@@ -16939,11 +16962,6 @@ entities:
       parent: 2
 - proto: Ash
   entities:
-  - uid: 695
-    components:
-    - type: Transform
-      pos: -14.458229,4.527739
-      parent: 2
   - uid: 697
     components:
     - type: Transform
@@ -17555,33 +17573,25 @@ entities:
       parent: 2
 - proto: BarberScissors
   entities:
-  - uid: 24110
+  - uid: 828
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -12.985006,6.54281
+      pos: 15.539359,23.01795
+      parent: 2
+  - uid: 23165
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.46936,21.006554
       parent: 2
 - proto: BarberSignPole
   entities:
-  - uid: 16599
+  - uid: 8644
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,6.5
-      parent: 2
-- proto: BarberSignThesnip
-  entities:
-  - uid: 17774
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,2.5
-      parent: 2
-  - uid: 19909
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,4.5
+      rot: 3.141592653589793 rad
+      pos: 18.5,25.5
       parent: 2
 - proto: Barricade
   entities:
@@ -17597,11 +17607,6 @@ entities:
       parent: 2
 - proto: BarricadeBlock
   entities:
-  - uid: 828
-    components:
-    - type: Transform
-      pos: -15.5,3.5
-      parent: 2
   - uid: 830
     components:
     - type: Transform
@@ -18324,6 +18329,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 43.5,-25.5
       parent: 2
+  - uid: 10973
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 2
 - proto: BenchSofaCorpRight
   entities:
   - uid: 987
@@ -18331,6 +18342,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 44.5,-25.5
+      parent: 2
+  - uid: 11558
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
       parent: 2
 - proto: BenchSofaLeft
   entities:
@@ -19806,13 +19823,19 @@ entities:
   - uid: 1220
     components:
     - type: Transform
-      pos: 17.663635,21.630175
+      pos: -16.555672,7.451659
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 1221
     components:
     - type: Transform
-      pos: 17.84079,21.471666
+      pos: -16.601093,6.7563844
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: BoxFolderBlue
   entities:
   - uid: 1223
@@ -19960,8 +19983,11 @@ entities:
   - uid: 1249
     components:
     - type: Transform
-      pos: 17.421211,21.490314
+      pos: -16.421093,6.7563844
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: BoxFolderGrey
   entities:
   - uid: 1250
@@ -52565,41 +52591,25 @@ entities:
       rot: 3.141592653589793 rad
       pos: 40.5,-2.5
       parent: 2
-  - uid: 7607
+  - uid: 16477
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,20.5
+      pos: -16.5,6.5
       parent: 2
-  - uid: 7608
+  - uid: 22298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,21.5
+      pos: -16.5,7.5
       parent: 2
-  - uid: 7609
+  - uid: 24110
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,20.5
+      pos: -15.5,7.5
       parent: 2
-  - uid: 7610
+  - uid: 24204
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,21.5
-      parent: 2
-  - uid: 7611
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,20.5
-      parent: 2
-  - uid: 7612
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,21.5
+      pos: -15.5,6.5
       parent: 2
 - proto: CarpetOrange
   entities:
@@ -58519,24 +58529,31 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 6.5,-59.5
       parent: 2
-  - uid: 8644
-    components:
-    - type: Transform
-      pos: 19.5,22.5
-      parent: 2
 - proto: ChairBarber
   entities:
-  - uid: 23166
+  - uid: 8686
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,5.5
+      rot: -1.5707963267948966 rad
+      pos: 16.5,23.5
       parent: 2
-  - uid: 24205
+  - uid: 19502
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: 18.5,20.5
+      parent: 2
+  - uid: 23489
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,21.5
+      parent: 2
+  - uid: 24109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,22.5
       parent: 2
 - proto: ChairFolding
   entities:
@@ -58758,11 +58775,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -22.5,-55.5
       parent: 2
-  - uid: 8686
+  - uid: 9027
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 19.5,20.5
+      pos: -15.485475,6.776915
       parent: 2
 - proto: ChairOfficeLight
   entities:
@@ -60186,11 +60203,6 @@ entities:
     - type: Transform
       pos: 12.5,19.5
       parent: 2
-  - uid: 16156
-    components:
-    - type: Transform
-      pos: -17.5,4.5
-      parent: 2
   - uid: 16650
     components:
     - type: Transform
@@ -60229,6 +60241,11 @@ entities:
     components:
     - type: Transform
       pos: 34.5,23.5
+      parent: 2
+  - uid: 23164
+    components:
+    - type: Transform
+      pos: 19.5,22.5
       parent: 2
 - proto: ClosetToolFilled
   entities:
@@ -61212,6 +61229,11 @@ entities:
       parent: 2
 - proto: ComfyChair
   entities:
+  - uid: 3964
+    components:
+    - type: Transform
+      pos: -11.5,6.5
+      parent: 2
   - uid: 9060
     components:
     - type: Transform
@@ -61832,10 +61854,10 @@ entities:
       parent: 2
 - proto: ComputerMassMedia
   entities:
-  - uid: 9167
+  - uid: 7609
     components:
     - type: Transform
-      pos: 19.5,21.5
+      pos: -15.5,7.5
       parent: 2
 - proto: ComputerMassMediaCircuitboard
   entities:
@@ -63554,6 +63576,18 @@ entities:
     - type: Transform
       pos: 34.5,24.5
       parent: 2
+- proto: CryogenicSleepUnitSpawnerPrisoner
+  entities:
+  - uid: 16991
+    components:
+    - type: Transform
+      pos: -36.5,39.5
+      parent: 2
+  - uid: 23166
+    components:
+    - type: Transform
+      pos: -37.5,39.5
+      parent: 2
 - proto: CryoPod
   entities:
   - uid: 9390
@@ -63641,6 +63675,18 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 40.5,42.5
+      parent: 2
+  - uid: 24255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 24256
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
       parent: 2
 - proto: CurtainsRedOpen
   entities:
@@ -64083,10 +64129,10 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconReporter
   entities:
-  - uid: 16477
+  - uid: 7607
     components:
     - type: Transform
-      pos: 17.5,22.5
+      pos: -16.5,5.5
       parent: 2
 - proto: DefaultStationBeaconRND
   entities:
@@ -65112,6 +65158,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 36.5,36.5
       parent: 2
+  - uid: 24205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.5,4.5
+      parent: 2
+  - uid: 24226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,4.5
+      parent: 2
+  - uid: 24227
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,2.5
+      parent: 2
 - proto: DisposalJunction
   entities:
   - uid: 3966
@@ -65304,6 +65368,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,11.5
+      parent: 2
+  - uid: 16179
+    components:
+    - type: Transform
+      pos: 0.5,2.5
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
@@ -67486,11 +67555,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,3.5
-      parent: 2
-  - uid: 10019
-    components:
-    - type: Transform
-      pos: 0.5,2.5
       parent: 2
   - uid: 10020
     components:
@@ -70031,6 +70095,102 @@ entities:
     - type: Transform
       pos: -32.5,12.5
       parent: 2
+  - uid: 24228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,3.5
+      parent: 2
+  - uid: 24229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -14.5,2.5
+      parent: 2
+  - uid: 24230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,2.5
+      parent: 2
+  - uid: 24231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,2.5
+      parent: 2
+  - uid: 24232
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,2.5
+      parent: 2
+  - uid: 24233
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,2.5
+      parent: 2
+  - uid: 24234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,2.5
+      parent: 2
+  - uid: 24235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,2.5
+      parent: 2
+  - uid: 24236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,2.5
+      parent: 2
+  - uid: 24237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,2.5
+      parent: 2
+  - uid: 24238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 24239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 24240
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 24241
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 24242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 24243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 2
 - proto: DisposalPipeBroken
   entities:
   - uid: 10459
@@ -70497,6 +70657,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -31.5,16.5
       parent: 2
+  - uid: 23357
+    components:
+    - type: Transform
+      pos: -14.5,5.5
+      parent: 2
   - uid: 24125
     components:
     - type: Transform
@@ -70898,6 +71063,11 @@ entities:
     components:
     - type: Transform
       pos: 33.5,-36.5
+      parent: 2
+  - uid: 17774
+    components:
+    - type: Transform
+      pos: -14.5,5.5
       parent: 2
   - uid: 20361
     components:
@@ -71328,8 +71498,11 @@ entities:
   - uid: 10683
     components:
     - type: Transform
-      pos: 18.667133,21.53536
+      pos: -16.451096,6.59127
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: DrinkMugRainbow
   entities:
   - uid: 10684
@@ -72943,13 +73116,13 @@ entities:
       parent: 2
 - proto: FaxMachineBase
   entities:
-  - uid: 10973
+  - uid: 7610
     components:
     - type: Transform
-      pos: 17.5,21.5
+      pos: -16.5,7.5
       parent: 2
     - type: FaxMachine
-      name: Reporter
+      name: Reporters Office
   - uid: 10974
     components:
     - type: Transform
@@ -77291,6 +77464,24 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 34.5,38.5
       parent: 2
+  - uid: 24258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+  - uid: 24259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
 - proto: Fireplace
   entities:
   - uid: 11516
@@ -77576,8 +77767,11 @@ entities:
   - uid: 11559
     components:
     - type: Transform
-      pos: 18.205593,21.53536
+      pos: -16.406094,6.6586804
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: FoodBurgerEmpowered
   entities:
   - uid: 11560
@@ -80371,6 +80565,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 24251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -20.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
 - proto: GasPipeFourway
   entities:
   - uid: 276
@@ -86345,14 +86547,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -16.5,1.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 12702
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,1.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -93714,14 +93908,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FF0000FF'
-  - uid: 13655
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#FF0000FF'
   - uid: 13656
     components:
     - type: Transform
@@ -99076,6 +99262,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 16609
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
   - uid: 16755
     components:
     - type: Transform
@@ -99443,6 +99637,70 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 24203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 24244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 24247
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24248
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24249
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24252
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -19.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24253
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 10251
@@ -101852,6 +102110,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#FFA500FF'
+  - uid: 16599
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 24189
     components:
     - type: Transform
@@ -101873,6 +102139,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 24254
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,0.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
 - proto: GasPort
   entities:
   - uid: 157
@@ -103773,6 +104047,16 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 24245
+    components:
+    - type: Transform
+      pos: -15.5,4.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 14905
@@ -105032,6 +105316,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 12214
+    - type: AtmosPipeColor
+      color: '#FF0000FF'
+  - uid: 24246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5
     - type: AtmosPipeColor
       color: '#FF0000FF'
 - proto: GasVolumePump
@@ -108045,6 +108340,18 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -42.5,21.5
       parent: 2
+  - uid: 19650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 19817
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,5.5
+      parent: 2
 - proto: GrilleBroken
   entities:
   - uid: 15609
@@ -109660,13 +109967,6 @@ entities:
     components:
     - type: Transform
       pos: 2.524012,-59.40162
-      parent: 2
-- proto: Jug
-  entities:
-  - uid: 19512
-    components:
-    - type: Transform
-      pos: -15.502858,5.7273717
       parent: 2
 - proto: KitchenElectricGrill
   entities:
@@ -111711,6 +112011,12 @@ entities:
       parent: 2
 - proto: Mirror
   entities:
+  - uid: 13655
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,23.5
+      parent: 2
   - uid: 16158
     components:
     - type: Transform
@@ -111740,15 +112046,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 33.5,-29.5
       parent: 2
-  - uid: 17773
+  - uid: 23717
     components:
     - type: Transform
-      pos: -13.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 20.5,20.5
       parent: 2
-  - uid: 23164
+  - uid: 23718
     components:
     - type: Transform
-      pos: -12.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: 20.5,21.5
+      parent: 2
+  - uid: 23719
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,22.5
       parent: 2
 - proto: MMI
   entities:
@@ -111833,11 +112147,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-18.5
-      parent: 2
-  - uid: 16179
-    components:
-    - type: Transform
-      pos: -36.5,39.5
       parent: 2
   - uid: 16180
     components:
@@ -117357,28 +117666,6 @@ entities:
       parent: 2
 - proto: PoweredlightLED
   entities:
-  - uid: 16989
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 33.5,32.5
-      parent: 2
-  - uid: 16990
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 39.5,32.5
-      parent: 2
-  - uid: 16991
-    components:
-    - type: Transform
-      pos: 33.5,41.5
-      parent: 2
-  - uid: 16992
-    components:
-    - type: Transform
-      pos: 39.5,41.5
-      parent: 2
   - uid: 16993
     components:
     - type: Transform
@@ -117390,6 +117677,30 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,77.5
+      parent: 2
+  - uid: 24260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,40.5
+      parent: 2
+  - uid: 24261
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 37.5,40.5
+      parent: 2
+  - uid: 24262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 35.5,33.5
+      parent: 2
+  - uid: 24263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 37.5,33.5
       parent: 2
 - proto: PoweredLightPostSmall
   entities:
@@ -117615,6 +117926,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -17.5,-2.5
       parent: 2
+  - uid: 16613
+    components:
+    - type: Transform
+      pos: -17.5,7.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 18445
   - uid: 17028
     components:
     - type: Transform
@@ -117661,15 +117981,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 10.5,-58.5
       parent: 2
-  - uid: 17034
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,5.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18445
   - uid: 17035
     components:
     - type: Transform
@@ -118405,6 +118716,25 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 26.5,-69.5
       parent: 2
+  - uid: 19512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -17.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 18445
+  - uid: 19649
+    components:
+    - type: Transform
+      pos: -12.5,6.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 18445
   - uid: 24171
     components:
     - type: Transform
@@ -123651,6 +123981,18 @@ entities:
     - type: Transform
       pos: -35.5,-0.5
       parent: 2
+  - uid: 18217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 18218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,4.5
+      parent: 2
 - proto: RemoteSignaller
   entities:
   - uid: 18098
@@ -124355,24 +124697,6 @@ entities:
       fixtures: {}
 - proto: ShuttersNormal
   entities:
-  - uid: 18217
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,4.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18340
-  - uid: 18218
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,5.5
-      parent: 2
-    - type: DeviceLinkSink
-      links:
-      - 18340
   - uid: 18219
     components:
     - type: Transform
@@ -125442,18 +125766,6 @@ entities:
         1061:
         - Pressed: Toggle
         1062:
-        - Pressed: Toggle
-  - uid: 18340
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,6.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        18218:
-        - Pressed: Toggle
-        18217:
         - Pressed: Toggle
   - uid: 18341
     components:
@@ -126580,7 +126892,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -29.5,-15.5
       parent: 2
-    - type: DeviceLinkSource
   - uid: 18426
     components:
     - type: Transform
@@ -126842,7 +127153,11 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        17034:
+        19649:
+        - Status: Toggle
+        19512:
+        - Status: Toggle
+        16613:
         - Status: Toggle
   - uid: 18446
     components:
@@ -128112,11 +128427,11 @@ entities:
       parent: 2
 - proto: SignBarbershop
   entities:
-  - uid: 16609
+  - uid: 9167
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -11.5,3.5
+      pos: 18.5,24.5
       parent: 2
 - proto: SignBio
   entities:
@@ -128199,14 +128514,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,24.5
-      parent: 2
-- proto: SignDirectionalWash
-  entities:
-  - uid: 11558
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,3.5
       parent: 2
 - proto: SignDoors
   entities:
@@ -128390,6 +128697,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-27.5
+      parent: 2
+- proto: SignNews
+  entities:
+  - uid: 19080
+    components:
+    - type: Transform
+      pos: -11.5,3.5
       parent: 2
 - proto: SignNosmoking
   entities:
@@ -131034,6 +131348,21 @@ entities:
       parent: 2
 - proto: SpawnPointObserver
   entities:
+  - uid: 16992
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 17034
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 17773
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
   - uid: 19018
     components:
     - type: Transform
@@ -131385,10 +131714,15 @@ entities:
       parent: 2
 - proto: SpawnPointReporter
   entities:
-  - uid: 19080
+  - uid: 19646
     components:
     - type: Transform
-      pos: 18.5,20.5
+      pos: -11.5,6.5
+      parent: 2
+  - uid: 19647
+    components:
+    - type: Transform
+      pos: -15.5,6.5
       parent: 2
 - proto: SpawnPointResearchAssistant
   entities:
@@ -131580,11 +131914,6 @@ entities:
     components:
     - type: Transform
       pos: 34.5,11.5
-      parent: 2
-  - uid: 24203
-    components:
-    - type: Transform
-      pos: -16.5,5.5
       parent: 2
 - proto: SpawnPointStationEngineer
   entities:
@@ -134716,19 +135045,18 @@ entities:
       - SurveillanceCameraEntertainment
       nameSet: True
       id: 24 Hour Court
-- proto: SurveillanceWirelessCameraMovableConstructed
-  entities:
-  - uid: 19501
+  - uid: 23720
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,23.5
+      pos: -12.5,6.5
       parent: 2
-  - uid: 19502
+- proto: SurveillanceWirelessCameraMovableEntertainment
+  entities:
+  - uid: 695
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 15.5,22.5
+      pos: -17.5,4.5
       parent: 2
 - proto: SynthesizerInstrument
   entities:
@@ -134765,11 +135093,15 @@ entities:
       parent: 2
 - proto: Table
   entities:
-  - uid: 16613
+  - uid: 16990
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,5.5
+      pos: -16.5,7.5
+      parent: 2
+  - uid: 19501
+    components:
+    - type: Transform
+      pos: -16.5,6.5
       parent: 2
   - uid: 19508
     components:
@@ -135501,32 +135833,10 @@ entities:
     - type: Transform
       pos: 22.5,-45.5
       parent: 2
-  - uid: 19646
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,5.5
-      parent: 2
-  - uid: 19647
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,4.5
-      parent: 2
   - uid: 19648
     components:
     - type: Transform
       pos: 41.5,-25.5
-      parent: 2
-  - uid: 19649
-    components:
-    - type: Transform
-      pos: 18.5,21.5
-      parent: 2
-  - uid: 19650
-    components:
-    - type: Transform
-      pos: 17.5,21.5
       parent: 2
   - uid: 19651
     components:
@@ -135570,16 +135880,6 @@ entities:
     components:
     - type: Transform
       pos: 9.5,48.5
-      parent: 2
-  - uid: 23165
-    components:
-    - type: Transform
-      pos: -13.5,6.5
-      parent: 2
-  - uid: 24204
-    components:
-    - type: Transform
-      pos: -12.5,6.5
       parent: 2
 - proto: TableCarpet
   entities:
@@ -135959,6 +136259,30 @@ entities:
       parent: 2
 - proto: TableReinforced
   entities:
+  - uid: 7611
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,20.5
+      parent: 2
+  - uid: 7612
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,21.5
+      parent: 2
+  - uid: 10019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,23.5
+      parent: 2
+  - uid: 12702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,22.5
+      parent: 2
   - uid: 15270
     components:
     - type: Transform
@@ -136497,11 +136821,6 @@ entities:
     components:
     - type: Transform
       pos: -42.5,34.5
-      parent: 2
-  - uid: 19817
-    components:
-    - type: Transform
-      pos: -37.5,39.5
       parent: 2
   - uid: 19819
     components:
@@ -138971,6 +139290,11 @@ entities:
       parent: 2
 - proto: VendingMachineCoffee
   entities:
+  - uid: 18340
+    components:
+    - type: Transform
+      pos: -13.5,6.5
+      parent: 2
   - uid: 20162
     components:
     - type: Transform
@@ -151192,11 +151516,6 @@ entities:
     - type: Transform
       pos: -14.5,6.5
       parent: 2
-  - uid: 22298
-    components:
-    - type: Transform
-      pos: -14.5,5.5
-      parent: 2
   - uid: 22299
     components:
     - type: Transform
@@ -156869,15 +157188,15 @@ entities:
       parent: 2
 - proto: WardrobeFormal
   entities:
+  - uid: 16989
+    components:
+    - type: Transform
+      pos: -17.5,7.5
+      parent: 2
   - uid: 23356
     components:
     - type: Transform
       pos: -35.5,-60.5
-      parent: 2
-  - uid: 23357
-    components:
-    - type: Transform
-      pos: 18.5,23.5
       parent: 2
 - proto: WardrobeGeneticsFilled
   entities:
@@ -157213,10 +157532,10 @@ entities:
       parent: 2
 - proto: WarpPointReporter
   entities:
-  - uid: 15684
+  - uid: 324
     components:
     - type: Transform
-      pos: 17.5,22.5
+      pos: -16.5,5.5
       parent: 2
 - proto: WarpPointSecurity
   entities:
@@ -157232,26 +157551,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,-13.5
-      parent: 2
-- proto: WashingMachineFilledClothes
-  entities:
-  - uid: 3964
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,7.5
-      parent: 2
-  - uid: 9027
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,7.5
-      parent: 2
-  - uid: 24109
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,7.5
       parent: 2
 - proto: WaterCooler
   entities:
@@ -157859,12 +158158,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 46.5,-37.5
       parent: 2
-  - uid: 23489
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,4.5
-      parent: 2
 - proto: WindoorBarKitchenLocked
   entities:
   - uid: 23490
@@ -157925,7 +158218,7 @@ entities:
       links:
       - 20116
     - type: Door
-      secondsUntilStateChange: -202288.25
+      secondsUntilStateChange: -203952.1
       state: Opening
   - uid: 23498
     components:
@@ -158525,11 +158818,10 @@ entities:
       parent: 2
 - proto: WindoorServiceLocked
   entities:
-  - uid: 23596
+  - uid: 15684
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,20.5
+      pos: -15.5,6.5
       parent: 2
 - proto: Window
   entities:
@@ -158869,6 +159161,23 @@ entities:
       parent: 2
 - proto: WindowDirectional
   entities:
+  - uid: 16156
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,6.5
+      parent: 2
+  - uid: 19909
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,7.5
+      parent: 2
+  - uid: 23596
+    components:
+    - type: Transform
+      pos: -16.5,6.5
+      parent: 2
   - uid: 23656
     components:
     - type: Transform
@@ -159218,30 +159527,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 39.5,-22.5
-      parent: 2
-  - uid: 23717
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,21.5
-      parent: 2
-  - uid: 23718
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,21.5
-      parent: 2
-  - uid: 23719
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,21.5
-      parent: 2
-  - uid: 23720
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,21.5
       parent: 2
 - proto: WindowFrostedDirectional
   entities:

--- a/Resources/Maps/Floof/radstation.yml
+++ b/Resources/Maps/Floof/radstation.yml
@@ -14977,7 +14977,7 @@ entities:
       pos: -23.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -3040.622
+      secondsUntilStateChange: -4105.455
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15011,7 +15011,7 @@ entities:
       pos: 34.5,-35.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -67659.81
+      secondsUntilStateChange: -68724.65
       state: Opening
   - uid: 386
     components:
@@ -15337,7 +15337,7 @@ entities:
       pos: -35.5,-8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -3442.6538
+      secondsUntilStateChange: -4507.487
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -16891,12 +16891,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,-11.5
       parent: 2
-  - uid: 688
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,-27.5
-      parent: 2
   - uid: 891
     components:
     - type: Transform
@@ -16914,6 +16908,20 @@ entities:
     - type: Transform
       pos: 11.5,-56.5
       parent: 2
+  - uid: 1860
+    components:
+    - type: Transform
+      pos: -14.5,-25.5
+      parent: 2
+  - uid: 6502
+    components:
+    - type: Transform
+      pos: -31.5,-28.5
+      parent: 2
+    - type: Apc
+      hasAccess: True
+      lastExternalState: Good
+      lastChargeState: Full
   - uid: 9185
     components:
     - type: MetaData
@@ -23136,15 +23144,10 @@ entities:
     - type: Transform
       pos: -25.5,-28.5
       parent: 2
-  - uid: 1860
-    components:
-    - type: Transform
-      pos: -27.5,-27.5
-      parent: 2
   - uid: 1861
     components:
     - type: Transform
-      pos: -26.5,-27.5
+      pos: -14.5,-25.5
       parent: 2
   - uid: 1862
     components:
@@ -23325,16 +23328,6 @@ entities:
     components:
     - type: Transform
       pos: -26.5,-30.5
-      parent: 2
-  - uid: 1898
-    components:
-    - type: Transform
-      pos: -27.5,-30.5
-      parent: 2
-  - uid: 1899
-    components:
-    - type: Transform
-      pos: -28.5,-30.5
       parent: 2
   - uid: 1900
     components:
@@ -37066,6 +37059,16 @@ entities:
     - type: Transform
       pos: -28.5,-10.5
       parent: 2
+  - uid: 24271
+    components:
+    - type: Transform
+      pos: -31.5,-28.5
+      parent: 2
+  - uid: 24272
+    components:
+    - type: Transform
+      pos: -14.5,-26.5
+      parent: 2
 - proto: CableApcStack
   entities:
   - uid: 4626
@@ -44986,6 +44989,11 @@ entities:
     - type: Transform
       pos: -11.5,-8.5
       parent: 2
+  - uid: 3243
+    components:
+    - type: Transform
+      pos: -33.5,17.5
+      parent: 2
   - uid: 3825
     components:
     - type: Transform
@@ -46726,20 +46734,15 @@ entities:
     - type: Transform
       pos: -24.5,-27.5
       parent: 2
-  - uid: 6502
-    components:
-    - type: Transform
-      pos: -25.5,-27.5
-      parent: 2
   - uid: 6503
     components:
     - type: Transform
-      pos: -26.5,-27.5
+      pos: -31.5,-30.5
       parent: 2
   - uid: 6504
     components:
     - type: Transform
-      pos: -27.5,-27.5
+      pos: -31.5,-29.5
       parent: 2
   - uid: 6505
     components:
@@ -49184,12 +49187,12 @@ entities:
   - uid: 6999
     components:
     - type: Transform
-      pos: -40.5,10.5
+      pos: -33.5,16.5
       parent: 2
   - uid: 7000
     components:
     - type: Transform
-      pos: -40.5,8.5
+      pos: -38.5,14.5
       parent: 2
   - uid: 7001
     components:
@@ -49199,7 +49202,7 @@ entities:
   - uid: 7002
     components:
     - type: Transform
-      pos: -40.5,11.5
+      pos: -35.5,17.5
       parent: 2
   - uid: 7003
     components:
@@ -49209,17 +49212,17 @@ entities:
   - uid: 7004
     components:
     - type: Transform
-      pos: -40.5,13.5
+      pos: -40.5,14.5
       parent: 2
   - uid: 7005
     components:
     - type: Transform
-      pos: -40.5,14.5
+      pos: -36.5,17.5
       parent: 2
   - uid: 7006
     components:
     - type: Transform
-      pos: -40.5,13.5
+      pos: -37.5,17.5
       parent: 2
   - uid: 7007
     components:
@@ -50686,6 +50689,11 @@ entities:
     - type: Transform
       pos: -19.5,-12.5
       parent: 2
+  - uid: 7822
+    components:
+    - type: Transform
+      pos: -38.5,17.5
+      parent: 2
   - uid: 8642
     components:
     - type: Transform
@@ -50730,6 +50738,11 @@ entities:
     components:
     - type: Transform
       pos: -18.5,5.5
+      parent: 2
+  - uid: 11590
+    components:
+    - type: Transform
+      pos: -38.5,16.5
       parent: 2
   - uid: 15970
     components:
@@ -50801,6 +50814,11 @@ entities:
     - type: Transform
       pos: -33.5,-15.5
       parent: 2
+  - uid: 22567
+    components:
+    - type: Transform
+      pos: -31.5,-28.5
+      parent: 2
   - uid: 24007
     components:
     - type: Transform
@@ -50850,6 +50868,31 @@ entities:
     components:
     - type: Transform
       pos: -32.5,10.5
+      parent: 2
+  - uid: 24273
+    components:
+    - type: Transform
+      pos: -14.5,-25.5
+      parent: 2
+  - uid: 24274
+    components:
+    - type: Transform
+      pos: -14.5,-26.5
+      parent: 2
+  - uid: 24276
+    components:
+    - type: Transform
+      pos: -38.5,15.5
+      parent: 2
+  - uid: 24277
+    components:
+    - type: Transform
+      pos: -39.5,14.5
+      parent: 2
+  - uid: 24280
+    components:
+    - type: Transform
+      pos: -34.5,17.5
       parent: 2
 - proto: CableMVStack
   entities:
@@ -53777,18 +53820,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,13.5
-      parent: 2
-  - uid: 7821
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,13.5
-      parent: 2
-  - uid: 7822
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,14.5
       parent: 2
   - uid: 7823
     components:
@@ -58208,6 +58239,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -37.5,14.5
+      parent: 2
+  - uid: 24278
+    components:
+    - type: Transform
+      pos: -40.5,14.5
       parent: 2
 - proto: CellRechargerCircuitboard
   entities:
@@ -63715,6 +63751,13 @@ entities:
     - type: Transform
       pos: -15.5,-6.5
       parent: 2
+- proto: CyborgEndoskeleton
+  entities:
+  - uid: 24275
+    components:
+    - type: Transform
+      pos: -21.5,-21.5
+      parent: 2
 - proto: DarkTile
   entities:
   - uid: 23986
@@ -63771,6 +63814,13 @@ entities:
     components:
     - type: Transform
       pos: -21.5,-13.5
+      parent: 2
+- proto: DefaultStationBeacon
+  entities:
+  - uid: 24270
+    components:
+    - type: Transform
+      pos: 0.5,0.5
       parent: 2
 - proto: DefaultStationBeaconAICore
   entities:
@@ -63909,6 +63959,11 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconChemistry
   entities:
+  - uid: 1899
+    components:
+    - type: Transform
+      pos: 31.5,-18.5
+      parent: 2
   - uid: 9414
     components:
     - type: Transform
@@ -63989,6 +64044,11 @@ entities:
     - type: Transform
       pos: 29.5,41.5
       parent: 2
+  - uid: 24265
+    components:
+    - type: Transform
+      pos: -48.5,-26.5
+      parent: 2
 - proto: DefaultStationBeaconEvac
   entities:
   - uid: 9425
@@ -64042,6 +64102,11 @@ entities:
     components:
     - type: Transform
       pos: 23.5,17.5
+      parent: 2
+  - uid: 19895
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
       parent: 2
 - proto: DefaultStationBeaconLawOffice
   entities:
@@ -64113,6 +64178,13 @@ entities:
     - type: Transform
       pos: -18.5,-57.5
       parent: 2
+- proto: DefaultStationBeaconPsychologist
+  entities:
+  - uid: 1898
+    components:
+    - type: Transform
+      pos: 45.5,-22.5
+      parent: 2
 - proto: DefaultStationBeaconQMRoom
   entities:
   - uid: 9442
@@ -64154,6 +64226,11 @@ entities:
     components:
     - type: Transform
       pos: -39.5,-10.5
+      parent: 2
+  - uid: 24264
+    components:
+    - type: Transform
+      pos: -44.5,-19.5
       parent: 2
 - proto: DefaultStationBeaconScience
   entities:
@@ -64229,6 +64306,11 @@ entities:
     - type: Transform
       pos: -38.5,-56.5
       parent: 2
+  - uid: 24266
+    components:
+    - type: Transform
+      pos: -40.5,20.5
+      parent: 2
 - proto: DefaultStationBeaconSupply
   entities:
   - uid: 9459
@@ -64258,6 +64340,11 @@ entities:
     - type: Transform
       pos: 15.5,-44.5
       parent: 2
+  - uid: 24268
+    components:
+    - type: Transform
+      pos: 35.5,-43.5
+      parent: 2
 - proto: DefaultStationBeaconTelecoms
   entities:
   - uid: 9463
@@ -64271,6 +64358,11 @@ entities:
     components:
     - type: Transform
       pos: 34.5,10.5
+      parent: 2
+  - uid: 24267
+    components:
+    - type: Transform
+      pos: -14.5,-4.5
       parent: 2
 - proto: DefaultStationBeaconToolRoom
   entities:
@@ -64319,11 +64411,6 @@ entities:
     components:
     - type: Transform
       pos: -36.629433,6.548981
-      parent: 2
-  - uid: 9472
-    components:
-    - type: Transform
-      pos: -33.687996,-25.481403
       parent: 2
   - uid: 9473
     components:
@@ -64374,6 +64461,11 @@ entities:
     components:
     - type: Transform
       pos: -6.2765236,36.841625
+      parent: 2
+  - uid: 18681
+    components:
+    - type: Transform
+      pos: -34.451977,-25.336582
       parent: 2
 - proto: DiagnoserMachineCircuitboard
   entities:
@@ -102605,6 +102697,8 @@ entities:
       color: '#9003FCFF'
   - uid: 14721
     components:
+    - type: MetaData
+      name: Distro Pump
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 24.5,-52.5
@@ -105480,7 +105574,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,-58.5
       parent: 2
-  - uid: 11590
+  - uid: 7821
     components:
     - type: Transform
       pos: -40.5,13.5
@@ -109968,6 +110062,14 @@ entities:
     - type: Transform
       pos: 2.524012,-59.40162
       parent: 2
+- proto: KitchenDeepFryer
+  entities:
+  - uid: 22236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-14.5
+      parent: 2
 - proto: KitchenElectricGrill
   entities:
   - uid: 15885
@@ -110031,11 +110133,6 @@ entities:
     components:
     - type: Transform
       pos: -6.5,-31.5
-      parent: 2
-  - uid: 22236
-    components:
-    - type: Transform
-      pos: -4.5,-14.5
       parent: 2
 - proto: KitchenReagentGrinder
   entities:
@@ -112570,8 +112667,13 @@ entities:
   - uid: 16256
     components:
     - type: Transform
-      pos: -33.320435,-25.397486
+      rot: 2.578358880567233E-11 rad
+      pos: -33.32056,-25.39744
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      fixedRotation: False
   - uid: 16257
     components:
     - type: Transform
@@ -114236,6 +114338,11 @@ entities:
     components:
     - type: Transform
       pos: -32.5,17.5
+      parent: 2
+  - uid: 24269
+    components:
+    - type: Transform
+      pos: -11.5,-2.5
       parent: 2
 - proto: PottedPlantRandomPlastic
   entities:
@@ -123993,6 +124100,31 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -10.5,4.5
       parent: 2
+  - uid: 23607
+    components:
+    - type: Transform
+      pos: -44.5,13.5
+      parent: 2
+  - uid: 23608
+    components:
+    - type: Transform
+      pos: -43.5,13.5
+      parent: 2
+  - uid: 23609
+    components:
+    - type: Transform
+      pos: -42.5,13.5
+      parent: 2
+  - uid: 23610
+    components:
+    - type: Transform
+      pos: -41.5,13.5
+      parent: 2
+  - uid: 24279
+    components:
+    - type: Transform
+      pos: -40.5,13.5
+      parent: 2
 - proto: RemoteSignaller
   entities:
   - uid: 18098
@@ -124047,6 +124179,13 @@ entities:
     components:
     - type: Transform
       pos: -23.451546,-39.448074
+      parent: 2
+- proto: ReverseEngineeringMachine
+  entities:
+  - uid: 9472
+    components:
+    - type: Transform
+      pos: -31.5,-29.5
       parent: 2
 - proto: RevolverCapGun
   entities:
@@ -129262,11 +129401,6 @@ entities:
       parent: 2
 - proto: SmartFridge
   entities:
-  - uid: 18681
-    components:
-    - type: Transform
-      pos: -34.5,-25.5
-      parent: 2
   - uid: 18682
     components:
     - type: Transform
@@ -137230,6 +137364,11 @@ entities:
     - type: Transform
       pos: 0.5,-43.5
       parent: 2
+  - uid: 23815
+    components:
+    - type: Transform
+      pos: -34.5,-25.5
+      parent: 2
   - uid: 24115
     components:
     - type: Transform
@@ -137262,12 +137401,6 @@ entities:
       parent: 2
 - proto: TableStone
   entities:
-  - uid: 19895
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-14.5
-      parent: 2
   - uid: 19897
     components:
     - type: Transform
@@ -139499,17 +139632,17 @@ entities:
       parent: 2
 - proto: VendingMachineRoboDrobe
   entities:
-  - uid: 20195
-    components:
-    - type: Transform
-      pos: -22.5,-16.5
-      parent: 2
-- proto: VendingMachineRobotics
-  entities:
   - uid: 22450
     components:
     - type: Transform
       pos: -24.5,-16.5
+      parent: 2
+- proto: VendingMachineRobotics
+  entities:
+  - uid: 20195
+    components:
+    - type: Transform
+      pos: -22.5,-16.5
       parent: 2
 - proto: VendingMachineSalvage
   entities:
@@ -150877,6 +151010,11 @@ entities:
     - type: Transform
       pos: -23.5,10.5
       parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      pos: -27.5,-27.5
+      parent: 2
   - uid: 696
     components:
     - type: Transform
@@ -152927,12 +153065,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -27.5,-26.5
-      parent: 2
-  - uid: 22567
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,-27.5
       parent: 2
   - uid: 22568
     components:
@@ -158218,7 +158350,7 @@ entities:
       links:
       - 20116
     - type: Door
-      secondsUntilStateChange: -203952.1
+      secondsUntilStateChange: -205016.92
       state: Opening
   - uid: 23498
     components:
@@ -158825,11 +158957,6 @@ entities:
       parent: 2
 - proto: Window
   entities:
-  - uid: 3243
-    components:
-    - type: Transform
-      pos: -40.5,13.5
-      parent: 2
   - uid: 23597
     components:
     - type: Transform
@@ -158884,30 +159011,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-12.5
-      parent: 2
-  - uid: 23607
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,13.5
-      parent: 2
-  - uid: 23608
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,13.5
-      parent: 2
-  - uid: 23609
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -43.5,13.5
-      parent: 2
-  - uid: 23610
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -44.5,13.5
       parent: 2
   - uid: 23611
     components:
@@ -160073,12 +160176,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -32.5,-25.5
-      parent: 2
-  - uid: 23815
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,-25.5
       parent: 2
   - uid: 23816
     components:

--- a/Resources/Maps/Floof/radstation.yml
+++ b/Resources/Maps/Floof/radstation.yml
@@ -126581,9 +126581,6 @@ entities:
       pos: -29.5,-15.5
       parent: 2
     - type: DeviceLinkSource
-      linkedPorts:
-        invalid:
-        - Status: Toggle
   - uid: 18426
     components:
     - type: Transform

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -16,3 +16,4 @@
   - TheHive
   #- Gax # Floof - Remvoe Gax due to mapping issues, power, access, etc.
   - Rad
+  - Kettle


### PR DESCRIPTION
# Description

Additional community requested changes for Kettle & Rad station

Added various things to all stations that the community requested. Mostly a lot of beacons for the station maps and warp points.

Map Specific Changes:

Kettle:
- added missing warp poitns
- added missing station beacons
- changed solars to have some broken so engineering will need to repair them
- added more station maps
- added arrivals shuttle ETA screen
- added evac shuttle ETA screen
- extended salvages dock to allow for them to dock to the station easier and to allow the logi shuttle to fit into the logi shuttle docking bay
- added justice key to service telecoms
- added a station anchor

Rad:
- renamed all substations, smes faxes
- moved vault from its old location to the portal room that was above epi
- changed the old vault room to be a way to access maints for engineering to get to NW solars with out having to go around logi maints
- changed the old vault room to be a way to leave the disposals so no one has to rely on logi
- changed more of the middle of the station to allow for service workers to have something to work on, this includes a barber stall, small kitchen and a stage for any plays
- swapped the barber shop stall with the reporters office so its in the center of the station now
- added prisoner cryosleep pods to perma 
- added missing vendors to the robotics portion of epi and gave them one cyborg endoskeleton
- added other missing station beacons
- split more of epis power grid between their two substations to make the load on one less
- move the MV wires that were powering disposals to be accessible by engineering if they would need to repair it
- added a reverse engineering machine to epi and changed the front counter
- added a station anchor

Lighthouse:

- added prefilled filing cabinets that have the paper work templates in them to every department
- changed arrivals airlocks to be the proper type of airlock, before they were just AirlockExternalGlassShuttleLocked, now they are AirlockExternalGlassArrivals
- added a station anchor

---

# TODO

- [x] Add Kettle the map pool
- [x] Add updated Kettle
- [x] Add updated RadStation
- [x] See about moving the barber shop & reporters office on rad again

---

<details><summary><h1>Map Renders</h1></summary>
<p>
Kettle:

![Kettle-0](https://github.com/user-attachments/assets/09f26460-4e2a-4520-95ed-9f360068aaf1)


Rad:

![Rad-0](https://github.com/user-attachments/assets/5e1ebcf4-6dc5-4668-8b74-90dceab6ea16)


</p>
</details>

---

# Changelog

:cl:
- add: Added kettle to the map pool
- tweak: Tweaked Kettle to add missing warp points and map beacons
- tweak: Tweaked Rad based on additional community feedback
- tweak: Lighthouse so every department has paper work templates