### PR TITLE
Make CourierDrobes Restockable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -122,6 +122,7 @@
     - CargoDrobeInventory
     - ChefDrobeInventory
     - ChemDrobeInventory
+    - CourierDrobeInventory # DeltaV - Make CourierDrobe refillable
     - DetDrobeInventory
     - EngiDrobeInventory
     - GeneDrobeInventory


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Cherry-picks this PR: https://github.com/DeltaV-Station/Delta-v/pull/1768

Yes, I cherry-picked a PR for a single line of YAML. I'd do it again, too.

This does what it says on the tin, makes the CourierDrobe restockable using the generic clothing restock. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Cherry-pick https://github.com/DeltaV-Station/Delta-v/pull/1768
- [x] Give myself a pat for a job well done.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

I... I forgot to take a screenshot or video. It works, promise.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: CourierDrobes are now restockable with clothing restocks
