### PR TITLE
Increase CO2 sensor danger threshold to 1%

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -36,7 +36,7 @@
 - type: alarmThreshold
   id: stationCO2
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.0025
+    threshold: 0.01
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.5
 


### PR DESCRIPTION
# Description

Increases the default CO2 danger threshold on air sensor components to 1%. The warning threshold is changed to 0.5% (automatically calculated as half of the danger threshold).

This will reduce the currently-common occurance of nuisance alarms, which currently distract atmospherics attention and train people to ignore the air alarms, degrading their purpose. This is an especially large problem with the addition of the atmospheric alert computer.

I have extensively tested the danger of CO2, and determined 1.2% to be the point at which it starts to become potentially dangerous. The danger level of 1% stands off slightly short of this and ensures that firelocks will come down in the event of any dangerous concentration of CO2. The air alarm warnings will also trigger significantly in advance of this (at 0.5%).

In addition, the occurrence of actually dangerous CO2 levels is particularly rare, further reducing the risk that this change will result in uncontrolled CO2 accidents.

Hopefully, this will make it easier for atmospherics engineers to diagnose and fix actual atmospheric issues.

---

<details><summary><h1>Media</h1></summary>
<h4>Testing the effects of CO2 exposure</h4>
<p>

![Testing the effects of CO2 exposure](https://github.com/user-attachments/assets/be80606d-77ca-45a3-9ee9-8a75f8e49915)

</p>
<h4>The new default air sensor settings</h4>
<p>

![The new default air sensor settings](https://github.com/user-attachments/assets/586455fa-2f9e-4ece-8842-3ed973618a31)

</p>
</details>

---

# Changelog

:cl:
- tweak: Increased CO2 alarm thresholds.
