### PR TITLE
ERT/Testing Surgical Tool Crate

### DIFF
--- a/Resources/Prototypes/Floof/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Floof/Catalog/Fills/Crates/medical.yml
@@ -1,0 +1,18 @@
+- type: entity
+  id: CrateERTSurgery
+  parent: CrateSurgery
+  name: ERT surgical supplies crate
+  description: Special surgical instruments provided to Emergency Response Teams.
+  components:
+  - type: StorageFill
+    contents:
+      - id: ERTOmnimedTool
+      - id: ClothingMaskBreathMedical
+      - id: NitrousOxideTankFilled
+      - id: BoxLatexGloves
+      - id: BoxSterileMask
+      - id: MedBiofabFlatpack
+      - id: OperatingTableFlatpack
+      - id: Multitool
+      - id: MaterialBiomass
+        amount: 3

--- a/Resources/Prototypes/Floof/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Floof/Catalog/Fills/Crates/medical.yml
@@ -6,7 +6,7 @@
   components:
   - type: StorageFill
     contents:
-      - id: ERTOmnimedTool
+      - id: BluespaceOmnimedTool
       - id: ClothingMaskBreathMedical
       - id: NitrousOxideTankFilled
       - id: BoxLatexGloves

--- a/Resources/Prototypes/Floof/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Devices/flatpack.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: BaseFlatpack
+  id: MedBiofabFlatpack
+  name: medical biofabricator flatpack
+  description: A flatpack used for constructing a medical biofabricator.
+  components:
+  - type: Flatpack
+    entity: MedicalBiofabricator
+
+- type: entity
+  parent: BaseFlatpack
+  id: OperatingTableFlatpack
+  name: operating table flatpack
+  description: A flatpack used for constructing an operating table.
+  components:
+  - type: Flatpack
+    entity: OperatingTable

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/surgery.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: ERT medical multitool
-  id: ERTOmnimedTool
+  name: bluespace medical multitool
+  id: BluespaceOmnimedTool
   parent: BaseToolSurgery
-  suffix: Admeme
+  suffix: debug, DO NOT MAP
   components:
   - type: Sprite
     sprite: Objects/Specific/Medical/Surgery/omnimed.rsi

--- a/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Floof/Entities/Objects/Specific/Medical/surgery.yml
@@ -1,0 +1,34 @@
+- type: entity
+  name: ERT medical multitool
+  id: ERTOmnimedTool
+  parent: BaseToolSurgery
+  suffix: Admeme
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/Surgery/omnimed.rsi
+    state: omnimed
+  - type: Item
+    sprite: Objects/Specific/Medical/Surgery/omnimed.rsi
+  - type: SurgeryTool
+    startSound:
+      path: /Audio/Medical/Surgery/saw.ogg
+  - type: Hemostat
+    speed: 10
+  - type: Scalpel
+    speed: 10
+  - type: Drill
+    speed: 10
+  - type: BoneSetter
+    speed: 10
+  - type: Retractor
+    speed: 10
+  - type: Cautery
+    speed: 10
+  - type: BoneGel
+    speed: 10
+  - type: BoneSaw
+    speed: 10
+  - type: Tweezers
+    speed: 10
+  - type: Tending
+    speed: 10


### PR DESCRIPTION
# Description

As I was testing all of these surgery bugs I often found myself spawning in the same items over and over again every time I needed to reload the instance. I figured not only would it be easier on myself to make a crate prototype, but it could also serve as an ERT Medical option. Includes:
- a souped up medical multitool (because ERT get the fancy tools)
- sterile mask and nitrile glove boxes
- a general anesthetic tank
- a medical breath mask, 
- flatpacks for a medical biofabricator and an operating table
- a multitool to unpack the flatpacks
- 300 biomass to print up to 30 body parts

---

# Changelog

:cl:
ADMIN:
- add: Added an ERT surgical tools crate, which includes new items such as an admeme medical multitool and flatpacks for the med biofab and operating tables.
