### PR TITLE
Remove Deprecated JobPrototype Whitelist Requirements

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -3,6 +3,7 @@
   name: job-name-chief-justice
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
+  whitelisted: true # Floof - CJ whitelist
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobClerk
@@ -15,7 +16,7 @@
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement
       min: 90000 # 25 hours
-    - !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges
+    #- !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges | Floof - M3739 - How this made it past prod for this long is beyond me.
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -3,7 +3,7 @@
   name: job-name-chief-justice
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
-  whitelisted: true # Floof - CJ whitelist
+  # whitelisted: true # Floof - CJ whitelist
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobClerk
@@ -16,7 +16,7 @@
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement
       min: 90000 # 25 hours
-    #- !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges | Floof - M3739 - How this made it past prod for this long is beyond me.
+    #- !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges | Floof - M3739 - Does not work properly, do not use.
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -3,7 +3,7 @@
   name: job-name-chief-justice
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
-  # whitelisted: true # Floof - CJ whitelist
+  # whitelisted: true # whitelist requirement because I don't want any dingus judges | Floof - Chief Justice is not whitelisted.
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobClerk
@@ -16,7 +16,6 @@
       min: 36000 # 10 hours
     - !type:CharacterOverallTimeRequirement
       min: 90000 # 25 hours
-    #- !type:CharacterWhitelistRequirement # whitelist requirement because I don't want any dingus judges | Floof - M3739 - Does not work properly, do not use.
   weight: 20
   startingGear: CJGear
   icon: "JobIconChiefJustice"

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -39,7 +39,6 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
     min: 14400 # Floofstation - 4 hours
-  - !type:CharacterWhitelistRequirement
 
 #Lone Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -30,6 +30,7 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
+  whitelisted: true # Floof - Whitelist
   requirements:
   - !type:CharacterOverallTimeRequirement
     min: 54000 # Floofstation - 15 hours
@@ -39,7 +40,7 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
     min: 14400 # Floofstation - 4 hours
-  - !type:CharacterWhitelistRequirement
+  # - !type:CharacterWhitelistRequirement | Floof - M3739 - How this made it past prod for this long is beyond me.
 
 #Lone Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -30,7 +30,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-nuclear-operative-commander-objective
-  whitelisted: true # Floof - Whitelist
   requirements:
   - !type:CharacterOverallTimeRequirement
     min: 54000 # Floofstation - 15 hours
@@ -40,7 +39,7 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
     min: 14400 # Floofstation - 4 hours
-  # - !type:CharacterWhitelistRequirement | Floof - M3739 - How this made it past prod for this long is beyond me.
+  - !type:CharacterWhitelistRequirement
 
 #Lone Operative Gear
 - type: startingGear


### PR DESCRIPTION
Round 2153 was arguably a horrible round for both Security and Justice members involved. However, after some discussion with some fellow players and revelations, we found out that the whitelist system for Chief Justice is actually broken. Along with the CJ at the time not being whitelisted according to public sources within the Discord server.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This PR seeks to fix the aforementioned issue, which if not clear is as entails;

Currently at the moment you need 600 minutes and a "whitelist" to play as Chief Justice. However, due to an oversight in the YAML, this whitelist actually never existed.

For example, the `captain.yaml` utilizes the statement `whitelisted: true` to implement it. But for Chief Justice, this is instead utilizing the `!type;CharacterWhitelistRequirement` to attempt to accomplish this. However, this may likely be reliant on a non-existent component or system from DeltaV, and thus, it does not work as expected.

To correct this, `chief_justice.yml` now utilizes the `whitelisted: true` field instead of the flawed requirement as stated before. This change has also been attempted to be reflected to the Nuclear Operative Commander as it too used the same flawed requirement, but as it turns out, the antags work a bit differently on that regard. (For context, I never got whitelisted for ANY role, and I have access to Nuke Op Commander on live servers.)

![HOW](https://media1.tenor.com/m/9RCIDZjkhBsAAAAC/hamster-meme.gif)

LIVE M3739 REACTION

Edit: Originally, this PR was to fix what was thought to be a botched whitelist, and I was informed that the said whitelist never actually existed to begin with. This PR now removes the deprecated way of whitelisting jobs, so now players should no longer be confused as to Chief Justice needing a whitelist.

The rest of this PR's post is unaltered for posterity.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: M3739
- fix: Central Command has conducted a review of it's assignment system. Chief Justice should no longer be erroneously reporting that the job needs a whitelist.
