### PR TITLE
Restore Missing Changelog Entries

### DIFF
--- a/Resources/Changelog/Floof.yml
+++ b/Resources/Changelog/Floof.yml
@@ -2513,14 +2513,14 @@ Entries:
   changes:
     - type: Fix
       message: >- 
-        Did another wave of bugfixes. Vending machines can be repaired, 
+        Did another wave of bugfixes. Vending machines can be repaired,
         pseudo-items (small people in bags) are less broken, wagging can
-        be toggled while cuffed/sleeping, cryptobiollin no longer leaves 
+        be toggled while cuffed/sleeping, cryptobiollin no longer leaves
         you stuttering for 50 hours, and xeno larvae no longer weigh 50 terragrams.
     - type: Tweak
       message: >- 
-        PKAs now have lower spread when not wielded, and their accuracy 
-        increases the more you wait between shots, but sawn-off PKAs in turn 
+        PKAs now have lower spread when not wielded, and their accuracy
+        increases the more you wait between shots, but sawn-off PKAs in turn
         cannot be wielded.
     - type: Tweak
       message: The mood buffs from hugging and kissing now last longer.
@@ -2549,7 +2549,7 @@ Entries:
   changes:
     - type: Tweak
       message: >-
-        Tweaked the CC Outpost by adding missing rooms and renovating the bar, 
+        Tweaked the CC Outpost by adding missing rooms and renovating the bar,
         and improved the decals on the CC shuttle.
   id: 000 # Manual add
   time: '2025-02-02T18:56:00.0000000+00:00'
@@ -2597,17 +2597,17 @@ Entries:
   changes:
     - type: Tweak
       message: >-
-        In order to perform surgery, you now have to right-click a lying entity 
+        In order to perform surgery, you now have to right-click a lying entity
         while holding a surgical tool and use the "perform surgery" verb instead
         of just clicking on the said entity.
     - type: Add
       message: >-
-        Organs without a host will now rot within 5 and perish within 15 minutes. 
+        Organs without a host will now rot within 5 and perish within 15 minutes.
         Rotting organs cannot be transplanted.
     - type: Fix
       message: >-
-        Performed yet another wave of fixes. Blood deficiency no longer causes 
-        constant bleeding, buckling should no longer break your entity's draw 
+        Performed yet another wave of fixes. Blood deficiency no longer causes
+        constant bleeding, buckling should no longer break your entity's draw
         depth, and more.
   id: 000 # Manual add
   time: '2025-02-06T19:32:00.0000000+00:00'
@@ -2623,7 +2623,7 @@ Entries:
   changes:
     - type: Add
       message: >-
-        General anesthesia and Liquid general anesthesia canisters can now be 
+        General anesthesia and Liquid general anesthesia canisters can now be
         purchased from Logistics.
   id: 000 # Manual add
   time: '2025-02-06T19:37:00.0000000+00:00'
@@ -2632,7 +2632,7 @@ Entries:
   changes:
     - type: Tweak
       message: >-
-        Made it overall harder to severe body parts via damage, and made 
+        Made it overall harder to severe body parts via damage, and made
         environmental hazards less harmful to body parts.
   id: 000 # Manual add
   time: '2025-02-06T20:04:00.0000000+00:00'
@@ -2789,11 +2789,11 @@ Entries:
   changes:
     - type: Tweak
       message: >-
-        The crew monitor handheld and console now beep when a crew member goes into 
+        The crew monitor handheld and console now beep when a crew member goes into
         critical condition or dies!
     - type: Tweak
       message: >-
-        surgical duffels and syndicate surgical duffels now contain a nitrous oxide 
+        surgical duffels and syndicate surgical duffels now contain a nitrous oxide
         tank
   id: 000 # Manual add
   time: '2025-02-16T01:52:20.0000000+00:00'

--- a/Resources/Changelog/Floof.yml
+++ b/Resources/Changelog/Floof.yml
@@ -2447,6 +2447,203 @@ Entries:
   id: 305
   time: '2025-01-24T17:45:56.0000000+00:00'
   url: https://github.com/Fansana/floofstation1/pull/501
