### PR TITLE
Uniform Printer Additions

### DIFF
--- a/Resources/Locale/en-US/Floof/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/Floof/lathe/lathe-categories.ftl
@@ -1,0 +1,9 @@
+lathe-category-clothing-command = Command
+lathe-category-clothing-engineering = Engineering
+lathe-category-clothing-epistemics = Epistemics
+lathe-category-clothing-logistics = Logistics
+lathe-category-clothing-medical = Medical
+lathe-category-clothing-security = Security
+lathe-category-clothing-service = Service
+lathe-category-clothing-other = Other
+lathe-category-carpet = Carpet

--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/clothing.yml
@@ -3,6 +3,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSecBlue
   result: ClothingUniformJumpsuitSecBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -10,6 +11,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSecGrey
   result: ClothingUniformJumpsuitSecGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -17,6 +19,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitWardenBlue
   result: ClothingUniformJumpsuitWardenBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -24,6 +27,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitWardenGrey
   result: ClothingUniformJumpsuitWardenGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -33,6 +37,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSecBlue
   result: ClothingUniformJumpskirtSecBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -40,6 +45,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSecGrey
   result: ClothingUniformJumpskirtSecGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -47,6 +53,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoSBlue
   result: ClothingUniformJumpskirtHoSBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -54,6 +61,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoSGrey
   result: ClothingUniformJumpskirtHoSGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -61,6 +69,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtWardenBlue
   result: ClothingUniformJumpskirtWardenBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -68,6 +77,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtWardenGrey
   result: ClothingUniformJumpskirtWardenGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -77,6 +87,7 @@
 - type: latheRecipe
   id: ClothingOuterStasecSweater
   result: ClothingOuterStasecSweater
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 500

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1346,6 +1346,9 @@
     staticRecipes:
       - ClothingUniformJumpsuitColorGrey
       - ClothingUniformJumpskirtColorGrey
+      - ClothingUniformJumpsuitAtmos # Floof
+      - ClothingUniformJumpskirtAtmos # Floof
+      - ClothingUniformJumpsuitAtmosCasual # Floof
       - ClothingUniformJumpsuitBartender
       - ClothingUniformJumpskirtBartender
       - ClothingHeadHatCapcap
@@ -1432,6 +1435,9 @@
       - ClothingHeadHatBeretRND
       - ClothingUniformJumpsuitResearchDirector
       - ClothingUniformJumpskirtResearchDirector
+      - ClothingUniformJumpsuitRoboticist # Floof
+      - ClothingUniformJumpskirtRoboticist # Floof
+      - ClothingOuterRoboOveralls # Floof
       - ClothingUniformJumpsuitScientist
       - ClothingUniformJumpskirtScientist
       - ClothingUniformJumpsuitSeniorResearcher

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1549,27 +1549,69 @@
       - ClothingHandsEngiWarmers
       - ClothingUnderSocksEngi
       - ClothingUniformEngiThong
+      - ClothingHandsChiefEngiWarmers
+      - ClothingUnderSocksChiefEngi
+      - ClothingUniformChiefEngiThong
       - ClothingHandsEpiWarmers
       - ClothingUnderSocksEpi
       - ClothingUniformEpiThong
       - ClothingHandsChaplainWarmers
       - ClothingUnderSocksChaplain
       - ClothingUniformChaplainThong
+      - ClothingHandsEpiHeadWarmers
+      - ClothingUnderSocksEpiHead
+      - ClothingUniformEpiHeadThong
+      - ClothingHandsMantisEpiWarmers
+      - ClothingUnderSocksMantisEpi
+      - ClothingUniformMantisEpiThong
       - ClothingHandsLogisWarmers
       - ClothingUnderSocksLogis
       - ClothingUniformLogisThong
+      - ClothingHandsLOLogisWarmers
+      - ClothingUnderSocksLOLogis
+      - ClothingUniformLOLogisThong
+      - ClothingHandsCourierWarmers
+      - ClothingUnderSocksCourier
+      - ClothingUniformCourierThong
       - ClothingHandsMedicWarmers
       - ClothingUnderSocksMedic
       - ClothingUniformMedicThong
+      - ClothingHandsChemistsWarmers
+      - ClothingUnderSocksChemists
+      - ClothingUniformChemistsThong
+      - ClothingHandsParaMedicWarmers
+      - ClothingUnderSocksParaMedic
+      - ClothingUniformParaMedicThong
+      - ClothingHandsCMOWarmers
+      - ClothingUnderSocksCMO
+      - ClothingUniformCMOThong
       - ClothingHandsSecurityWarmers
       - ClothingUnderSocksSecurity
       - ClothingUniformSecurityThong
+      - ClothingHandsHeadSecurityWarmers
+      - ClothingUnderSocksHeadSecurity
+      - ClothingUniformHeadSecurityThong
+      - ClothingHandsDetectiveWarmers
+      - ClothingUnderSocksDetective
+      - ClothingUniformDetectiveThong
+      - ClothingHandsCorpsmanWarmers
+      - ClothingUnderSocksCorpsman
+      - ClothingUniformCorpsmanThong
       - ClothingHandsServiceWarmers
       - ClothingUnderSocksService
       - ClothingUniformServiceThong
       - ClothingHandsJanitorWarmers
       - ClothingUnderSocksJanitor
       - ClothingUniformJanitorThong
+      - ClothingHandsBartenderWarmers
+      - ClothingUnderSocksBartender
+      - ClothingUniformBartenderThong
+      - ClothingHandsMusicianWarmers
+      - ClothingUnderSocksMusician
+      - ClothingUniformMusicianThong
+      - ClothingHandsChefWarmers
+      - ClothingUnderSocksChef
+      - ClothingUniformChefThong
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - ClothingHeadHatCentcomcap

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1515,6 +1515,7 @@
       - CarpetPurple
       - CarpetCyan
       - CarpetWhite
+      # Floofstation section start
       # Floofstation - Collars
       - ClothingNeckCollarCmd
       # Floofstation - Socks, Armwarmers ect
@@ -1612,6 +1613,7 @@
       - ClothingHandsChefWarmers
       - ClothingUnderSocksChef
       - ClothingUniformChefThong
