### PR TITLE
Moth Wings Quick Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
@@ -175,7 +175,7 @@
 # Wings
 - type: marking
   id: MothWingsDefault
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -184,7 +184,7 @@
 
 - type: marking
   id: MothWingsCharred
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -193,7 +193,7 @@
 
 - type: marking
   id: MothWingsDbushy
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -204,7 +204,7 @@
 
 - type: marking
   id: MothWingsDeathhead
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -215,7 +215,7 @@
 
 - type: marking
   id: MothWingsFan
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -224,7 +224,7 @@
 
 - type: marking
   id: MothWingsDfan
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -233,7 +233,7 @@
 
 - type: marking
   id: MothWingsFeathery
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -242,7 +242,7 @@
 
 - type: marking
   id: MothWingsFirewatch
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -253,7 +253,7 @@
 
 - type: marking
   id: MothWingsGothic
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -262,7 +262,7 @@
 
 - type: marking
   id: MothWingsJungle
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -271,7 +271,7 @@
 
 - type: marking
   id: MothWingsLadybug
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -280,7 +280,7 @@
 
 - type: marking
   id: MothWingsMaple
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -289,7 +289,7 @@
 
 - type: marking
   id: MothWingsMoffra
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -300,7 +300,7 @@
 
 - type: marking
   id: MothWingsOakworm
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -309,7 +309,7 @@
 
 - type: marking
   id: MothWingsPlasmafire
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -320,7 +320,7 @@
 
 - type: marking
   id: MothWingsPointy
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -329,7 +329,7 @@
 
 - type: marking
   id: MothWingsRoyal
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -340,7 +340,7 @@
 
 - type: marking
   id: MothWingsStellar
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -349,7 +349,7 @@
 
 - type: marking
   id: MothWingsStriped
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -358,7 +358,7 @@
 
 - type: marking
   id: MothWingsSwirly
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -367,7 +367,7 @@
 
 - type: marking
   id: MothWingsWhitefly
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -376,7 +376,7 @@
 
 - type: marking
   id: MothWingsWitchwing
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:
@@ -385,7 +385,7 @@
 
 - type: marking
   id: MothWingsUnderwing
-  bodyPart: Wings
+  bodyPart: Tail
   markingCategory: Wings
   speciesRestriction: [Moth, SlimePerson]
   sprites:


### PR DESCRIPTION

# Description

Moth wings didnt show up in game, due to them beeing on a wing layer instead of tail, fixed the issue while keeping them in the wings category

![image](https://github.com/user-attachments/assets/90bc0647-5147-49e2-b9c8-e587f852485d)

---

# TODO

n/a

---


# Changelog


:cl:
- fix: Made the moth wings appiear again

