### PR TITLE
Converts 2 Regular Pkas to 2 Sawn Off Pka in the Vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -9,7 +9,8 @@
     Floodlight: 2
     HandheldGPSBasic: 2
     RadioHandheld: 2
-    WeaponProtoKineticAccelerator: 4
+    WeaponProtoKineticAccelerator: 2
+    WeaponProtoKineticAcceleratorSawn: 2 # Floof
     SeismicCharge: 2
     FultonBeacon: 1
     Fulton: 2


### PR DESCRIPTION

# Description
most stations are equipt with 3-4 salvagers and most salvagers already just go to get the saw to saw off the PKA to make the sawn off version because of the firing rate. this is really just a time saver quality of life thing 

Replaces two regulars with sawn-off versions 

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/b46d5d21-b046-4cef-825c-2db90bc914d9)

</p>
</details>

---

# Changelog

:cl:
- tweak: There is now 2 sawn-off pka and 2 regular pka in the vendors instead of 4 regular pka's