+      # Floofstation section end
   - type: EmagLatheRecipes
     emagStaticRecipes:
       - ClothingHeadHatCentcomcap

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1636,6 +1636,8 @@
       - ClothingOuterWinterCentcom
       - ClothingOuterWinterSyndie
       - ClothingOuterWinterSyndieCap
+      # Floofstation - Department Socks, Armwarmers ect
+      - ClothingUniformSurgeonGerneralThong
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Floof/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/categories.yml
@@ -1,0 +1,35 @@
+- type: latheCategory
+  id: ClothingCommand
+  name: lathe-category-clothing-command
+
+- type: latheCategory
+  id: ClothingEngineering
+  name: lathe-category-clothing-engineering
+
+- type: latheCategory
+  id: ClothingEpistemics
+  name: lathe-category-clothing-epistemics
+
+- type: latheCategory
+  id: ClothingLogistics
+  name: lathe-category-clothing-logistics
+
+- type: latheCategory
+  id: ClothingMedical
+  name: lathe-category-clothing-medical
+
+- type: latheCategory
+  id: ClothingSecurity
+  name: lathe-category-clothing-security
+
+- type: latheCategory
+  id: ClothingService
+  name: lathe-category-clothing-service
+
+- type: latheCategory
+  id: ClothingOther
+  name: lathe-category-clothing-other
+
+- type: latheCategory
+  id: Carpet
+  name: lathe-category-carpet

--- a/Resources/Prototypes/Floof/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/clothing.yml
@@ -1,0 +1,70 @@
+# Engineering
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitAtmos
+  icon:
+    sprite: Clothing/Uniforms/Jumpsuit/atmos.rsi
+    state: icon
+  result: ClothingUniformJumpsuitAtmos
+  category: ClothingEngineering
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtAtmos
+  icon:
+    sprite: Clothing/Uniforms/Jumpskirt/atmosf.rsi
+    state: icon
+  result: ClothingUniformJumpskirtAtmos
+  category: ClothingEngineering
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitAtmosCasual
+  icon:
+    sprite: Clothing/Uniforms/Jumpsuit/atmos_casual.rsi
+    state: icon
+  result: ClothingUniformJumpsuitAtmosCasual
+  category: ClothingEngineering
+  completetime: 4
+  materials:
+    Cloth: 300
+
+# Epistemics
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitRoboticist
+  icon:
+    sprite: Clothing/Uniforms/Jumpsuit/roboticist.rsi
+    state: icon
+  result: ClothingUniformJumpsuitRoboticist
+  category: ClothingEpistemics
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformJumpskirtRoboticist
+  icon:
+    sprite: Clothing/Uniforms/Jumpskirt/roboticist.rsi
+    state: icon
+  result: ClothingUniformJumpskirtRoboticist
+  category: ClothingEpistemics
+  completetime: 4
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingOuterRoboOveralls
+  icon:
+    sprite: Floof/Clothing/OuterClothing/Misc/robooveralls.rsi
+    state: icon
+  result: ClothingOuterRoboOveralls
+  category: ClothingEpistemics
+  completetime: 3.2
+  materials:
+    Cloth: 500
+    Durathread: 300

--- a/Resources/Prototypes/Floof/Recipes/Lathes/sockoutfits.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/sockoutfits.yml
@@ -3,6 +3,7 @@
 - type: latheRecipe
   id: ClothingHandsPlainWarmers
   result: ClothingHandsPlainWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -10,6 +11,7 @@
 - type: latheRecipe
   id: ClothingHandsStripeRainbowWarmers
   result: ClothingHandsStripeRainbowWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -17,6 +19,7 @@
 - type: latheRecipe
   id: ClothingHandsStripePurpleWarmers
   result: ClothingHandsStripePurpleWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -24,6 +27,7 @@
 - type: latheRecipe
   id: ClothingHandsStripeWhiteWarmers
   result: ClothingHandsStripeWhiteWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -31,6 +35,7 @@
 - type: latheRecipe
   id: ClothingHandsBeeWarmers
   result: ClothingHandsBeeWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -38,6 +43,7 @@
 - type: latheRecipe
   id: ClothingHandsCoderWarmers
   result: ClothingHandsCoderWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -45,6 +51,7 @@
 - type: latheRecipe
   id: ClothingHandsCoderValidWarmers
   result: ClothingHandsCoderValidWarmers
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -54,6 +61,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksPlain
   result: ClothingUnderSocksPlain
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -61,6 +69,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksStripedRainbow
   result: ClothingUnderSocksStripedRainbow
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -68,6 +77,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksStripedPurple
   result: ClothingUnderSocksStripedPurple
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -75,6 +85,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksStripedWhite
   result: ClothingUnderSocksStripedWhite
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -82,6 +93,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksBee
   result: ClothingUnderSocksBee
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -89,6 +101,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCoder
   result: ClothingUnderSocksCoder
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -96,6 +109,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCoderValid
   result: ClothingUnderSocksCoderValid
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -105,6 +119,7 @@
 - type: latheRecipe
   id: ClothingUniformThongPlain
   result: ClothingUniformThongPlain
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -112,6 +127,7 @@
 - type: latheRecipe
   id: ClothingUniformStripedThongRainbow
   result: ClothingUniformStripedThongRainbow
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -119,6 +135,7 @@
 - type: latheRecipe
   id: ClothingUniformStripedThongPurple
   result: ClothingUniformStripedThongPurple
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -126,6 +143,7 @@
 - type: latheRecipe
   id: ClothingUniformStripedThongWhite
   result: ClothingUniformStripedThongWhite
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -133,6 +151,7 @@
 - type: latheRecipe
   id: ClothingUniformThongBee
   result: ClothingUniformThongBee
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -140,6 +159,7 @@
 - type: latheRecipe
   id: ClothingUniformThongCoder
   result: ClothingUniformThongCoder
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200
@@ -147,6 +167,7 @@
 - type: latheRecipe
   id: ClothingUniformThongCoderValid
   result: ClothingUniformThongCoderValid
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 200

--- a/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
@@ -546,3 +546,11 @@
   completetime: 2
   materials:
     Cloth: 100
+
+# Surgeon General
+- type: latheRecipe
+  id: ClothingUniformSurgeonGerneralThong
+  result: ClothingUniformSurgeonGerneralThong
+  completetime: 2
+  materials:
+    Cloth: 100

