### PR TITLE
Vore fixes and consent menu improvement

### DIFF
--- a/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -157,7 +157,10 @@ public sealed partial class ConsentWindow : FancyWindow
 
         _entries.Clear();
 
-        var consentprototypelist = _protoManager.EnumeratePrototypes<ConsentTogglePrototype>();
+        var consentprototypelist = new List<ConsentTogglePrototype>(_protoManager.EnumeratePrototypes<ConsentTogglePrototype>());
+
+        consentprototypelist.Sort();
+
         foreach (var prototype in consentprototypelist)
             AddConsentEntry(prototype);
 

--- a/Content.Server/FloofStation/VoreSystem.cs
+++ b/Content.Server/FloofStation/VoreSystem.cs
@@ -36,6 +36,7 @@ using Content.Server.Power.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Hands.EntitySystems;
+using Content.Server.Carrying;
 
 namespace Content.Server.FloofStation;
 
@@ -61,6 +62,7 @@ public sealed class VoreSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly FoodSystem _food = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly CarryingSystem _carrying = default!;
 
     public override void Initialize()
     {
@@ -98,13 +100,13 @@ public sealed class VoreSystem : EntitySystem
             || !voreuser.CanVore
             || !TryComp<VoreComponent>(args.Target, out var voretarget)
             || !voretarget.CanBeVored
-            || !_consent.HasConsent(args.User, "Vore")
+            || !_consent.HasConsent(args.User, "VorePred")
             || !_consent.HasConsent(args.Target, "Vore"))
             return;
 
         InnateVerb verbDevour = new()
         {
-            Act = () => TryDevour(args.User, args.Target, component),
+            Act = () => TryDevour(args.User, args.Target, component, false),
             Text = Loc.GetString("vore-devour"),
             Category = VerbCategory.Interaction,
             Icon = new SpriteSpecifier.Rsi(new ResPath("Interface/Actions/devour.rsi"), "icon-on"),
@@ -122,13 +124,13 @@ public sealed class VoreSystem : EntitySystem
             || !voreuser.CanBeVored
             || !TryComp<VoreComponent>(args.Target, out var voretarget)
             || !voretarget.CanVore
-            || !_consent.HasConsent(args.Target, "Vore")
+            || !_consent.HasConsent(args.Target, "VorePred")
             || !_consent.HasConsent(args.User, "Vore"))
             return;
 
         InnateVerb verbInsert = new()
         {
-            Act = () => TryDevour(args.Target, args.User, voretarget),
+            Act = () => TryDevour(args.Target, args.User, voretarget, true),
             Text = Loc.GetString("action-name-insert-self"),
             Category = VerbCategory.Interaction,
             Icon = new SpriteSpecifier.Rsi(new ResPath("Interface/Actions/devour.rsi"), "icon"),
@@ -186,7 +188,7 @@ public sealed class VoreSystem : EntitySystem
         }
     }
 
