### PR TITLE
Medical Balance Tweaks and Fixes

### DIFF
--- a/Content.Server/Medical/Components/HealingComponent.cs
+++ b/Content.Server/Medical/Components/HealingComponent.cs
@@ -43,13 +43,13 @@ namespace Content.Server.Medical.Components
         /// </summary>
         [ViewVariables(VVAccess.ReadWrite)]
         [DataField("delay")]
-        public float Delay = 2f; //Was 3f, changed due to Surgery Changes
+        public float Delay = 3f; //Was 3f, changed due to Surgery Changes # Floof - reverted
 
         /// <summary>
         /// Delay multiplier when healing yourself.
         /// </summary>
         [DataField("selfHealPenaltyMultiplier")]
-        public float SelfHealPenaltyMultiplier = 2f; //Was 3f, changed due to Surgery Changes
+        public float SelfHealPenaltyMultiplier = 3f; //Was 3f, changed due to Surgery Changes # Floof - reverted
 
         /// <summary>
         ///     Sound played on healing begin

--- a/Content.Shared/Body/Part/BodyPartComponent.cs
+++ b/Content.Shared/Body/Part/BodyPartComponent.cs
@@ -117,7 +117,7 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     /// How much health to heal on the body part per tick.
     /// </summary>
     [DataField]
-    public float SelfHealingAmount = 5;
+    public float SelfHealingAmount = 0.5f; // Floof - reduced from 5 due to body part damage nerf. Was 10/min, now 1/min.
 
     /// <summary>
     /// The name of the container for this body part. Used in insertion surgeries.