--- a/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
@@ -3,6 +3,7 @@
 - type: latheRecipe
   id: ClothingHandsCaptainWarmers
   result: ClothingHandsCaptainWarmers
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 300
@@ -11,6 +12,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCaptain
   result: ClothingUnderSocksCaptain
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 300
@@ -19,6 +21,7 @@
 - type: latheRecipe
   id: ClothingUniformCaptainThong
   result: ClothingUniformCaptainThong
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 100
@@ -29,6 +32,7 @@
 - type: latheRecipe
   id: ClothingHandsCommandWarmers
   result: ClothingHandsCommandWarmers
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 300
@@ -37,6 +41,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCommand
   result: ClothingUnderSocksCommand
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 300
@@ -45,6 +50,7 @@
 - type: latheRecipe
   id: ClothingUniformCommandThong
   result: ClothingUniformCommandThong
+  category: ClothingCommand
   completetime: 2
   materials:
     Cloth: 100
@@ -55,6 +61,7 @@
 - type: latheRecipe
   id: ClothingHandsEngiWarmers
   result: ClothingHandsEngiWarmers
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 300
@@ -62,6 +69,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksEngi
   result: ClothingUnderSocksEngi
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 300
@@ -69,6 +77,7 @@
 - type: latheRecipe
   id: ClothingUniformEngiThong
   result: ClothingUniformEngiThong
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 100
@@ -77,6 +86,7 @@
 - type: latheRecipe
   id: ClothingHandsChiefEngiWarmers
   result: ClothingHandsChiefEngiWarmers
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 300
@@ -84,6 +94,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksChiefEngi
   result: ClothingUnderSocksChiefEngi
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 300
@@ -91,6 +102,7 @@
 - type: latheRecipe
   id: ClothingUniformChiefEngiThong
   result: ClothingUniformChiefEngiThong
+  category: ClothingEngineering
   completetime: 2
   materials:
     Cloth: 100
@@ -99,6 +111,7 @@
 - type: latheRecipe
   id: ClothingHandsEpiWarmers
   result: ClothingHandsEpiWarmers
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -106,6 +119,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksEpi
   result: ClothingUnderSocksEpi
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -113,6 +127,7 @@
 - type: latheRecipe
   id: ClothingUniformEpiThong
   result: ClothingUniformEpiThong
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 100
@@ -121,6 +136,7 @@
 - type: latheRecipe
   id: ClothingHandsEpiHeadWarmers
   result: ClothingHandsEpiHeadWarmers
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -128,6 +144,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksEpiHead
   result: ClothingUnderSocksEpiHead
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -135,6 +152,7 @@
 - type: latheRecipe
   id: ClothingUniformEpiHeadThong
   result: ClothingUniformEpiHeadThong
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 100
@@ -143,6 +161,7 @@
 - type: latheRecipe
   id: ClothingHandsMantisEpiWarmers
   result: ClothingHandsMantisEpiWarmers
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -150,6 +169,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksMantisEpi
   result: ClothingUnderSocksMantisEpi
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -157,6 +177,7 @@
 - type: latheRecipe
   id: ClothingUniformMantisEpiThong
   result: ClothingUniformMantisEpiThong
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 100
@@ -165,6 +186,7 @@
 - type: latheRecipe
   id: ClothingHandsChaplainWarmers
   result: ClothingHandsChaplainWarmers
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -172,6 +194,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksChaplain
   result: ClothingUnderSocksChaplain
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 300
@@ -179,6 +202,7 @@
 - type: latheRecipe
   id: ClothingUniformChaplainThong
   result: ClothingUniformChaplainThong
+  category: ClothingEpistemics
   completetime: 2
   materials:
     Cloth: 100
@@ -187,6 +211,7 @@
 - type: latheRecipe
   id: ClothingHandsLogisWarmers
   result: ClothingHandsLogisWarmers
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -194,6 +219,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksLogis
   result: ClothingUnderSocksLogis
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -201,6 +227,7 @@
 - type: latheRecipe
   id: ClothingUniformLogisThong
   result: ClothingUniformLogisThong
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 100
@@ -209,6 +236,7 @@
 - type: latheRecipe
   id: ClothingHandsLOLogisWarmers
   result: ClothingHandsLOLogisWarmers
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -216,6 +244,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksLOLogis
   result: ClothingUnderSocksLOLogis
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -223,6 +252,7 @@
 - type: latheRecipe
   id: ClothingUniformLOLogisThong
   result: ClothingUniformLOLogisThong
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 100
@@ -231,6 +261,7 @@
 - type: latheRecipe
   id: ClothingHandsCourierWarmers
   result: ClothingHandsCourierWarmers
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -238,6 +269,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCourier
   result: ClothingUnderSocksCourier
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 300
@@ -245,6 +277,7 @@
 - type: latheRecipe
   id: ClothingUniformCourierThong
   result: ClothingUniformCourierThong
+  category: ClothingLogistics
   completetime: 2
   materials:
     Cloth: 100
@@ -253,6 +286,7 @@
 - type: latheRecipe
   id: ClothingHandsMedicWarmers
   result: ClothingHandsMedicWarmers
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -260,6 +294,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksMedic
   result: ClothingUnderSocksMedic
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -267,6 +302,7 @@
 - type: latheRecipe
   id: ClothingUniformMedicThong
   result: ClothingUniformMedicThong
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 100
@@ -275,6 +311,7 @@
 - type: latheRecipe
   id: ClothingHandsChemistsWarmers
   result: ClothingHandsChemistsWarmers
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -282,6 +319,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksChemists
   result: ClothingUnderSocksChemists
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -289,6 +327,7 @@
 - type: latheRecipe
   id: ClothingUniformChemistsThong
   result: ClothingUniformChemistsThong
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 100
@@ -297,6 +336,7 @@
 - type: latheRecipe
   id: ClothingHandsParaMedicWarmers
   result: ClothingHandsParaMedicWarmers
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -304,6 +344,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksParaMedic
   result: ClothingUnderSocksParaMedic
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -311,6 +352,7 @@
 - type: latheRecipe
   id: ClothingUniformParaMedicThong
   result: ClothingUniformParaMedicThong
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 100
@@ -319,6 +361,7 @@
 - type: latheRecipe
   id: ClothingHandsCMOWarmers
   result: ClothingHandsCMOWarmers
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -326,6 +369,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCMO
   result: ClothingUnderSocksCMO
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 300
@@ -333,6 +377,7 @@
 - type: latheRecipe
   id: ClothingUniformCMOThong
   result: ClothingUniformCMOThong
