### PR TITLE
General anesthesia canisters and associated cargo order

### DIFF
--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_atmospherics.yml
@@ -1,0 +1,19 @@
+- type: cargoProduct
+  id: AtmosphericsNitrousMix
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: redws
+  product: NitrousOxideMixCanister
+  cost: 2100
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsLiquidNitrousMix
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: redws
+  product: LiquidNitrousOxideMixCanister
+  cost: 5200
+  category: cargoproduct-category-name-atmospherics
+  group: market

--- a/Resources/Prototypes/Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Floof/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -1,0 +1,67 @@
+- type: entity
+  parent: GasCanister
+  id: NitrousOxideMixCanister
+  name: general anesthesia canister
+  description: A canister that can contain any type of gas. This one is supposed to contain nitrous oxide and oxygen in a 3-to-7 ratio. It can be attached to connector ports using a wrench.
+  components:
+    - type: Sprite
+      layers:
+        - state: redws
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 1310.19735 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Plasma
+          - 0 # Tritium
+          - 0 #  Water vapor
+          - 0 # Ammonia
+          - 561.51315 # N2O
+        temperature: 293.15
+    - type: Destructible
+      thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 600
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalBreak
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            NitrousOxideCanisterBroken:
+              min: 1
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:DumpCanisterBehavior
+    - type: AccessReader
+      access: [["Atmospherics"],["Medical"],["Research"]]
+
+- type: entity
+  parent: NitrousOxideMixCanister
+  id: LiquidNitrousOxideMixCanister
+  name: liquid general anesthesia canister
+  description: A canister that can contain any type of gas. This one is supposed to contain liquid nitrous oxide and oxygen in a 3-to-7 ratio. It can be attached to connector ports using a wrench.
+  components:
+    - type: GasCanister
+      gasMixture:
+        volume: 1000
+        moles:
+          - 13100.19735 # oxygen
+          - 0 # nitrogen
+          - 0 # CO2
+          - 0 # Plasma
+          - 0 # Tritium
+          - 0 #  Water vapor
+          - 0 # Ammonia
+          - 5610.51315 # N2O
+        temperature: 72


### PR DESCRIPTION
# Description

For how necessary N2O/O2 mix is for medbay now, it's more difficult to come by than it should be. I've made canisters of pre-mixed N2O/O2 in the same ratio that the robovend canisters are at, labeled them "general anesthesia canister" to differentiate them from normal nitrous oxide, and also made a logistics orders so we can actually get them reasonably. In both standard temp and pressure and liquid varieties.

---

# Changelog

:cl:
- add: General anesthesia and Liquid general anesthesia canisters can now be purchased from Logistics.
