### PR TITLE
Removes the Beacon From the Uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1425,15 +1425,16 @@
     blacklist:
       components:
       - SurplusBundle
-- type: listing
-  id: UplinkSingarityBeacon
-  name: uplink-singularity-beacon-name
-  description: uplink-singularity-beacon-desc
-  productEntity: SingularityBeacon
-  cost:
-    Telecrystal: 12
-  categories:
-    - UplinkUtility
+
+#- type: listing  floof
+ # id: UplinkSingarityBeacon
+ # name: uplink-singularity-beacon-name
+ # description: uplink-singularity-beacon-desc
+ # productEntity: SingularityBeacon
+ # cost:
+ #   Telecrystal: 12
+ # categories:
+ #   - UplinkUtility
 
 # Armor
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1426,7 +1426,8 @@
       components:
       - SurplusBundle
 
-#- type: listing  floof
+# Floofstation: disabled because of the "proportional damage" rule
+# - type: listing
  # id: UplinkSingarityBeacon
  # name: uplink-singularity-beacon-name
  # description: uplink-singularity-beacon-desc


### PR DESCRIPTION
I go banned

# Description
It causes extreme Destruction on the station, items of this nature was already removed (zombie bundle, china lake)

real reason is I got banned for using a Beacon so I want to prevent other people from getting banned
Description.

# Media

![image](https://github.com/user-attachments/assets/5138ad12-8998-4a20-96c2-129025b77c76)


# Changelog

:cl:

- remove: Removed the singulo beacon from the uplink.