+  category: ClothingMedical
   completetime: 2
   materials:
     Cloth: 100
@@ -341,6 +386,7 @@
 - type: latheRecipe
   id: ClothingHandsSecurityWarmers
   result: ClothingHandsSecurityWarmers
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -349,6 +395,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksSecurity
   result: ClothingUnderSocksSecurity
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -357,6 +404,7 @@
 - type: latheRecipe
   id: ClothingUniformSecurityThong
   result: ClothingUniformSecurityThong
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 100
@@ -366,6 +414,7 @@
 - type: latheRecipe
   id: ClothingHandsHeadSecurityWarmers
   result: ClothingHandsHeadSecurityWarmers
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -374,6 +423,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksHeadSecurity
   result: ClothingUnderSocksHeadSecurity
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -382,6 +432,7 @@
 - type: latheRecipe
   id: ClothingUniformHeadSecurityThong
   result: ClothingUniformHeadSecurityThong
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 100
@@ -391,6 +442,7 @@
 - type: latheRecipe
   id: ClothingHandsDetectiveWarmers
   result: ClothingHandsDetectiveWarmers
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -399,6 +451,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksDetective
   result: ClothingUnderSocksDetective
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -407,6 +460,7 @@
 - type: latheRecipe
   id: ClothingUniformDetectiveThong
   result: ClothingUniformDetectiveThong
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 100
@@ -416,6 +470,7 @@
 - type: latheRecipe
   id: ClothingHandsCorpsmanWarmers
   result: ClothingHandsCorpsmanWarmers
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -424,6 +479,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksCorpsman
   result: ClothingUnderSocksCorpsman
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 200
@@ -432,6 +488,7 @@
 - type: latheRecipe
   id: ClothingUniformCorpsmanThong
   result: ClothingUniformCorpsmanThong
+  category: ClothingSecurity
   completetime: 2
   materials:
     Cloth: 100
@@ -441,6 +498,7 @@
 - type: latheRecipe
   id: ClothingHandsServiceWarmers
   result: ClothingHandsServiceWarmers
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -448,6 +506,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksService
   result: ClothingUnderSocksService
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -455,6 +514,7 @@
 - type: latheRecipe
   id: ClothingUniformServiceThong
   result: ClothingUniformServiceThong
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 100
@@ -463,6 +523,7 @@
 - type: latheRecipe
   id: ClothingHandsJanitorWarmers
   result: ClothingHandsJanitorWarmers
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -470,6 +531,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksJanitor
   result: ClothingUnderSocksJanitor
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -477,6 +539,7 @@
 - type: latheRecipe
   id: ClothingUniformJanitorThong
   result: ClothingUniformJanitorThong
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 100
@@ -485,6 +548,7 @@
 - type: latheRecipe
   id: ClothingHandsBartenderWarmers
   result: ClothingHandsBartenderWarmers
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -492,6 +556,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksBartender
   result: ClothingUnderSocksBartender
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -499,6 +564,7 @@
 - type: latheRecipe
   id: ClothingUniformBartenderThong
   result: ClothingUniformBartenderThong
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 100
@@ -507,6 +573,7 @@
 - type: latheRecipe
   id: ClothingHandsMusicianWarmers
   result: ClothingHandsMusicianWarmers
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -514,6 +581,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksMusician
   result: ClothingUnderSocksMusician
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -521,6 +589,7 @@
 - type: latheRecipe
   id: ClothingUniformMusicianThong
   result: ClothingUniformMusicianThong
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 100
@@ -529,6 +598,7 @@
 - type: latheRecipe
   id: ClothingHandsChefWarmers
   result: ClothingHandsChefWarmers
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -536,6 +606,7 @@
 - type: latheRecipe
   id: ClothingUnderSocksChef
   result: ClothingUnderSocksChef
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 300
@@ -543,6 +614,7 @@
 - type: latheRecipe
   id: ClothingUniformChefThong
   result: ClothingUniformChefThong
+  category: ClothingService
   completetime: 2
   materials:
     Cloth: 100
@@ -551,6 +623,7 @@
 - type: latheRecipe
   id: ClothingUniformSurgeonGerneralThong
   result: ClothingUniformSurgeonGerneralThong
+  category: ClothingOther
   completetime: 2
   materials:
     Cloth: 100

--- a/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
@@ -73,6 +73,28 @@
   materials:
     Cloth: 100
 
+# Chief Engineer
+- type: latheRecipe
+  id: ClothingHandsChiefEngiWarmers
+  result: ClothingHandsChiefEngiWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksChiefEngi
+  result: ClothingUnderSocksChiefEngi
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformChiefEngiThong
+  result: ClothingUniformChiefEngiThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
 #Epistemics
 - type: latheRecipe
   id: ClothingHandsEpiWarmers
@@ -91,6 +113,50 @@
 - type: latheRecipe
   id: ClothingUniformEpiThong
   result: ClothingUniformEpiThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Mystagogue
+- type: latheRecipe
+  id: ClothingHandsEpiHeadWarmers
+  result: ClothingHandsEpiHeadWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksEpiHead
+  result: ClothingUnderSocksEpiHead
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformEpiHeadThong
+  result: ClothingUniformEpiHeadThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Mantis
+- type: latheRecipe
+  id: ClothingHandsMantisEpiWarmers
+  result: ClothingHandsMantisEpiWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksMantisEpi
+  result: ClothingUnderSocksMantisEpi
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformMantisEpiThong
+  result: ClothingUniformMantisEpiThong
   completetime: 2
   materials:
     Cloth: 100
@@ -139,6 +205,50 @@
   materials:
     Cloth: 100
 
