### PR TITLE
Weaken the effects of damage on body parts

### DIFF
--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -231,10 +231,12 @@ namespace Content.Server.Atmos.EntitySystems
                     >= Atmospherics.WarningHighPressure => GetFeltHighPressure(uid, barotrauma, pressure),
                     _ => pressure
                 };
+
+                const float partMultiplier = 0.4f; // Floof - weakened the effect of barotrauma on body parts to 40%
                 if (pressure <= Atmospherics.HazardLowPressure)
                 {
                     // Deal damage and ignore resistances. Resistance to pressure damage should be done via pressure protection gear.
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, canSever: false);
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * Atmospherics.LowPressureDamage, true, false, canSever: false, partMultiplier: partMultiplier); // Floof - added partMultiplier
                     if (!barotrauma.TakingDamage)
                     {
                         barotrauma.TakingDamage = true;
@@ -247,7 +249,7 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     var damageScale = MathF.Min(((pressure / Atmospherics.HazardHighPressure) - 1) * Atmospherics.PressureDamageCoefficient, Atmospherics.MaxHighPressureDamage);
 
-                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, canSever: false);
+                    _damageableSystem.TryChangeDamage(uid, barotrauma.Damage * damageScale, true, false, canSever: false, partMultiplier: partMultiplier); // Floof - added partMultiplier
                     RaiseLocalEvent(uid, new MoodEffectEvent("MobHighPressure"));
 
                     if (!barotrauma.TakingDamage)

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -142,7 +142,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     /// to make possible severing it.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float SeverIntegrity = 90;
+    public float SeverIntegrity = 300; // Floof - increased to 300 due to frequent RR
 
     /// <summary>
     /// The ID of the base layer for this body part.
@@ -159,8 +159,8 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     [DataField, AutoNetworkedField]
     public Dictionary<TargetIntegrity, float> IntegrityThresholds = new()
     {
-        { TargetIntegrity.CriticallyWounded, 90 },
-        { TargetIntegrity.HeavilyWounded, 75 },
+        { TargetIntegrity.CriticallyWounded, 100 }, // Floof - adjusted the thresholds to come in increments of 20
+        { TargetIntegrity.HeavilyWounded, 80 },
         { TargetIntegrity.ModeratelyWounded, 60 },
         { TargetIntegrity.SomewhatWounded, 40},
         { TargetIntegrity.LightlyWounded, 20 },

--- a/Content.Shared/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Targeting.cs
@@ -139,7 +139,7 @@ public partial class SharedBodySystem
                 else if (damage != null)
                 {
                     // Division by 2 cuz damaging all parts by the same damage by default is too much.
-                    damage /= 2;
+                    damage /= 10; // Floofstation - changed to 10 because there's typically 10 parts and division by 2 is just too little.
                     targetPart = TargetBodyPart.All;
                 }
             }


### PR DESCRIPTION
# Description
This increases the default part severing threshold (the amount of damage it takes to severe a part) from 90 to 300 damage, increases the disability threshold (the amount of damage to DISABLE a part without severing it) from 90 to 100, weakens the damage multiplier of TargetBodyPart.All (damage dealt by things like fire that affect your whole body) from 0.5x to 0.1x, and decreases barotrauma damage to parts to only 40% (so the body will receive most of the damage, while its parts will receive very little).

Also spent some time silently crying from how bad the body part damage code is.

<details><summary><h1>Media</h1></summary>
<p>

Part severing:


https://github.com/user-attachments/assets/4da55afa-ea75-4d6c-b9d3-95be2dd2f66e



</p>
</details>

# Changelog
:cl:
- tweak: Made it overall harder to severe body parts via damage, and made environmental hazards less harmful to body parts.
