### PR TITLE
Fix nuke alert localization

### DIFF
--- a/Content.Server/Nuke/NukeSystem.cs
+++ b/Content.Server/Nuke/NukeSystem.cs
@@ -462,7 +462,7 @@ public sealed class NukeSystem : EntitySystem
             Color.Red,
             stationUid ?? uid,
             null,
-            ("time", (int) component.RemainingTime), ("position", FormattedMessage.RemoveMarkupPermissive(_navMap.GetNearestBeaconString((uid, nukeXform))))
+            ("time", (int) component.RemainingTime), ("location", FormattedMessage.RemoveMarkupPermissive(_navMap.GetNearestBeaconString((uid, nukeXform))))
         );
 
         _sound.PlayGlobalOnStation(uid, _audio.GetSound(component.ArmSound));


### PR DESCRIPTION
# Description

Y'know how when the nuke is armed it just says "{$location}"? Yeah it's because someone wrote "position" in the code instead.

---
<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/d7e2de91-741f-49a2-b803-73750fcf773e)

</p>
</details>

---

# Changelog

:cl:
- fix: Nuclear Fission Explosive Announcements now properly alert the crew to their approximate location.