+- author: VividPups
+  changes:
+    - type: Add
+      message: Girl failure plushie added to the spawner
+  id: 000 # Manual add
+  time: '2025-01-25T18:16:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/507
+- author: WhiteLightningTwister
+  changes:
+    - type: Fix
+      message: Fixed incorrect doors either granting access or denying access.
+  id: 000 # Manual add
+  time: '2025-01-25T21:39:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/494
+- author: VividPups
+  changes:
+    - type: Tweak
+      message: Added the girl failure plushie to the prize counter and prize balls.
+  id: 000 # Manual add
+  time: '2025-01-26T12:05:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/513
+- author: Dzordz
+  changes:
+    - type: Tweak
+      message: Modified Marking data to allow slimes to use markis of other races
+    - type: Tweak
+      message: >- 
+        Modified Slime spieces to allow use of snowts, tails, head top and side,
+        markings
+  id: 000 # Manual add
+  time: '2025-01-26T13:54:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/417
+- author: FoxxoTrystan
+  changes:
+    - type: Add
+      message: Hypno Visor
+  id: 000 # Manual add
+  time: '2025-01-26T13:55:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/497
+- author: Dunrab
+  changes:
+    - type: Tweak
+      message: Replaced Submarine's broken decals and added missing things.
+    - type: Tweak
+      message: Changed Arena based on community feedback.
+  id: 000 # Manual add
+  time: '2025-01-26T14:39:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/510
+- author: fenndragon
+  changes:
+    - type: Add
+      message: Updated the rules, adding new sections and functionality.
+  id: 000 # Manual add
+  time: '2025-01-30T15:11:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/518
+- author: VividPups
+  changes:
+    - type: Add
+      message: Added the shark tail to reptilian markings.
+  id: 000 # Manual add
+  time: '2025-01-30T19:25:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/519
+- author: Mnemotechnician
+  changes:
+    - type: Fix
+      message: >- 
+        Did another wave of bugfixes. Vending machines can be repaired, 
+        pseudo-items (small people in bags) are less broken, wagging can
+        be toggled while cuffed/sleeping, cryptobiollin no longer leaves 
+        you stuttering for 50 hours, and xeno larvae no longer weigh 50 terragrams.
+    - type: Tweak
+      message: >- 
+        PKAs now have lower spread when not wielded, and their accuracy 
+        increases the more you wait between shots, but sawn-off PKAs in turn 
+        cannot be wielded.
+    - type: Tweak
+      message: The mood buffs from hugging and kissing now last longer.
+  id: 000 # Manual add
+  time: '2025-01-31T21:35:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/515
+- author: ItsDzordz
+  changes:
+    - type: Fix
+      message: Made the moth wings appiear again
+  id: 000 # Manual add
+  time: '2025-02-02T13:51:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/522
+- author: Mnemotechnician
+  changes:
+    - type: Add
+      message: Merged a number of QOL changes and fixes from upstream.
+    - type: Fix
+      message: >-
+        Fixed random humanoids all having the default placeholder humanoid
+        profiles.
+  id: 000 # Manual add
+  time: '2025-02-02T18:56:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/505
+- author: JenreyDominos
+  changes:
+    - type: Tweak
+      message: >-
+        Tweaked the CC Outpost by adding missing rooms and renovating the bar, 
+        and improved the decals on the CC shuttle.
+  id: 000 # Manual add
+  time: '2025-02-02T18:56:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/506
+- author: VividPups
+  changes:
+    - type: Add
+      message: SEWSC added the ability to print pre-filled non-lethal magazines.
+    - type: Tweak
+      message: SEWSC fixed the visual problems with some of the standard magazines.
+  id: 000 # Manual add
+  time: '2025-02-02T18:57:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/512
+- author: Dunrab
+  changes:
+    - type: Add
+      message: Added fland as a high pop map
+  id: 000 # Manual add
+  time: '2025-02-02T18:59:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/502
+- author: Errant-4
+  changes:
+    - type: Fix
+      message: Map labels no longer suddenly disappear for the rest of the round.
+  id: 000 # Manual add
+  time: '2025-02-03T18:45:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/517
+- author: LucasTheDrgn
+  changes:
+    - type: Fix
+      message: >-
+        Bio-synthetic left legs now properly expect and allow a left foot to be
+        attached.
+  id: 000 # Manual add
+  time: '2025-02-05T13:32:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/528
+- author: LucasTheDrgn
+  changes:
+    - type: Fix
+      message: Resomi now can have limbs reattached after having them removed.
+  id: 000 # Manual add
+  time: '2025-02-05T13:33:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/526
+- author: Mnemotechnician
+  changes:
+    - type: Tweak
+      message: >-
+        In order to perform surgery, you now have to right-click a lying entity 
+        while holding a surgical tool and use the "perform surgery" verb instead
+        of just clicking on the said entity.
+    - type: Add
+      message: >-
+        Organs without a host will now rot within 5 and perish within 15 minutes. 
+        Rotting organs cannot be transplanted.
+    - type: Fix
+      message: >-
+        Performed yet another wave of fixes. Blood deficiency no longer causes 
+        constant bleeding, buckling should no longer break your entity's draw 
+        depth, and more.
+  id: 000 # Manual add
+  time: '2025-02-06T19:32:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/531
+- author: Eagle0600
+  changes:
+    - type: Tweak
+      message: Increased CO2 alarm thresholds.
+  id: 000 # Manual add
+  time: '2025-02-06T19:36:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/530
+- author: LucasTheDrgn
+  changes:
+    - type: Add
+      message: >-
+        General anesthesia and Liquid general anesthesia canisters can now be 
+        purchased from Logistics.
+  id: 000 # Manual add
+  time: '2025-02-06T19:37:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/527
+- author: Mnemotechnician
+  changes:
+    - type: Tweak
+      message: >-
+        Made it overall harder to severe body parts via damage, and made 
+        environmental hazards less harmful to body parts.
+  id: 000 # Manual add
+  time: '2025-02-06T20:04:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/535
+- author: Forzii
+  changes:
+    - type: Add
+      message: Vulpkanin, Felinid, and Oni guidebook entries from Delta-V
+  id: 000 # Manual add
+  time: '2025-02-06T20:14:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/532
 - author: Mnemotechnician
   changes:
     - type: Fix