+# Logistics Officer
+- type: latheRecipe
+  id: ClothingHandsLOLogisWarmers
+  result: ClothingHandsLOLogisWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksLOLogis
+  result: ClothingUnderSocksLOLogis
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformLOLogisThong
+  result: ClothingUniformLOLogisThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Courier
+- type: latheRecipe
+  id: ClothingHandsCourierWarmers
+  result: ClothingHandsCourierWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksCourier
+  result: ClothingUnderSocksCourier
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformCourierThong
+  result: ClothingUniformCourierThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
 #Medical
 - type: latheRecipe
   id: ClothingHandsMedicWarmers
@@ -157,6 +267,72 @@
 - type: latheRecipe
   id: ClothingUniformMedicThong
   result: ClothingUniformMedicThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Chemist
+- type: latheRecipe
+  id: ClothingHandsChemistsWarmers
+  result: ClothingHandsChemistsWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksChemists
+  result: ClothingUnderSocksChemists
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformChemistsThong
+  result: ClothingUniformChemistsThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Paramedic
+- type: latheRecipe
+  id: ClothingHandsParaMedicWarmers
+  result: ClothingHandsParaMedicWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksParaMedic
+  result: ClothingUnderSocksParaMedic
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformParaMedicThong
+  result: ClothingUniformParaMedicThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Chief Medical Officer
+- type: latheRecipe
+  id: ClothingHandsCMOWarmers
+  result: ClothingHandsCMOWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksCMO
+  result: ClothingUnderSocksCMO
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformCMOThong
+  result: ClothingUniformCMOThong
   completetime: 2
   materials:
     Cloth: 100
@@ -181,6 +357,81 @@
 - type: latheRecipe
   id: ClothingUniformSecurityThong
   result: ClothingUniformSecurityThong
+  completetime: 2
+  materials:
+    Cloth: 100
+    Durathread: 50
+
+# Head of Security
+- type: latheRecipe
+  id: ClothingHandsHeadSecurityWarmers
+  result: ClothingHandsHeadSecurityWarmers
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUnderSocksHeadSecurity
+  result: ClothingUnderSocksHeadSecurity
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformHeadSecurityThong
+  result: ClothingUniformHeadSecurityThong
+  completetime: 2
+  materials:
+    Cloth: 100
+    Durathread: 50
+
+# Detective
+- type: latheRecipe
+  id: ClothingHandsDetectiveWarmers
+  result: ClothingHandsDetectiveWarmers
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUnderSocksDetective
+  result: ClothingUnderSocksDetective
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformDetectiveThong
+  result: ClothingUniformDetectiveThong
+  completetime: 2
+  materials:
+    Cloth: 100
+    Durathread: 50
+
+# Corpsman
+- type: latheRecipe
+  id: ClothingHandsCorpsmanWarmers
+  result: ClothingHandsCorpsmanWarmers
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUnderSocksCorpsman
+  result: ClothingUnderSocksCorpsman
+  completetime: 2
+  materials:
+    Cloth: 200
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformCorpsmanThong
+  result: ClothingUniformCorpsmanThong
   completetime: 2
   materials:
     Cloth: 100
@@ -270,6 +521,28 @@
 - type: latheRecipe
   id: ClothingUniformMusicianThong
   result: ClothingUniformMusicianThong
+  completetime: 2
+  materials:
+    Cloth: 100
+
+# Chef
+- type: latheRecipe
+  id: ClothingHandsChefWarmers
+  result: ClothingHandsChefWarmers
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUnderSocksChef
+  result: ClothingUnderSocksChef
+  completetime: 2
+  materials:
+    Cloth: 300
+
+- type: latheRecipe
+  id: ClothingUniformChefThong
+  result: ClothingUniformChefThong
   completetime: 2
   materials:
     Cloth: 100

--- a/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
+++ b/Resources/Prototypes/Floof/Recipes/Lathes/uniformssocksect.yml
@@ -22,7 +22,7 @@
   completetime: 2
   materials:
     Cloth: 100
-    Durathread: 100
+    Durathread: 50
 
 #Command
 
@@ -48,7 +48,7 @@
   completetime: 2
   materials:
     Cloth: 100
