### PR TITLE
Fix Ripley Clamps Depositing

### DIFF
--- a/Content.Client/Buckle/BuckleSystem.cs
+++ b/Content.Client/Buckle/BuckleSystem.cs
@@ -98,7 +98,7 @@ internal sealed class BuckleSystem : SharedBuckleSystem
         var isNorth = GetEntityOrientation(uid) == Direction.North; // Floof - replaced with a method call
         foreach (var buckledEntity in component.BuckledEntities)
         {
-            if (!TryComp<BuckleComponent>(buckledEntity, out var buckle))
+            if (!TryComp<BuckleComponent>(buckledEntity, out var buckle) || buckle.BuckledTo != uid)
                 continue;
 
             if (!TryComp<SpriteComponent>(buckledEntity, out var buckledSprite))

--- a/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
+++ b/Content.Server/Mech/Equipment/EntitySystems/MechGrabberSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Numerics;
 using Content.Server.Interaction;
 using Content.Server.Mech.Equipment.Components;
 using Content.Server.Mech.Systems;
@@ -83,7 +84,7 @@ public sealed class MechGrabberSystem : EntitySystem
         var xform = Transform(toRemove);
         _transform.AttachToGridOrMap(toRemove, xform);
         var (mechPos, mechRot) = _transform.GetWorldPositionRotation(mechxform);
-        var toRemoveWorldPos = _transform.GetWorldPosition(xform);
+        var toRemoveWorldPos = Vector2.Zero; // _transform.GetWorldPosition(xform); // Floof - this used to add the item's position twice.
 
         var offset = mechPos + mechRot.RotateVec(component.DepositOffset);
         _transform.SetWorldPositionRotation(toRemove, toRemoveWorldPos + offset, Angle.Zero);
@@ -156,7 +157,7 @@ public sealed class MechGrabberSystem : EntitySystem
 
         args.Handled = true;
         var audio = _audio.PlayPvs(component.GrabSound, uid);
-        
+
         if (audio == null)
             return;
 


### PR DESCRIPTION
# Description
Ripley clamps used to calculate the world position of both the stored item and the ripley iteself and the deposit offset, and sum all of it, which resulted in `result_pos = ripley_pos + (ripley_pos + local_item_pos) + offset`, so the ripley would deposit items... Somewhere far away. Dumb.

Also made a small change to buckles in a HOPE that it fixes the sprite draw depth misprediction which I still cannot reproduce.

# Changelog
:cl:
- fix: Ripley and other mechs can once again deposit stored entities correctly.
