### PR TITLE
Biosynthetic Left Leg Fix

### DIFF
--- a/Resources/Prototypes/Body/Parts/generic.yml
+++ b/Resources/Prototypes/Body/Parts/generic.yml
@@ -43,7 +43,7 @@
   - type: BodyPart
     children:
       right foot:
-        id: "right foot"
+        id: "left foot"
         type: Foot
 
 - type: entity

--- a/Resources/Prototypes/Body/Parts/generic.yml
+++ b/Resources/Prototypes/Body/Parts/generic.yml
@@ -42,7 +42,7 @@
   components:
   - type: BodyPart
     children:
-      right foot:
+      left foot:
         id: "left foot"
         type: Foot
 


### PR DESCRIPTION
# Description

Copy/paste error causing bio-synthetic left lefts to expect right feet as children.

---

# Changelog

:cl:
- fix: Bio-synthetic left legs now properly expect and allow a left foot to be attached.