-    Durathread: 100
+    Durathread: 50
 
 #Engineering
 

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Lathes/clothing.yml
@@ -4,6 +4,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpsuit/prisonguard.rsi
     state: icon
   result: ClothingUniformJumpsuitPrisonGuard
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -14,6 +15,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpsuit/mantis_uniform.rsi
     state: icon
   result: ClothingUniformJumpsuitMantis
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -24,6 +26,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpskirt/mantis_jumpskirt.rsi
     state: icon
   result: ClothingUniformSkirtMantis
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -34,6 +37,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpsuit/mailman.rsi
     state: icon
   result: ClothingUniformCourier
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -44,6 +48,7 @@
     sprite: Nyanotrasen/Clothing/Uniforms/Jumpskirt/mailman.rsi
     state: icon
   result: ClothingUniformSkirtCourier
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -3,6 +3,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitColorGrey # Tide
   result: ClothingUniformJumpsuitColorGrey
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -10,6 +11,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtColorGrey
   result: ClothingUniformJumpskirtColorGrey
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -17,6 +19,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitBartender
   result: ClothingUniformJumpsuitBartender
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -24,6 +27,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtBartender
   result: ClothingUniformJumpskirtBartender
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -31,6 +35,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCaptain
   result: ClothingUniformJumpsuitCaptain
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -39,6 +44,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCapFormal
   result: ClothingUniformJumpsuitCapFormal
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -48,6 +54,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtCapFormalDress
   result: ClothingUniformJumpskirtCapFormalDress
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -56,6 +63,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtCaptain
   result: ClothingUniformJumpskirtCaptain
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -64,6 +72,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCargo
   result: ClothingUniformJumpsuitCargo
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -71,6 +80,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtCargo
   result: ClothingUniformJumpskirtCargo
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -78,6 +88,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSalvageSpecialist
   result: ClothingUniformJumpsuitSalvageSpecialist
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 500 #It's armored but I don't want to include durathread for a non-head
@@ -85,6 +96,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCentcomAgent
   result: ClothingUniformJumpsuitCentcomAgent
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -93,6 +105,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCentcomFormal
   result: ClothingUniformJumpsuitCentcomFormal
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -101,6 +114,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtCentcomFormalDress
   result: ClothingUniformJumpskirtCentcomFormalDress
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -109,6 +123,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCentcomOfficer
   result: ClothingUniformJumpsuitCentcomOfficer
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -117,6 +132,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCentcomOfficial
   result: ClothingUniformJumpsuitCentcomOfficial
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -125,6 +141,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitChiefEngineer
   result: ClothingUniformJumpsuitChiefEngineer
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -133,6 +150,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtChiefEngineer
   result: ClothingUniformJumpskirtChiefEngineer
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -141,6 +159,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitChiefEngineerTurtle
   result: ClothingUniformJumpsuitChiefEngineerTurtle
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -148,6 +167,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtChiefEngineerTurtle
   result: ClothingUniformJumpskirtChiefEngineerTurtle
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -155,6 +175,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitChaplain
   result: ClothingUniformJumpsuitChaplain
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -162,6 +183,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtChaplain
   result: ClothingUniformJumpskirtChaplain
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -169,6 +191,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitChef
   result: ClothingUniformJumpsuitChef
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -176,6 +199,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtChef
   result: ClothingUniformJumpskirtChef
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -183,6 +207,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitChemistry
   result: ClothingUniformJumpsuitChemistry
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -190,6 +215,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtChemistry
   result: ClothingUniformJumpskirtChemistry
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -197,6 +223,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitClown
   result: ClothingUniformJumpsuitClown
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -204,6 +231,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitCMO
   result: ClothingUniformJumpsuitCMO
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -212,6 +240,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtCMO
   result: ClothingUniformJumpskirtCMO
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -220,6 +249,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitDetective
   result: ClothingUniformJumpsuitDetective
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -227,6 +257,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtDetective
   result: ClothingUniformJumpskirtDetective
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -234,6 +265,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitEngineering
   result: ClothingUniformJumpsuitEngineering
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -241,6 +273,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtEngineering
   result: ClothingUniformJumpskirtEngineering
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -248,6 +281,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSeniorEngineer
   result: ClothingUniformJumpsuitSeniorEngineer
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -255,6 +289,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSeniorEngineer
   result: ClothingUniformJumpskirtSeniorEngineer
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -262,6 +297,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoP
   result: ClothingUniformJumpsuitHoP
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -270,6 +306,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoP
   result: ClothingUniformJumpskirtHoP
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -278,6 +315,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoS
   result: ClothingUniformJumpsuitHoS
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -286,6 +324,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoS
   result: ClothingUniformJumpskirtHoS
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -294,6 +333,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHosFormal
   result: ClothingUniformJumpsuitHosFormal
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -302,6 +342,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHosFormal
   result: ClothingUniformJumpskirtHosFormal
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -310,6 +351,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoSParadeMale
   result: ClothingUniformJumpsuitHoSParadeMale
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 5
   materials:
     Cloth: 300
@@ -318,6 +360,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoSParadeMale
   result: ClothingUniformJumpskirtHoSParadeMale
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 5
   materials:
     Cloth: 300
@@ -326,6 +369,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoSAlt
   result: ClothingUniformJumpsuitHoSAlt
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -334,6 +378,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoSBlue
   result: ClothingUniformJumpsuitHoSBlue
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -342,6 +387,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHoSGrey
   result: ClothingUniformJumpsuitHoSGrey
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -350,6 +396,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHoSAlt
   result: ClothingUniformJumpskirtHoSAlt
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -358,6 +405,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitHydroponics
   result: ClothingUniformJumpsuitHydroponics
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -365,6 +413,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtHydroponics
   result: ClothingUniformJumpskirtHydroponics
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -372,6 +421,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitJanitor
   result: ClothingUniformJumpsuitJanitor
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -379,6 +429,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtJanitor
   result: ClothingUniformJumpskirtJanitor
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -386,6 +437,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitLawyerBlack
   result: ClothingUniformJumpsuitLawyerBlack
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -393,6 +445,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitLibrarian
   result: ClothingUniformJumpsuitLibrarian
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -400,6 +453,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtColorLightBrown #Librarian
   result: ClothingUniformJumpskirtColorLightBrown
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -407,6 +461,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitMedicalDoctor
   result: ClothingUniformJumpsuitMedicalDoctor
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -414,6 +469,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtMedicalDoctor
   result: ClothingUniformJumpskirtMedicalDoctor
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -421,6 +477,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSeniorPhysician
   result: ClothingUniformJumpsuitSeniorPhysician
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -428,6 +485,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSeniorPhysician
   result: ClothingUniformJumpskirtSeniorPhysician
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -435,6 +493,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitMime
   result: ClothingUniformJumpsuitMime
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -442,6 +501,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtMime
   result: ClothingUniformJumpskirtMime
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -449,6 +509,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitMusician
   result: ClothingUniformJumpsuitMusician
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -456,6 +517,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitOperative
   result: ClothingUniformJumpsuitOperative
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -463,6 +525,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtOperative
   result: ClothingUniformJumpskirtOperative
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -470,6 +533,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitParamedic
   result: ClothingUniformJumpsuitParamedic
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -477,6 +541,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtParamedic
   result: ClothingUniformJumpskirtParamedic
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -484,6 +549,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSeniorOfficer
   result: ClothingUniformJumpsuitSeniorOfficer
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -491,6 +557,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSeniorOfficer
   result: ClothingUniformJumpskirtSeniorOfficer
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -498,6 +565,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitPrisoner
   result: ClothingUniformJumpsuitPrisoner
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -505,6 +573,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtPrisoner
   result: ClothingUniformJumpskirtPrisoner
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -512,6 +581,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitQM
   result: ClothingUniformJumpsuitQM
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -519,6 +589,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitQMFormal
   result: ClothingUniformJumpsuitQMFormal
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -526,6 +597,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtQM
   result: ClothingUniformJumpskirtQM
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -533,6 +605,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitQMTurtleneck
   result: ClothingUniformJumpsuitQMTurtleneck
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -540,6 +613,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtQMTurtleneck
   result: ClothingUniformJumpskirtQMTurtleneck
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -547,6 +621,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitResearchDirector
   result: ClothingUniformJumpsuitResearchDirector
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -555,6 +630,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtResearchDirector
   result: ClothingUniformJumpskirtResearchDirector
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -563,6 +639,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitScientist
   result: ClothingUniformJumpsuitScientist
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -570,6 +647,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtScientist
   result: ClothingUniformJumpskirtScientist
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -577,6 +655,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSeniorResearcher
   result: ClothingUniformJumpsuitSeniorResearcher
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -584,6 +663,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSeniorResearcher
   result: ClothingUniformJumpskirtSeniorResearcher
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -591,6 +671,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSec
   result: ClothingUniformJumpsuitSec
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -598,6 +679,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSec
   result: ClothingUniformJumpskirtSec
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -605,6 +687,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitBrigmedic
   result: ClothingUniformJumpsuitBrigmedic
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -612,6 +695,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtBrigmedic
   result: ClothingUniformJumpskirtBrigmedic
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -619,6 +703,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitSyndieFormal
   result: ClothingUniformJumpsuitSyndieFormal
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -626,6 +711,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtSyndieFormalDress
   result: ClothingUniformJumpskirtSyndieFormalDress
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -633,6 +719,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitPyjamaSyndicateBlack
   result: ClothingUniformJumpsuitPyjamaSyndicateBlack
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -640,6 +727,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitPyjamaSyndicatePink
   result: ClothingUniformJumpsuitPyjamaSyndicatePink
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -647,6 +735,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitPyjamaSyndicateRed
   result: ClothingUniformJumpsuitPyjamaSyndicateRed
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -654,6 +743,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpsuitWarden
   result: ClothingUniformJumpsuitWarden
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -661,6 +751,7 @@
 - type: latheRecipe
   id: ClothingUniformJumpskirtWarden
   result: ClothingUniformJumpskirtWarden
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 4
   materials:
     Cloth: 300
