### PR TITLE
Paradox Anomaly Opt-Out Consent Toggle

### DIFF
--- a/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/DeltaV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -17,6 +17,8 @@ using Content.Shared.Roles.Jobs;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Diagnostics.CodeAnalysis;
+using Content.Server.Consent;
+
 
 namespace Content.Server.DeltaV.ParadoxAnomaly.Systems;
 
@@ -26,6 +28,7 @@ namespace Content.Server.DeltaV.ParadoxAnomaly.Systems;
 /// </summary>
 public sealed class ParadoxAnomalySystem : EntitySystem
 {
+    [Dependency] private readonly ConsentSystem _consent = default!;
     [Dependency] private readonly GenericAntagSystem _genericAntag = default!;
     [Dependency] private readonly GhostRoleSystem _ghostRole = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
@@ -79,6 +82,9 @@ public sealed class ParadoxAnomalySystem : EntitySystem
                 continue;
 
             if (_role.MindIsAntagonist(mindId))
+                continue;
+
+            if (_consent.HasConsent(uid, "NoClone"))
                 continue;
 
             // TODO: when metempsychosis real skip whoever has Karma

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -29,3 +29,6 @@ consent-Digestion-desc = Allow yourself to be digested. WARNING: BEING DIGESTED 
 
 consent-Hypno-name = Hypnosis
 consent-Hypno-desc = Allow yourself to be hypnotized.
+
+consent-NoClone-name = Disallow Paradox Anomaly
+consent-NoClone-desc = Disallow yourself to be the target of a paradox anomaly clone.

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -9,3 +9,6 @@
 
 - type: consentToggle
   id: Hypno
+
+- type: consentToggle
+  id: NoClone


### PR DESCRIPTION
# Description

Adds an opt-out for targets of the Paradox Anomaly ghost role through the consent menu.

# Changelog

:cl:
- add: Paradox Anomaly clones of your character can be disabled through the consent preferences menu.

