### PR TITLE
Make Visual Disabilities and Cybereyes Mutually Exclusive

### DIFF
--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -8,6 +8,12 @@
       jobs:
         - Borg
         - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Nearsighted
+        - Photophobia
+        - CyberEyes
   functions:
     - !type:TraitAddComponent
       components:
@@ -23,6 +29,11 @@
       jobs:
         - Borg
         - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Blindness
+        - CyberEyes
   functions:
     - !type:TraitAddComponent
       components:
@@ -264,6 +275,11 @@
       species:
         - Vulpkanin # This trait functions exactly as-is for the Vulpkanin trait.
         - Shadowkin
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Blindness
+        - CyberEyes
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds incompatibility to ensure that someone cannot take negative visual traits while having cyber-eyes systems, and likewise cannot take redundant negative visual traits.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![githubphotophobiaimage](https://github.com/user-attachments/assets/fd27ac82-d4b5-4c67-a4ad-35c6be9862b4)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Made Photophobia, Blindness, Nearsightedness, and Cyber-eyes mutually exclusive.