@@ -668,6 +759,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCap
   result: ClothingOuterWinterCap
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -676,6 +768,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCE
   result: ClothingOuterWinterCE
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -684,6 +777,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCentcom
   result: ClothingOuterWinterCentcom
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -692,6 +786,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCMO
   result: ClothingOuterWinterCMO
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -700,6 +795,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterHoP
   result: ClothingOuterWinterHoP
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -708,6 +804,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterHoSUnarmored
   result: ClothingOuterWinterHoSUnarmored
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -716,6 +813,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterWardenUnarmored
   result: ClothingOuterWinterWardenUnarmored
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -724,6 +822,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterQM
   result: ClothingOuterWinterQM
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -732,6 +831,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterRD
   result: ClothingOuterWinterRD
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -740,6 +840,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleCap
   result: ClothingNeckMantleCap
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -748,6 +849,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleCE
   result: ClothingNeckMantleCE
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -756,6 +858,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleCMO
   result: ClothingNeckMantleCMO
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -764,6 +867,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleHOP
   result: ClothingNeckMantleHOP
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -772,6 +876,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleHOS
   result: ClothingNeckMantleHOS
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -780,6 +885,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleRD
   result: ClothingNeckMantleRD
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -788,6 +894,7 @@
 - type: latheRecipe
   id: ClothingNeckMantleQM
   result: ClothingNeckMantleQM
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 2.8
   materials:
     Cloth: 200
@@ -796,6 +903,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterMusician
   result: ClothingOuterWinterMusician
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -804,6 +912,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterClown
   result: ClothingOuterWinterClown
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -812,6 +921,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterMime
   result: ClothingOuterWinterMime
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -820,6 +930,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCoat
   result: ClothingOuterWinterCoat
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -828,6 +939,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterJani
   result: ClothingOuterWinterJani
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -836,6 +948,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterBar
   result: ClothingOuterWinterBar
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -844,6 +957,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterChef
   result: ClothingOuterWinterChef
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -852,6 +966,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterHydro
   result: ClothingOuterWinterHydro
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -860,6 +975,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterAtmos
   result: ClothingOuterWinterAtmos
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -868,6 +984,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterEngi
   result: ClothingOuterWinterEngi
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -876,6 +993,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterCargo
   result: ClothingOuterWinterCargo
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -884,6 +1002,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterMiner
   result: ClothingOuterWinterMiner
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -892,6 +1011,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterMed
   result: ClothingOuterWinterMed
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -900,6 +1020,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterPara
   result: ClothingOuterWinterPara
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -908,6 +1029,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterChem
   result: ClothingOuterWinterChem
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -916,6 +1038,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterGen
   result: ClothingOuterWinterGen
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -924,6 +1047,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterViro
   result: ClothingOuterWinterViro
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -932,6 +1056,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterSci
   result: ClothingOuterWinterSci
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -940,6 +1065,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterRobo
   result: ClothingOuterWinterRobo
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -948,6 +1074,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterSec
   result: ClothingOuterWinterSec
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -956,6 +1083,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterSyndie
   result: ClothingOuterWinterSyndie
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -964,6 +1092,7 @@
 - type: latheRecipe
   id: ClothingOuterWinterSyndieCap
   result: ClothingOuterWinterSyndieCap
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 3.2
   materials:
     Cloth: 500
@@ -972,6 +1101,7 @@
 - type: latheRecipe
   id: ClothingHeadHatCaptain
   result: ClothingHeadHatCaptain
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -980,6 +1110,7 @@
 - type: latheRecipe
   id: ClothingHeadHatCapcap
   result: ClothingHeadHatCapcap
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -988,6 +1119,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretHoS
   result: ClothingHeadHatBeretHoS
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -996,6 +1128,7 @@
 - type: latheRecipe
   id: ClothingHeadHatHoshat
   result: ClothingHeadHatHoshat
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1004,6 +1137,7 @@
 - type: latheRecipe
   id: ClothingHeadHatWarden
   result: ClothingHeadHatWarden
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1012,6 +1146,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretWarden
   result: ClothingHeadHatBeretWarden
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1020,6 +1155,7 @@
 - type: latheRecipe
   id: ClothingHeadHatHopcap
   result: ClothingHeadHatHopcap
+  category: ClothingService # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1028,6 +1164,7 @@
 - type: latheRecipe
   id: ClothingHeadHatQMsoft
   result: ClothingHeadHatQMsoft
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1036,6 +1173,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretRND
   result: ClothingHeadHatBeretRND
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1044,6 +1182,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretEngineering
   result: ClothingHeadHatBeretEngineering
+  category: ClothingEngineering # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1052,6 +1191,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretQM
   result: ClothingHeadHatBeretQM
