### PR TITLE
Allow Gladiabots to Wear Hats

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/gladiabot.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/gladiabot.yml
@@ -7,9 +7,18 @@
   - type: Sprite
     sprite: Mobs/Silicon/Bots/gladiabot.rsi
     state: gladiabot
+  - type: Inventory
+    templateId: gladiabot
+  - type: InventorySlots
+  - type: UserInterface
+    interfaces:
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
   - type: Construction
     graph: GladiaBot
     node: bot
+  - type: Stripping
+  - type: Strippable
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical
   - type: UseDelay
@@ -52,6 +61,9 @@
           MaterialCloth1:
             min: 1
             max: 1
+      - !type:EmptyContainersBehaviour
+        containers:
+        - head
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: MovementSpeedModifier

--- a/Resources/Prototypes/InventoryTemplates/gladiabot_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/gladiabot_inventory_template.yml
@@ -1,0 +1,10 @@
+- type: inventoryTemplate
+  id: gladiabot
+  slots:
+  - name: head
+    slotTexture: head
+    slotFlags: HEAD
+    uiWindowPos: 0,1
+    strippingWindowPos: 0,0
+    displayName: Head
+    offset: 0.1, -0.15


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This adds an inventory template for a Gladiabot and allows it to wear hats.
This makes it easier to see which bot is which in a fight, allowing people to place bets on the winner!

There is no way to force an orientation for a hat that I know of, but it still looks OK if the hat is sideways

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Allow Gladiabots to wear hats
- [x] Drop the hat when it's destroyed
- [ ] Make sure the hat always faces the right way

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/7c793e0c-d2b0-4483-98a0-aee93e6a60d9)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Timfa
- tweak: Allowed Gladiabots to wear hats!
