### PR TITLE
Space Cleaner Grenade Crate 

### DIFF
--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_misc.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_misc.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: Cleanergrenades
+  icon:
+    sprite: Structures/Storage/Crates/plastic.rsi
+    state: icon
+  product: CrateCleanerGreande
+  cost: 1000
+  category: cargoproduct-category-name-fun
+  group: market

--- a/Resources/Prototypes/Floof/Catalog/Fills/Crates/cleannade.yml
+++ b/Resources/Prototypes/Floof/Catalog/Fills/Crates/cleannade.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: CrateCleanerGreande
+  parent: CratePlastic
+  name: space cleaner grenade crate
+  description: Crate full of two boxes of cleaner grenades, eight grenades in total for heavy used cleaning. Sold by SESWC.
+  components:
+  - type: StorageFill
+    contents:
+      - id: BoxCleanerGrenades
+        amount: 2


### PR DESCRIPTION

# Description
adds the ability to Buy JUST clean grenades for when the station is extremely dirty


# TODO
get it to work 

# Media

![image](https://github.com/user-attachments/assets/65fa0c6f-e622-4dce-a3ed-f2c0377b8e62)

# Changelog

:cl:
- add: Clean grenades crate buyable from cargo
