### PR TITLE
add plushie to the prize

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/prizeticket.yml
@@ -386,6 +386,9 @@
         prob: 0.50
         orGroup: Prize
        #HypnoTemp Merch - End
+      - id: Plushiegirlfailure #Floof
+        prob: 0.50
+        orGroup: Prize
       # Rare
       - id: PlushieAbductorAgent
         prob: 0.30
@@ -420,3 +423,4 @@
       - id: PlushieHypnoTempCap # Floofstation
         prob: 0.30
         orGroup: Prize
+

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1829,6 +1829,7 @@
       - PlushieFPraetorian
       - PlushieFDrone
       - PlushieFRouny
+      - Plushiegirlfailure
       #Floof Plushies - End
   - type: EmagLatheRecipes
     emagStaticRecipes:

--- a/Resources/Prototypes/Recipes/Lathes/prizecounter.yml
+++ b/Resources/Prototypes/Recipes/Lathes/prizecounter.yml
@@ -686,6 +686,15 @@
   completetime: 0.1
   materials:
     PrizeTicket: 50
+
+- type: latheRecipe
+  id: Plushiegirlfailure
+  result: Plushiegirlfailure
+  applyMaterialDiscount: false
+  completetime: 0.1
+  materials:
+    PrizeTicket: 50
+
 # HypnoTemp Plushies - Start
 - type: latheRecipe
   id: PlushieHypnoTempCap
@@ -742,6 +751,9 @@
   completetime: 0.1
   materials:
     PrizeTicket: 100
+
+
+
 # HypnoTemp Plushies - End
 # Floof Plushies - End
 


### PR DESCRIPTION
adds that shitty plushie to the prize


# Description
adds that shitty plushie to the prize counter

![image](https://github.com/user-attachments/assets/b2ad7bb8-9c61-4fe2-a7ba-aa890f1123ef)

# Changelog

:cl:
- tweak: Added the girl failure plushie to the prize counter and prize balls.
