### PR TITLE
Cyborg Zipties Patch

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -458,7 +458,8 @@ namespace Content.Shared.Cuffs
             else
             {
                 handcuff = Spawn("Zipties", Transform(user).Coordinates);
-                EnsureComp<HandcuffComponent>(handcuff);
+                var newcuffs = EnsureComp<HandcuffComponent>(handcuff);
+                newcuffs.Used = true;
             }
 
             _container.Insert(handcuff, component.Container);


### PR DESCRIPTION
This PR fixes a bug regarding the Cyborg Zipties, when an ent was cuffed, the new ziptie was not "used", this changes it.
In general in my head i should not have used cuffsystem to make this, but right now this will work and i think its should be changed.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: FoxxoTrystan
- fix: Fixed cyborg zipties being unable to be removed.
