### PR TITLE
Increase Artifact Analyzer's Point-to-Glimmer Ratio

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
@@ -25,6 +25,7 @@ public sealed partial class ArtifactAnalyzerComponent : Component
     /// Each is 150 and added to this, so
     /// 550 / 700 / 850 / 1000
     /// </summary>
+    [DataField]
     public int ExtractRatio = 400;
     // Nyano - End modified code block.
 

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -44,6 +44,7 @@
     powerLoad: 12000
     needsPower: false #only turns on when scanning
   - type: ArtifactAnalyzer
+    extractRatio: 1000 # Floof - increase the ratio to reduce the strain from xenoarch on glimmer
   - type: TraversalDistorter
   - type: ItemPlacer
     whitelist:


### PR DESCRIPTION
# Description
This makes ExtractRatio property of artifact analyzers (the amount of points needed to raise 1 milipsi of glimmer) a DataField, and changes that property of MachineArtifactAnalyzer to be 2.5 times higher than the default (1000 instead of 400 points per 1 milipsi).

This should make xenoarch more of a viable research method, because as of now anomalies are the go-to due to their incredibly low glimmer generation compared to that of xenoarch.

### **This will require testing.**

# Changelog
:cl:
- tweak: Artifact extractions should now generate 2.5 times less glimmer than before.