+  category: ClothingLogistics # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1060,6 +1200,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretCmo
   result: ClothingHeadHatBeretCmo
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1068,6 +1209,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretMedic
   result: ClothingHeadHatBeretMedic
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1075,6 +1217,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretBrigmedic
   result: ClothingHeadHatBeretBrigmedic
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1082,6 +1225,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretSecurity
   result: ClothingHeadHatBeretSecurity
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1089,6 +1233,7 @@
 - type: latheRecipe
   id: ClothingHeadHatBeretSeniorPhysician
   result: ClothingHeadHatBeretSeniorPhysician
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1096,6 +1241,7 @@
 - type: latheRecipe
   id: ClothingHeadHatCentcom
   result: ClothingHeadHatCentcom
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1104,6 +1250,7 @@
 - type: latheRecipe
   id: ClothingHeadHatCentcomcap
   result: ClothingHeadHatCentcomcap
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1112,6 +1259,7 @@
 - type: latheRecipe
   id: ClothingHeadHatSyndie
   result: ClothingHeadHatSyndie
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1119,6 +1267,7 @@
 - type: latheRecipe
   id: ClothingHeadHatSyndieMAA
   result: ClothingHeadHatSyndieMAA
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1126,6 +1275,7 @@
 - type: latheRecipe
   id: ClothingHeadPyjamaSyndicateBlack
   result: ClothingHeadPyjamaSyndicateBlack
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1133,6 +1283,7 @@
 - type: latheRecipe
   id: ClothingHeadPyjamaSyndicatePink
   result: ClothingHeadPyjamaSyndicatePink
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1140,6 +1291,7 @@
 - type: latheRecipe
   id: ClothingHeadPyjamaSyndicateRed
   result: ClothingHeadPyjamaSyndicateRed
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100
@@ -1147,6 +1299,7 @@
 - type: latheRecipe
   id: ClothingHeadHatParamedicsoft
   result: ClothingHeadHatParamedicsoft
+  category: ClothingMedical # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1154,6 +1307,7 @@
 - type: latheRecipe
   id: ClothingNeckTieRed
   result: ClothingNeckTieRed
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1161,6 +1315,7 @@
 - type: latheRecipe
   id: ClothingNeckTieDet
   result: ClothingNeckTieDet
+  category: ClothingSecurity # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1168,6 +1323,7 @@
 - type: latheRecipe
   id: ClothingNeckTieSci
   result: ClothingNeckTieSci
+  category: ClothingEpistemics # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1175,6 +1331,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedGreen
   result: ClothingNeckScarfStripedGreen
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1182,6 +1339,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedBlue
   result: ClothingNeckScarfStripedBlue
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1189,6 +1347,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedRed
   result: ClothingNeckScarfStripedRed
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1196,6 +1355,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedBrown
   result: ClothingNeckScarfStripedBrown
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1203,6 +1363,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedLightBlue
   result: ClothingNeckScarfStripedLightBlue
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1210,6 +1371,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedOrange
   result: ClothingNeckScarfStripedOrange
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1217,6 +1379,7 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedBlack
   result: ClothingNeckScarfStripedBlack
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
@@ -1224,13 +1387,16 @@
 - type: latheRecipe
   id: ClothingNeckScarfStripedPurple
   result: ClothingNeckScarfStripedPurple
+  category: ClothingOther # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 200
+
 # Carpets
 - type: latheRecipe
   id: Carpet
   result: FloorCarpetItemRed
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1238,6 +1404,7 @@
 - type: latheRecipe
   id: CarpetBlack
   result: FloorCarpetItemBlack
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1245,6 +1412,7 @@
 - type: latheRecipe
   id: CarpetPink
   result: FloorCarpetItemPink
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1252,6 +1420,7 @@
 - type: latheRecipe
   id: CarpetBlue
   result: FloorCarpetItemBlue
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1259,6 +1428,7 @@
 - type: latheRecipe
   id: CarpetGreen
   result: FloorCarpetItemGreen
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1266,6 +1436,7 @@
 - type: latheRecipe
   id: CarpetOrange
   result: FloorCarpetItemOrange
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1273,6 +1444,7 @@
 - type: latheRecipe
   id: CarpetPurple
   result: FloorCarpetItemPurple
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1280,6 +1452,7 @@
 - type: latheRecipe
   id: CarpetCyan
   result: FloorCarpetItemCyan
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1287,6 +1460,7 @@
 - type: latheRecipe
   id: CarpetWhite
   result: FloorCarpetItemWhite
+  category: Carpet # Floof - add uniform printer clothing categories
   completetime: 1
   materials:
     Cloth: 100
@@ -1295,6 +1469,7 @@
 - type: latheRecipe
   id: ClothingNeckCollarCmd
   result: ClothingNeckCollarCmd
+  category: ClothingCommand # Floof - add uniform printer clothing categories
   completetime: 2
   materials:
     Cloth: 100


### PR DESCRIPTION
# Description

Adds missing departmental thongs, thigh highs, and socks to uniform printer, adds clothing categories, and adds some other missing uniforms.

We have had problems with the lingerie items since their addition to the game. Adding them in any quantity to the departmental 'drobes causes restock cost balance issues, and many of them are _only_ available as starting loadout (a system which itself has significant issues). This pull request seeks to address these issues in a small way by making them accessible post round-start via the uniform printer.

There are a lot of items available in the uniform printer. Adding categories is proposed as a way to make it easier to use.

The atmospheric and roboticist uniform items were found to be missing from the list. Since these are equivalent to many other items available in the printer and not special in any way, they were added to the uniform printer.

---

# TODO

- [x] Create recipes.
- [x] Add recipes to the uniform printer.
- [x] Investigate the possibility of adding categories.
- [x] Find more missing uniform recipes.
- [x] Test changes.
- [x] Add media.

---

<details><summary><h1>Media</h1></summary>
<h3>New clothing categories, atmospherics and chief engineer recipes (sample).<h3>
<p>

![new-categories-new-atmos](https://github.com/user-attachments/assets/7f17c472-b3e7-42c6-9a39-ae009f957fa1)


</p>
</details>

---

# Changelog

:cl:
- add: New uniform printer recipes for many missing departmental lingerie items.
