### PR TITLE
Update Resomi body and parts definition to follow surgery update specifications

### DIFF
--- a/Resources/Prototypes/Floof/Body/Parts/resomi.yml
+++ b/Resources/Prototypes/Floof/Body/Parts/resomi.yml
@@ -1,90 +1,188 @@
+# TODO: Add descriptions (many)
+# TODO BODY: Part damage
+- type: entity
+  id: PartResomi
+  parent: BaseItem
+  name: "resomi body part"
+  abstract: true
+  components:
+  - type: Damageable
+    damageContainer: OrganicPart
+  - type: BodyPart
+  - type: ContainerContainer
+    containers:
+      bodypart: !type:Container
+        ents: []
+  - type: StaticPrice #DynamicPrice
+    price: 100
+  - type: Tag
+    tags:
+      - Trash
+
 - type: entity
   id: TorsoResomi
   name: "resomi torso"
-  parent: TorsoHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "torso_m"
-
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "torso_m"
+  - type: BodyPart
+    partType: Torso
 
 - type: entity
   id: HeadResomi
   name: "resomi head"
-  parent: HeadHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "head_m"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "head_m"
+  - type: BodyPart
+    partType: Head
+    vital: true
+  - type: Input
+    context: "ghost"
+  - type: InputMover
+  - type: GhostOnMove
+  - type: Tag
+    tags:
+      - Head
 
 - type: entity
   id: LeftArmResomi
   name: "left resomi arm"
-  parent: LeftArmHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "l_arm"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "l_arm"
+  - type: BodyPart
+    partType: Arm
+    symmetry: Left
 
 - type: entity
   id: RightArmResomi
   name: "right resomi arm"
-  parent: RightArmHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "r_arm"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "r_arm"
+  - type: BodyPart
+    partType: Arm
+    symmetry: Right
 
 - type: entity
   id: LeftHandResomi
   name: "left resomi hand"
-  parent: LeftHandHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "l_hand"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "l_hand"
+  - type: BodyPart
+    partType: Hand
+    symmetry: Left
 
 - type: entity
   id: RightHandResomi
   name: "right resomi hand"
-  parent: RightHandHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "r_hand"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "r_hand"
+  - type: BodyPart
+    partType: Hand
+    symmetry: Right
 
 - type: entity
   id: LeftLegResomi
   name: "left resomi leg"
-  parent: LeftLegHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "l_leg"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "l_leg"
+  - type: BodyPart
+    partType: Leg
+    symmetry: Left
+  - type: MovementBodyPart
 
 - type: entity
   id: RightLegResomi
   name: "right resomi leg"
-  parent: RightLegHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "r_leg"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "r_leg"
+  - type: BodyPart
+    partType: Leg
+    symmetry: Right
+  - type: MovementBodyPart
 
 - type: entity
   id: LeftFootResomi
   name: "left resomi foot"
-  parent: LeftFootHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "l_foot"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "l_foot"
+  - type: BodyPart
+    partType: Foot
+    symmetry: Left
 
 - type: entity
   id: RightFootResomi
   name: "right resomi foot"
-  parent: RightFootHuman
+  parent: PartResomi
   components:
   - type: Sprite
+    netsync: false
     sprite: Floof/Mobs/Species/Resomi/parts.rsi
     state: "r_foot"
+  - type: Icon
+    sprite: Floof/Mobs/Species/Resomi/parts.rsi
+    state: "r_foot"
+  - type: BodyPart
+    partType: Foot
+    symmetry: Right

--- a/Resources/Prototypes/Floof/Body/Prototypes/resomi.yml
+++ b/Resources/Prototypes/Floof/Body/Prototypes/resomi.yml
@@ -13,37 +13,38 @@
     torso:
       part: TorsoResomi
       connections:
-      - right_arm
-      - left_arm
-      - right_leg
-      - left_leg
+      - right arm
+      - left arm
+      - right leg
+      - left leg
+      - head
       organs:
         heart: OrganHumanHeart
         lungs: OrganHumanLungs
         stomach: OrganHumanStomach
         liver: OrganHumanLiver
         kidneys: OrganHumanKidneys
-    right_arm:
+    right arm:
       part: RightArmResomi
       connections:
-      - right_hand
-    left_arm:
+      - right hand
+    left arm:
       part: LeftArmResomi
       connections:
-      - left_hand
-    right_hand:
+      - left hand
+    right hand:
       part: RightHandResomi
-    left_hand:
+    left hand:
       part: LeftHandResomi
-    right_leg:
+    right leg:
       part: RightLegResomi
       connections:
-      - right_foot
-    left_leg:
+      - right foot
+    left leg:
       part: LeftLegResomi
       connections:
-      - left_foot
-    right_foot:
+      - left foot
+    right foot:
       part: RightFootResomi
-    left_foot:
+    left foot:
       part: LeftFootResomi


### PR DESCRIPTION
# Description

Copying the templating from the vulpkanin and human definitions to make sure resomi body parts fit in the new medical system. Now you can detach their limbs and actually attach something back in their place.

Note/known visual bug: attaching non-resomi limbs, including the utility limbs, causes them to visually float in place. This should be fixed at some point. They work, they just aren't visually attached to the sprite.

---

:cl:
- fix: Resomi now can have limbs reattached after having them removed.