@@ -159,8 +159,8 @@ public sealed partial class BodyPartComponent : Component, ISurgeryToolComponent
     [DataField, AutoNetworkedField]
     public Dictionary<TargetIntegrity, float> IntegrityThresholds = new()
     {
-        { TargetIntegrity.CriticallyWounded, 100 }, // Floof - adjusted the thresholds to come in increments of 20
-        { TargetIntegrity.HeavilyWounded, 80 },
+        { TargetIntegrity.CriticallyWounded, 100 }, // Floof - Increased from 90
+        { TargetIntegrity.HeavilyWounded, 70 }, // Floof note: this is where "passive healing" stops
         { TargetIntegrity.ModeratelyWounded, 60 },
         { TargetIntegrity.SomewhatWounded, 40},
         { TargetIntegrity.LightlyWounded, 20 },

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -272,6 +272,7 @@
     graph: Gauze
     node: gauze
   - type: Healing
+    selfHealPenaltyMultiplier: 1.5 # Floof - useful gauze
     damageContainers:
       - Biological
     damage:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -32,10 +32,10 @@
       - Biological
     damage:
       types:
-        Heat: -10
-        Cold: -10
-        Shock: -10
-        Caustic: -3 #Was 5 per type & 1.5 caustic, Buffed due to limb damage changes # Floof - changed to 3. Who did the math on this one??
+        Heat: -5
+        Cold: -5
+        Shock: -5
+        Caustic: -1.5 #Was 5 per type & 1.5 caustic, Buffed due to limb damage changes # Floof - reverted
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -83,10 +83,10 @@
       - Biological
     damage:
       types:
-        Heat: -15
-        Cold: -15
-        Shock: -15
-        Caustic: -15 #Was 10 per type, Buffed due to limb damage changes
+        Heat: -10
+        Cold: -10
+        Shock: -10
+        Caustic: -10 #Was 10 per type, Buffed due to limb damage changes # Floof - reverted
     healingBeginSound:
       path: "/Audio/Items/Medical/ointment_begin.ogg"
     healingEndSound:
@@ -123,7 +123,7 @@
       - Biological
     damage:
       groups:
-        Brute: -30 # was 5 (-15 Brute) for each, Buffed due to limb damage changes
+        Brute: -15 # was 5 (-15 Brute) for each, Buffed due to limb damage changes # Floof - reverted
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
@@ -172,7 +172,7 @@
       - Biological
     damage:
       groups:
-        Brute: -45 # was 10 for each, now 20 for each type in the group, Buffed due to Limb Damage Changes
+        Brute: -30 # was 10 for each, now 20 for each type in the group, Buffed due to Limb Damage Changes # Floof - reverted
     bloodlossModifier: -10 # a suture should stop ongoing bleeding
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -210,8 +210,8 @@
       - Biological
     damage:
       types:
-        Bloodloss: -2.5 #lowers bloodloss damage, was .5, buffed due to Limb Damage Changes
-    ModifyBloodLevel: 30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to Limb Damage Changes
+        Bloodloss: -0.5 #lowers bloodloss damage, was .5, buffed due to Limb Damage Changes # Floof - reverted
+    ModifyBloodLevel: 15 #used to restore 5% blood per use Buffed due to Limb Damage Changes # Floof - reverted. This is NOT 5% on average (often ends up being 15%) due to mass diff.
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
     healingEndSound:
@@ -276,8 +276,8 @@
       - Biological
     damage:
       types:
-        Slash: -10 # Was 5
-        Piercing: -15 # Was 10, Buffed due to limb damage changes
+        Slash: -5 # Was 5 # Floof - reverted
+        Piercing: -10 # Was 10, Buffed due to limb damage changes # Floof - reverted
     bloodlossModifier: -10
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"
@@ -304,7 +304,7 @@
   components:
   - type: Stack
     lingering: true
-    count: 1
+    count: 10  # Floof - why was this randomly changed to 1?
 
 - type: entity
   name: aloe cream
@@ -317,7 +317,7 @@
     state: cream
   - type: Stack
     stackType: AloeCream
-    count: 15 #Was 10, Buffed due to limb damage changes
+    count: 10 #Was 10, Buffed due to limb damage changes # Floof - reverted
 
 - type: entity
   parent: BaseHealingItem

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -2085,7 +2085,7 @@
           amount: 0.10
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.25
 
 - type: reagent
@@ -2112,7 +2112,7 @@
           amount: 0.15
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.15
 
 - type: reagent
@@ -2139,7 +2139,7 @@
           amount: 0.10
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.15
 
 - type: reagent
@@ -2166,7 +2166,7 @@
           amount: 0.15
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.25
 
 - type: reagent
@@ -2193,7 +2193,7 @@
           amount: 0.07
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.15
 
 - type: reagent
@@ -2220,5 +2220,5 @@
           amount: 0.15
         - !type:AdjustReagent
           reagent: Theobromine
-          amount: 0.05
+          amount: 0.1
   fizziness: 0.25

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -14,7 +14,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Theobromine
-        amount: 0.05
+        amount: 0.1
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
     state: icon_empty
@@ -38,7 +38,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Theobromine
-        amount: 0.05
+        amount: 0.1
 
 - type: reagent
   id: Cream
@@ -185,7 +185,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Theobromine
-        amount: 0.05
+        amount: 0.1
 
 - type: reagent
   id: JuiceBerryPoison
@@ -374,7 +374,7 @@
         factor: 2
       - !type:AdjustReagent
         reagent: Theobromine
-        amount: 0.05
+        amount: 0.1
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/teaglass.rsi
     state: icon_empty
@@ -502,7 +502,7 @@
         factor: 4
       - !type:AdjustReagent
         reagent: Theobromine
-        amount: 0.05
+        amount: 0.1
 
 - type: reagent
   id: Pilk

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -43,7 +43,7 @@
       - !type:HealthChange
         damage:
           types:
-            Poison: -1.5 # Was 1, Slight Buff as it should heal for half the amount as Dip or Stelli
+            Poison: -1 # Was 1, Slight Buff as it should heal for half the amount as Dip or Stelli # Floof - reverted - why did you touch this??
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -153,7 +153,7 @@
       - !type:HealthChange
         damage:
           groups:
-            Brute: -2.5 # Was 2, Buffed due to limb damage changes
+            Brute: -2 # Was 2, Buffed due to limb damage changes # Floof - reverted
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -242,9 +242,9 @@
       - !type:HealthChange
         damage:
           types:
-            Heat: -2
-            Shock: -2
-            Cold: -2 # Was 1.5, Buffed due to limb damage changes
+            Heat: -1.5
+            Shock: -1.5
+            Cold: -1.5 # Was 1.5, Buffed due to limb damage changes # Floof - reverted
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -342,8 +342,8 @@
             Asphyxiation: -3
             Poison: -0.5
           groups:
-            Brute: -1
-            Burn: -1 # Was .5, Buffed due to limb damage changes
+            Brute: -0.5
+            Burn: -0.5 # Was .5, Buffed due to limb damage changes # Floof - reverted
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -818,10 +818,10 @@
       - !type:HealthChange
         damage:
           groups:
-            Burn: -3
-            Toxin: -3
-            Airloss: -3
-            Brute: -3 # Was 2, Buffed due to limb damage changes
+            Burn: -2
+            Toxin: -2
+            Airloss: -2
+            Brute: -2 # Was 2, Buffed due to limb damage changes # Floof - reverted
 
 - type: reagent
   id: Ultravasculine
@@ -995,7 +995,7 @@
       - !type:HealthChange
         damage:
           types:
-            Slash: -4 # Was 3, Buffed due to limb damage changes
+            Slash: -3 # Was 3, Buffed due to limb damage changes  # Floof - reverted
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -1042,7 +1042,7 @@
       - !type:HealthChange
         damage:
           types:
-            Blunt: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
+            Blunt: -3.5 # Was 3, Buffed due to limb damage changes(GoobStation)  # Floof - reverted
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
# Description
- Theobromine: increased the amount of THB added by drinks like coffee, tea, and their derivatives to 0.1 instead of 0.05, because otherwise drinking coffee and tea would never allow enough THB to accumulate in your body to deal damage (if you have an animal stomach that is). Some drinks already had this value set to 0.1 which allowed them to be poisonous to animals, as intended.

- Medical: EE has badly thrown medical balance off by introducing poorly thought out changes (namely, increasing the amount of healing topicals provide by a factor of 3 instead of nerfing space/fire damage that was the cause of that change). Those changes were introduced to floof in the commit b431d24f86f94433ea0c53982db83e40ef1d3f2c. Most of the changes there were reverted, except for the stack sizes of topicals. Bruise packs and ointments still come in stacks of 15, but heal the pre-surgery amount of damage. The healing of chemicals was also reverted to pre-surgery. The time it takes to apply topicals was reverted back to 3 seconds on others and 9 seconds on self, which that commit changed to 2 and 4 respectively.

- Medical: nerfed passive body part healing from 10 damage/minute to 1 damage/minute. This healing is applied to ALL body parts that are below the "heavily wounded" (now 70 damage) state at the same time and has rendered limb damage practically irrelevant on floof outside of prolongued spacings and fires.

# Changelog
:cl:
- tweak: The healing amounts of topicals (bruise packs, ointments, and so on) were reduced to pre-surgery-update amounts.
- fix: Theobromine gained from coffee and similar drinks will now properly accumulate in your body and deal damage to those with animal stomachs.