@@ -2547,6 +2744,29 @@ Entries:
   id: 315
   time: '2025-02-15T19:43:10.0000000+00:00'
   url: https://github.com/Fansana/floofstation1/pull/549
+- author: Forzii
+  changes:
+    - type: Add
+      message: Added NT Company Policy to guidebook
+  id: 000 # Manual add
+  time: '2025-02-16T01:50:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/525
+- author: Eagle0600
+  changes:
+    - type: Add
+      message: Added an engineering holoprojector autolathe recipe.
+    - type: Tweak
+      message: Engineering holoprojector power cells can now be removed and recharged.
+  id: 000 # Manual add
+  time: '2025-02-16T01:51:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/557
+- author: VividPups
+  changes:
+    - type: Add
+      message: Added a new blue space bag for botany
+  id: 000 # Manual add
+  time: '2025-02-16T01:51:30.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/551
 - author: Eagle0600
   changes:
     - type: Tweak
@@ -2556,6 +2776,28 @@ Entries:
   id: 316
   time: '2025-02-16T01:51:53.0000000+00:00'
   url: https://github.com/Fansana/floofstation1/pull/548
+- author: Forzii
+  changes:
+    - type: Add
+      message: >-
+        Added Moon Boots! Time to explain the team-building benefits of zero-g
+        water-gun fights to CC.
+  id: 000 # Manual add
+  time: '2025-02-16T01:52:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/547
+- author: Forzii
+  changes:
+    - type: Tweak
+      message: >-
+        The crew monitor handheld and console now beep when a crew member goes into 
+        critical condition or dies!
+    - type: Tweak
+      message: >-
+        surgical duffels and syndicate surgical duffels now contain a nitrous oxide 
+        tank
+  id: 000 # Manual add
+  time: '2025-02-16T01:52:20.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/546
 - author: fenndragon
   changes:
     - type: Add
@@ -2565,6 +2807,27 @@ Entries:
   id: 317
   time: '2025-02-16T01:52:39.0000000+00:00'
   url: https://github.com/Fansana/floofstation1/pull/539
+- author: Forzii
+  changes:
+    - type: Tweak
+      message: Diona can now have custom species names. Plants rejoice!
+  id: 000 # Manual add
+  time: '2025-02-18T13:48:20.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/567
+- author: Forzii
+  changes:
+    - type: Fix
+      message: CourierDrobes are now restockable with clothing restocks
+  id: 000 # Manual add
+  time: '2025-02-18T13:49:00.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/566
+- author: Forzii and Chokovit
+  changes:
+    - type: Add
+      message: Added custom rodentia scream
+  id: 000 # Manual add
+  time: '2025-02-18T13:49:20.0000000+00:00'
+  url: https://github.com/Fansana/floofstation1/pull/565
 - author: Eagle0600
   changes:
     - type: Add


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Manually added a bunch of changelog entries from between January 26th and February 18th that were missing.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Manually add missing changelog entries
- [ ] Figure out if Floof wants the IDs set to anything in particular

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Nahhh, you know what changelogs look like.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Added some missing changelog entries.
