### PR TITLE
More Fixes

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -140,6 +140,10 @@ public partial class SharedBodySystem
 
     private void OnStandAttempt(Entity<BodyComponent> ent, ref StandAttemptEvent args)
     {
+        // Floof - why did you not check for this???
+        if (ent.Comp.RequiredLegs <= 0)
+            return;
+
         if (ent.Comp.LegEntities.Count == 0)
             args.Cancel();
     }

--- a/Content.Shared/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/Standing/SharedLayingDownSystem.cs
@@ -145,8 +145,8 @@ public abstract class SharedLayingDownSystem : EntitySystem
             || standingState.CurrentState is not StandingState.Lying
             || !_mobState.IsAlive(uid)
             || TerminatingOrDeleted(uid)
-            || !TryComp<BodyComponent>(uid, out var body)
-            || body.LegEntities.Count == 0
+            // || !TryComp<BodyComponent>(uid, out var body)
+            // || body.LegEntities.Count == 0 // Floof - whoever wrote this, I hate you.
             || !_actionBlocker.CanConsciouslyPerformAction(uid)) // Floof - check for consciousness instead of a no-brain DeBrainedComponent check (pun intended)
             return false;
 


### PR DESCRIPTION
# Description
- Fixed the bug where borgs couldn't stand up after going crit (or any entity with standing state and body, but no limbs)
- Fixed the bug where buckle layering would break depending on grid rotation.
- Potentially fixed a client-side misprediction when unbuckling an entity from a north-facing chair.

# Changelog
:cl:
- fix: Borgs can stand up after falling again, and buckle layering should no longer break when the grid you are standing on is incorrectly oriented.
