### PR TITLE
Ice Metabolizes to Water, Lowers Temperature, and Causes Damage Once Frozen

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -53,6 +53,9 @@
       effects:
       - !type:SatiateThirst
         factor: 1
+      - !type:AdjustReagent # Floof - Cream breaks down into fat.
+        reagent: Nutriment # Representing fat. Fat itself is not used because sugar needs nutriment to metabolise.
+        amount: 0.15
 
 - type: reagent
   id: CoconutWater
@@ -426,26 +429,6 @@
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1
-  # Floof - section start
-  metabolisms:
-    Drink:
-      effects:
-      - !type:AdjustReagent
-        reagent: Water
-        amount: 0.5 # Given ice is less dense than water, 0.46 would be more scientifically accurate.
-      - !type:AdjustTemperature
-        conditions:
-        - !type:Temperature
-          min: 273
-        amount: -4000
-      - !type:HealthChange
-        conditions:
-        - !type:Temperature
-          max: 272
-        damage:
-          types:
-            Cold: 0.5
-  # Floof - section end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/iceglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -426,6 +426,26 @@
   recognizable: true
   meltingPoint: 0.0
   boilingPoint: 100.0
+  # Floof - section start
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Water
+        amount: 0.5 # Given ice is less dense than water, 0.46 would be more scientifically accurate.
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          min: 273
+        amount: -4000
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 272
+        damage:
+          types:
+            Cold: 0.5
+  # Floof - section end
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -426,6 +426,26 @@
   plantMetabolism:
   - !type:PlantAdjustWater
     amount: 1
+  # Floof - section start
+  metabolisms:
+    Drink:
+      effects:
+      - !type:AdjustReagent
+        reagent: Water
+        amount: 0.5 # Given ice is less dense than water, 0.46 would be more scientifically accurate.
+      - !type:AdjustTemperature
+        conditions:
+        - !type:Temperature
+          min: 273
+        amount: -4000
+      - !type:HealthChange
+        conditions:
+        - !type:Temperature
+          max: 272
+        damage:
+          types:
+            Cold: 0.5
+  # Floof - section end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/iceglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -102,8 +102,16 @@
   metabolisms:
     Drink:
       effects:
+      # Satiates thirst directly instead of breaking down into ice to avoid creating more ice cream in the body if drank alongside cream.
       - !type:SatiateThirst
         factor: 1.5
+      # Breaks down into more than the sum of its parts to reward the effort of making it. Less nutriment than sugar means that it's rewarding to eat alongside other food.
+      - !type:AdjustReagent
+        reagent: Nutriment # Representing fat. Fat itself is not used because sugar needs nutriment to metabolise.
+        amount: 0.15
+      - !type:AdjustReagent
+        reagent: Sugar
+        amount: 0.25
       - !type:ChemAddMoodlet
         moodPrototype: IceCreamBenefit
         conditions:


### PR DESCRIPTION
# Description

Ice is now a valid way to satiate thirst, but drinking a bucketful of ice is now a very bad idea.

From testing, a 30u glass is not enough to get an average human to frozen, but it will be more dangerous for smaller characters to drink large quantities. Nonetheless, it will never do more than 1 damage per 1u drank, so even the tiniest characters aren't going to die from drinking a glass.

By request, I also took a look at ice cream, but decided not to do what was requested and instead made both ice cream and cream satiate hunger. This is because fat (the primary component of both) is a known valid survival food. Cream breaks down into nutriment, and ice cream breaks down into nutriment and sugar. Both still satiate thirst.

---

# Changelog

:cl:
- tweak: Ice now satiates thirst, but also makes you cold. Don't drink too much!
- tweak: Cream and ice cream satiate hunger.
