### PR TITLE
Beacons no longer glitch off on grid split (WizardsDen#28518)

### DIFF
--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -237,6 +237,16 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
         component.Chunks.Clear();
         component.Beacons.Clear();
 
+        // Refresh beacons
+        var query = EntityQueryEnumerator<NavMapBeaconComponent, TransformComponent>();
+        while (query.MoveNext(out var qUid, out var qNavComp, out var qTransComp))
+        {
+            if (qTransComp.ParentUid != uid)
+                continue;
+
+            UpdateNavMapBeaconData(qUid, qNavComp);
+        }
+
         // Loop over all tiles
         var tileRefs = _mapSystem.GetAllTiles(uid, mapGrid);
 


### PR DESCRIPTION
# Description
Cherry-picks https://github.com/space-wizards/space-station-14/pull/28518 from WizDen to fix station beacons disappearing on grid split. This has not been tested, should test it before merging.


# Changelog
:cl: Errant-4
- fix: Map labels no longer suddenly disappear for the rest of the round.