### PR TITLE
Add Delta-V species guidebook entries

### DIFF
--- a/Resources/Prototypes/DeltaV/Guidebook/species.yml
+++ b/Resources/Prototypes/DeltaV/Guidebook/species.yml
@@ -8,10 +8,11 @@
   name: species-name-felinid
   text: "/ServerInfo/Guidebook/Mobs/DeltaV/Felinid.xml"
 
-- type: guideEntry
-  id: Harpy
-  name: species-name-harpy
-  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Harpy.xml"
+# Floofstation already had a Harpy guide entry, so this conflicts
+#- type: guideEntry
+#  id: Harpy
+#  name: species-name-harpy
+#  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Harpy.xml"
 
 - type: guideEntry
   id: Vulpkanin

--- a/Resources/Prototypes/DeltaV/Guidebook/species.yml
+++ b/Resources/Prototypes/DeltaV/Guidebook/species.yml
@@ -2,3 +2,23 @@
   id: Rodentia
   name: species-name-rodentia
   text: "/ServerInfo/Guidebook/Mobs/DeltaV/Rodentia.xml"
+
+- type: guideEntry
+  id: Felinid
+  name: species-name-felinid
+  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Felinid.xml"
+
+- type: guideEntry
+  id: Harpy
+  name: species-name-harpy
+  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Harpy.xml"
+
+- type: guideEntry
+  id: Vulpkanin
+  name: species-name-vulpkanin
+  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Vulpkanin.xml"
+
+- type: guideEntry
+  id: Oni
+  name: species-name-oni
+  text: "/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml"

--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -14,6 +14,12 @@
     - Harpy
     - Rodentia # Floofstation
     - Shadowkin
+    # DeltaV additions
+    - Vulpkanin
+    # Floofstation already has a harpy entry
+    #- Harpy
+    - Felinid
+    - Oni
 
 - type: guideEntry
   id: Arachnid

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Felinid.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Felinid.xml
@@ -1,0 +1,32 @@
+<Document>
+  # Felinids
+
+  <Box>
+    <GuideEntityEmbed Entity="MobFelinidDummy" Caption=""/>
+  </Box>
+
+  Small and mischievous cat-eared people. Being small in itself has lots of upsides and downsides. They can hide inside duffelbags.
+
+  ## Diet
+
+  - Can eat raw meat.
+  - Will get poisoned by Theobromine (Chocolate, Tea, Coffee) and Allicin (Onion, Garlic).
+
+  ## Benefits
+
+  - They are smaller than Humans, making them harder to hit.
+  - Can fit in duffelbags.
+  - Have the ability to throw up an hairball to get rid of some of the chemicals from their bloodstream.
+  - Able to eat mice and rats after picking them up. This has the benefit of regenerating the hairball ability and feeding them.
+  - Uses their claws to do Slashing damage and Piercing damage.
+  - Can walk completely silently, but only while barefooted.
+  - Immunity to the OwOnavirus disease.
+
+  ## Drawbacks
+
+  - Takes 15% more Blunt, Slash and Piercing damage.
+  - Are easily shoved, pushed and carried around by every other morphotypes due to their small size.
+  - They are weaker and struggle to carry and pull things due to their small size. They are unable to carry an Oni.
+  - They have slightly less stamina than Humans.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Harpy.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Harpy.xml
@@ -1,0 +1,40 @@
+<Document>
+  # Harpies
+
+  <Box>
+    <GuideEntityEmbed Entity="MobHarpyDummy" Caption=""/>
+  </Box>
+
+  An avian humanoid species that features colorful feathered wings and tails that can mimic almost any sound.
+
+  They are quite sensitive to the air quality, and when exposed to low quality air, they will begin to visibly gasp, and eventually start choking.
+  When this happens, a Harpy should either move away from sources of bad air, stand on top of a scrubber for a few seconds, or take a few breaths from a pure oxygen tank in order to restore their blood-oxygen levels. Only three seconds of being on pure oxygen is enough to completely restore a Harpy's blood oxygen saturation.
+
+  ## Diet
+
+  - Can eat raw meat.
+  - Will get poisoned by Theobromine (Chocolate, Tea, Coffee) and Allicin (Onion, Garlic).
+
+  ## Benefits
+
+  - Somewhat smaller than Humans, although not as small as Felinids
+  - Uses their talons to deal Piercing damage
+  - Can imitate around 70% of the game's sound library through a huge list of voice emotes
+  - They can "Sing" midis by imitating instruments. Right click yourself to select an instrument
+  - Moves 10% faster than other species.
+
+  ## Special
+
+  - Comes with the Ultraviolet Vision trait by default. This can be disabled via accessibility options.
+  - Cannot wear Jumpsuits, and will automatically start with a Jumpskirt instead.
+  - While singing, musical notes appear floating around their head.
+
+  ## Drawbacks
+
+  - Takes 15% more Blunt, Slash, and Piercing damage.
+  - Extreme low density, Harpies are lighter than even Felinids, and weigh half as much as a Human.
+  - A Harpy breathes in air twice as often as Humans, inhaling and exhaling every 3 seconds.
+  - - Air tanks last half as long and Harpies are more susceptible than usual to low air quality.
+  - - If a Harpy is exposed to at least 0.2 moles of combined CO2 and/or Miasma, they start struggling to take in oxygen.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Oni.xml
@@ -1,0 +1,26 @@
+<Document>
+  # Onis
+
+  <Box>
+    <GuideEntityEmbed Entity="MobOniDummy" Caption=""/>
+  </Box>
+
+  Large, horned people that come in a variety of colors. Their accuracy with guns is terrible, but their physical strength brings them a lot of boons both in and out of combat.
+
+  ## Diet
+  - Nothing special.
+
+  ## Benefits
+  - Takes 15% less Blunt, Slash and Piercing damage.
+  - Does more damage in melee; 35% more Blunt and Asphyxiation, 20% more Slash and Piercing.
+  - Due to their big size, they can easily carry, shove and pull any other morphotypes.
+  - They are harder to shove.
+  - Slightly more stamina than Humans.
+  - They have an easier time prying open doors, taking around 50% less time than other species.
+
+  ## Drawbacks
+  - Their accuracy with guns is terrible.
+  - They are harder to carry and pull.
+  - They are bigger than Humans, making them easier to hit.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Vulpkanin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/DeltaV/Vulpkanin.xml
@@ -1,0 +1,28 @@
+<Document>
+  # Vulpkanin
+
+  <Box>
+    <GuideEntityEmbed Entity="MobVulpkaninDummy" Caption=""/>
+  </Box>
+
+  The Vulpkanin (vulp-ka-nin) are a race of humanoid canine-like beings.
+
+  ## Diet
+
+  - Can eat raw meat.
+  - Will get poisoned by Theobromine (Chocolate, Tea, Coffee) and Allicin (Onion, Garlic).
+
+  ## Benefits
+
+  - Uses their claws to do some Slashing and Blunt damage.
+  - Their fur makes them able to withstand cold environments without the need of a coat.
+
+  ## Special
+
+  - Comes with the Deuteranopia trait by default. This can be disabled via accessibility options.
+
+  ## Drawbacks
+
+  - They take 15% more Heat damage.
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
@@ -7,5 +7,6 @@
 
   Dwarves are similar to humans in most respect, but tolerate alcohol better and are healed by it.
 