-    public void TryDevour(EntityUid uid, EntityUid target, VoreComponent? component = null)
+    public void TryDevour(EntityUid uid, EntityUid target, VoreComponent? component = null, bool isInsertion = false)
     {
         if (!Resolve(uid, ref component))
             return;
@@ -194,17 +196,22 @@ public sealed class VoreSystem : EntitySystem
         if (_food.IsMouthBlocked(uid, uid))
             return;
 
-        _popups.PopupEntity(Loc.GetString("vore-attempt-devour", ("entity", uid), ("prey", target)), uid, target, PopupType.MediumCaution);
-        _popups.PopupEntity(Loc.GetString("vore-attempt-devour", ("entity", uid), ("prey", target)), target, uid, PopupType.MediumCaution);
+        if (isInsertion) {
+            _popups.PopupEntity(Loc.GetString("vore-attempt-insert", ("entity", uid), ("prey", target)), uid, target, PopupType.MediumCaution);
+            _popups.PopupEntity(Loc.GetString("vore-attempt-insert", ("entity", uid), ("prey", target)), target, uid, PopupType.MediumCaution);
+        } else {
+            _popups.PopupEntity(Loc.GetString("vore-attempt-devour", ("entity", uid), ("prey", target)), uid, target, PopupType.MediumCaution);
+            _popups.PopupEntity(Loc.GetString("vore-attempt-devour", ("entity", uid), ("prey", target)), target, uid, PopupType.MediumCaution);
+        }
 
         if (!TryComp<PhysicsComponent>(uid, out var predPhysics)
             || !TryComp<PhysicsComponent>(target, out var preyPhysics))
             return;
 
         var length = TimeSpan.FromSeconds(component.Delay
-                        * _contests.MassContest(preyPhysics, predPhysics, false, 4f)
-                        * _contests.StaminaContest(uid, target)
-                        * (_standingState.IsDown(target) ? 0.5f : 1));
+                        * _contests.MassContest(preyPhysics, predPhysics, false, 4f) // Big things are harder to fit in small things
+                        * _contests.StaminaContest(isInsertion?target:uid, isInsertion?uid:target) // The person doing the action having higher stamina makes it easier
+                        * (_standingState.IsDown(isInsertion?uid:target) ? 0.5f : 1)); // If the person having the action done to them is on the ground it's easier
 
         _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, uid, length, new VoreDoAfterEvent(), uid, target: target)
         {
@@ -239,6 +246,9 @@ public sealed class VoreSystem : EntitySystem
         _blindableSystem.UpdateIsBlind(target);
         if (TryComp<TemperatureComponent>(target, out var temp))
             temp.AtmosTemperatureTransferEfficiency = 0;
+
+        _carrying.DropCarried(uid, target);
+        _carrying.DropCarried(target, uid);
 
         _containerSystem.Insert(target, component.Stomach);
 
@@ -426,7 +436,7 @@ public sealed class VoreSystem : EntitySystem
 
     private void OnExamine(EntityUid uid, ExaminedEvent args)
     {
-        if (!_consent.HasConsent(args.Examiner, "Vore"))
+        if (!(_consent.HasConsent(args.Examiner, "Vore") || _consent.HasConsent(args.Examiner, "VorePred")))
             return;
 
         if (!_containerSystem.TryGetContainer(uid, "stomach", out var stomach)

--- a/Content.Shared/Consent/ConsentTogglePrototype.cs
+++ b/Content.Shared/Consent/ConsentTogglePrototype.cs
@@ -1,13 +1,38 @@
 namespace Content.Shared.Consent;
 
+using System;
 using Robust.Shared.Prototypes;
 
 /// <summary>
 /// TODO
 /// </summary>
 [Prototype("consentToggle")]
-public sealed partial class ConsentTogglePrototype : IPrototype
+public sealed partial class ConsentTogglePrototype : IPrototype, IComparable
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    [DataField("category")]
+    public string Category { get; private set; } = default!;
+
+    [DataField("priority")]
+    public int priority { get; private set; } = 0;
+
+    public int CompareTo(object? obj) { // Allow for granular sorting to make the menu display consistently and intuitively
+        if (obj == null) return -1;
+
+        ConsentTogglePrototype? other = obj as ConsentTogglePrototype;
+        if (other != null){
+            var cat = this.Category.CompareTo(other.Category);
+            if (cat != 0){
+                return cat; // Categories are different, sort by category
+            }
+            if (this.priority != other.priority) {
+                return this.priority - other.priority; // Priorities are different, sort by priority
+            }
+            return this.ID.CompareTo(other.ID); // Category and priority are the same, sort by ID
+        } else {
+           throw new ArgumentException("Object is not a Consent Toggle");
+        }
+    }
 }

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -18,8 +18,11 @@ consent-examine-verb = Consent Info
 consent-examine-not-set = This player has no consent preferences set. Ask for consent first before engaging in any erotic roleplay.
 
 # Consent toggles
-consent-Vore-name = Vore
-consent-Vore-desc = Allow yourself to be predator or prey.
+consent-Vore-name = Vore Prey
+consent-Vore-desc = Allow yourself to be prey or insert yourself into a pred.
+
+consent-VorePred-name = Vore Pred
+consent-VorePred-desc = Allow yourself to be pred or have prey insert themselves into you.
 
 consent-Digestion-name = Digestion
 consent-Digestion-desc = Allow yourself to be digested. WARNING: BEING DIGESTED WILL ROUND-REMOVE YOU.

--- a/Resources/Locale/en-US/Floof/vore.ftl
+++ b/Resources/Locale/en-US/Floof/vore.ftl
@@ -6,6 +6,7 @@ vore-digest = Digest {CAPITALIZE($entity)}
 vore-stop-digest = Stop digesting {CAPITALIZE($entity)}
 
 vore-attempt-devour = {CAPITALIZE($entity)} is trying to devour {CAPITALIZE($prey)}!
+vore-attempt-insert = {CAPITALIZE($prey)} is trying to climb in {CAPITALIZE($entity)}!
 vore-devoured = {CAPITALIZE($entity)} devoured {CAPITALIZE($prey)}
 vore-digest-start = {CAPITALIZE($entity)} belly begins to get more active...
 vore-digest-start-chat = [color=red]{CAPITALIZE($entity)} belly begins to get more active...[/color]

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -2,6 +2,9 @@
   id: Vore
 
 - type: consentToggle
+  id: VorePred
+
+- type: consentToggle
   id: Digestion
 
 - type: consentToggle

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -1,14 +1,20 @@
 - type: consentToggle
   id: Vore
+  category: Vore
 
 - type: consentToggle
   id: VorePred
+  category: Vore
 
 - type: consentToggle
   id: Digestion
+  category: Vore
+  priority: 1
 
 - type: consentToggle
   id: Hypno
+  category: Hypno
 
 - type: consentToggle
   id: NoClone
+  category: Gameplay


### PR DESCRIPTION
# Description

- Re-splits the vore consent options, plenty of users want one side but not the other.
- - This is not just a rollback, this includes checking for the proper consent options when deciding if the examine text should include vore info
- Adds a unique popup text for inserting yourself vs being devoured (making it more obvious to both parties when this is happening)
- Adds nuance to the checks on how fast the doafter should be when devouring vs inserting (previously, it would use the downed/stamina status of the prey regardless of who initiated the action
- Fixes bugs involving carrying someone and devouring them/inserting yourself into them
- Sorting added to the consent toggle window so they should appear not only in a consistent order, but in an intentional order.
- - For example, all vore options are grouped together.
- - This system is expandable if proper categories are added in the future

---

# Changelog

:cl:
- add: Unique popup for inserting yourself into a pred
- tweak: Vore consent options are separate again
- tweak: Consent menu has been given consistent sorting
- fix: Insert Yourself verb now checks the stamina/downed status of the pred for doafter speed
- fix: Devouring or inserting yourself into someone you're carrying no longer causes issues
