### PR TITLE
Add submarine back into rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -11,7 +11,7 @@
   - Pebble
   - Saltern
   - Shoukou
-  #- Submarine # Floof - Map Compleatly Broken, need rework.
+  - Submarine
   - Tortuga
   - TheHive
   #- Gax # Floof - Remvoe Gax due to mapping issues, power, access, etc.


### PR DESCRIPTION
# Description
Adds submarine back to the default map pool as it has been patched and updated in #510.

Ironically, this map has survived being removed from rotation up until the moment the PR actually reworking it got merged.

# Changelog
:cl:
- fix: Submarine is back to the map pool.
