### PR TITLE
Make plushie crates buyable

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -65,9 +65,9 @@
       id: PlushiePenguin
 
 - type: entity
-  id: CrateFunImportedPlushie
+  id: CrateFunPlushie
   parent: CrateGenericSteel
-  name: imported plushie crate
+  name: plushie crate
   description: A bunch of older plushies from another sector, you'll have to look elsewhere for the newer models. Throw them around and then wonder how you're gonna explain this purchase to NT.
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -65,10 +65,10 @@
       id: PlushiePenguin
 
 - type: entity
-  id: CrateFunPlushie
+  id: CrateFunImportedPlushie
   parent: CrateGenericSteel
-  name: plushie crate
-  description: A buncha soft plushies. Throw them around and then wonder how you're gonna explain this purchase to NT.
+  name: imported plushie crate
+  description: A bunch of older plushies from another sector, you'll have to look elsewhere for the newer models. Throw them around and then wonder how you're gonna explain this purchase to NT.
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -68,7 +68,7 @@
   id: CrateFunPlushie
   parent: CrateGenericSteel
   name: plushie crate
-  description: A bunch of older plushies from another sector, you'll have to look elsewhere for the newer models. Throw them around and then wonder how you're gonna explain this purchase to NT.
+  description: A bunch of older plushies from another sector, you'll have to look elsewhere for the newer models. Throw them around and then wonder how you're gonna explain this purchase to NT. # Description modified for Floofstation - though we could always update the plushie table...
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -24,7 +24,7 @@
     sprite: Objects/Fun/toys.rsi
     state: plushie_h
   product: CrateFunPlushie
-  cost: 2500
+  cost: 3500
   category: cargoproduct-category-name-fun
   group: market
   
@@ -34,6 +34,6 @@
     sprite: Objects/Fun/toys.rsi
     state: plushie_lizard
   product: CrateFunLizardPlushieBulk
-  cost: 2000
+  cost: 2500
   category: cargoproduct-category-name-fun
   group: market

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -19,11 +19,11 @@
   group: market
   
 - type: cargoProduct
-  id: FunImportedPlushieCrate
+  id: FunPlushieCrate
   icon:
     sprite: Objects/Fun/toys.rsi
     state: plushie_h
-  product: CrateFunImportedPlushie
+  product: CrateFunPlushie
   cost: 2500
   category: cargoproduct-category-name-fun
   group: market

--- a/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Floof/Catalog/Cargo/cargo_fun.yml
@@ -17,3 +17,23 @@
   cost: 99999
   category: cargoproduct-category-name-fun
   group: market
+  
+- type: cargoProduct
+  id: FunImportedPlushieCrate
+  icon:
+    sprite: Objects/Fun/toys.rsi
+    state: plushie_h
+  product: CrateFunImportedPlushie
+  cost: 2500
+  category: cargoproduct-category-name-fun
+  group: market
+  
+- type: cargoProduct
+  id: FunLizardPlushieCrate
+  icon:
+    sprite: Objects/Fun/toys.rsi
+    state: plushie_lizard
+  product: CrateFunLizardPlushieBulk
+  cost: 2000
+  category: cargoproduct-category-name-fun
+  group: market


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes the upstream plushie and lizard plushie crates buyable by logistics/cargo. Attempted to balance cost around the fact that they don't contain all of the plushies like I believe the prizeballs do, and the prizeball crate is 5000. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Modify plushie crate description (and undo name changes - thanks for the input Trystan!)
- [x] Make plushie crates buyable

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/46cd8435-70eb-4536-81cc-4569a451c5d4)
![image](https://github.com/user-attachments/assets/25c5e630-da7b-4763-bea5-36e453cf375b)
![image](https://github.com/user-attachments/assets/9fdc9be7-961b-4042-bf51-1491818c85ed)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Logistics can now buy plushie crates
