### PR TITLE
Drunkard Accent

### DIFF
--- a/Content.Server/FloofStation/Speech/Components/DrunkardAccentComponent.cs
+++ b/Content.Server/FloofStation/Speech/Components/DrunkardAccentComponent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server.FloofStation.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class DrunkardAccentComponent : Component;

--- a/Content.Server/FloofStation/Speech/EntitySystems/DrunkardAccentSystem.cs
+++ b/Content.Server/FloofStation/Speech/EntitySystems/DrunkardAccentSystem.cs
@@ -1,0 +1,65 @@
+﻿using System.Text;
+using Content.Server.FloofStation.Speech.Components;
+using Content.Server.Speech;
+using Robust.Shared.Random;
+
+
+namespace Content.Server.FloofStation.Speech.EntitySystems;
+
+
+public sealed class DrunkardAccentSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DrunkardAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    // A modified copy of SlurredSystem's Accentuate.
+    public string Accentuate(string message)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var character in message)
+        {
+            if (_random.Prob(0.1f))
+            {
+                var lower = char.ToLowerInvariant(character);
+                var newString = lower switch
+                {
+                    'o' => "u",
+                    's' => "ch",
+                    'a' => "ah",
+                    'u' => "oo",
+                    'c' => "k",
+                    _ => $"{character}",
+                };
+
+                sb.Append(newString);
+            }
+
+            if (!_random.Prob(0.05f))
+            {
+                sb.Append(character);
+                continue;
+            }
+
+            var next = _random.Next(1, 3) switch
+            {
+                1 => "'",
+                2 => $"{character}{character}",
+                _ => $"{character}{character}{character}",
+            };
+
+            sb.Append(next);
+        }
+
+        return sb.ToString();
+    }
+
+    private void OnAccent(EntityUid uid, DrunkardAccentComponent component, AccentGetEvent args) =>
+        args.Message = Accentuate(args.Message);
+}

--- a/Resources/Locale/en-US/Floof/traits/traits.ftl
+++ b/Resources/Locale/en-US/Floof/traits/traits.ftl
@@ -26,3 +26,6 @@ trait-description-Lightweight =
 
 trait-name-GermanAccent = German accent
 trait-description-GermanAccent = You seem to come from space Germany.
+
+trait-name-DrunkardAccent = Drunkard accent
+trait-description-DrunkardAccent = You always sound like you're drunk.

--- a/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
@@ -35,3 +35,5 @@
       id: ScottishAccent
     - type: trait # Floof
       id: GermanAccent
+    - type: trait # Floof
+      id: DrunkardAccent

--- a/Resources/Prototypes/Floof/Traits/neutral.yml
+++ b/Resources/Prototypes/Floof/Traits/neutral.yml
@@ -8,3 +8,14 @@
     - !type:TraitAddComponent
       components:
         - type: GermanAccent
+
+- type: trait
+  id: DrunkardAccent
+  category: TraitsSpeechAccents
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: TraitsAccents
+  functions:
+    - !type:TraitAddComponent
+      components:
+      - type: DrunkardAccent


### PR DESCRIPTION
# Description

Adds a "drunkard accent", a trait that makes a character's speech slurred like they're drunk.

There are a few alcoholic characters on Floof that would benefit from being "constantly drunk" without the actual status effect. This could be a good effect for other characters that have a speech impediment.

## Technical notes

This uses a modified version of `SlurredSystem`'s `Accentuate` for the trait with hardcoded values and removing the burping and "huh" additions. The functionality *could* be extracted into a static method, however it would require changing code in non-Floof code when this works perfectly fine; reducing changes to the codebase is preferable.

If the character is drunk past a certain point, the `SlurredSpeech` effect will take precedence over `DrunkardAccent`.

# Changelog

:cl:
- add: Added a "drunkard accent", a trait that makes a character's speech slurred like they're drunk.