+  ## This species is disabled on Delta-V!
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Dwarf.xml
@@ -7,6 +7,6 @@
 
   Dwarves are similar to humans in most respect, but tolerate alcohol better and are healed by it.
 
-  ## This species is disabled on Delta-V!
+  ## This species is disabled on Floofstation
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -22,7 +22,12 @@
 
   # Delta-V specific species
   <Box>
-    <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
+  <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
+  <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vulpkanin"/>
+  <GuideEntityEmbed Entity="MobFelinid" Caption="Felinid"/>
+  <GuideEntityEmbed Entity="MobHarpy" Caption="Harpy"/>
+  <GuideEntityEmbed Entity="MobOni" Caption="Oni"/>
   </Box>
-  
+
+
 </Document>


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Ports https://github.com/DeltaV-Station/Delta-v/pull/1174 with some minor tweaks for Floof. That PR added guidebook entries for Vulpkanin, Felinid, Harpy, and Oni based on their wiki.

Primary differences:
Floof already has a Harpy guidebook entry so I commented out the Harpy definition from DV
This PR adds a note to Dwarf saying it's disabled - modified it to say disabled on Floofstation (vice DV)

Additional note:
MobFelinid, MobFelinidDummy, and MobOniDummy seem to be broken visually, but I believe fixing that should be outside the scope of this PR/commit.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Cherry-pick DV pull 1174
- [x] Tweak PR for Floof

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/4491c035-9a0d-41e4-8396-1338808ee877)
![image](https://github.com/user-attachments/assets/9c95ab80-b90c-4971-ac17-c429af57be6d)
![image](https://github.com/user-attachments/assets/cd99c209-0986-40c7-b7b3-7de3310bfb9b)
![image](https://github.com/user-attachments/assets/f689c98b-22fa-4abf-919c-b5343c44bbff)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Vulpkanin, Felinid, and Oni guidebook entries from Delta-V
