### PR TITLE
Various Loadout Changes

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
@@ -8,12 +8,6 @@
       id: LoadoutBackpackSatchelCaptain
     - type: loadout
       id: LoadoutBackpackDuffelCaptain
-    - type: loadout
-      id: LoadoutBackpackCaptainFilled
-    - type: loadout
-      id: LoadoutBackpackSatchelCaptainFilled
-    - type: loadout
-      id: LoadoutBackpackDuffelCaptainFilled
 
 - type: characterItemGroup
   id: LoadoutCaptainBelt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/captain.yml
@@ -8,6 +8,14 @@
       id: LoadoutBackpackSatchelCaptain
     - type: loadout
       id: LoadoutBackpackDuffelCaptain
+# Floof removal - Captain bags are now filled by default. Indistinguishable duplicate loadouts removed.
+#    - type: loadout
+#      id: LoadoutBackpackCaptainFilled
+#    - type: loadout
+#      id: LoadoutBackpackSatchelCaptainFilled
+#    - type: loadout
+#      id: LoadoutBackpackDuffelCaptainFilled
+# Floof removal end
 
 - type: characterItemGroup
   id: LoadoutCaptainBelt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/commandUncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/commandUncategorized.yml
@@ -38,6 +38,8 @@
   items:
     - type: loadout
       id: LoadoutCommandEyesCommand
+    - type: loadout # Floof - Add administration HUD to command loadout
+      id: LoadoutCommandEyesHudCommand
 
 #- type: characterItemGroup
 #  id: LoadoutCommandGloves

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -41,10 +41,14 @@
 #  maxItems: 1
 #  items:
 
-#- type: characterItemGroup
-#  id: LoadoutChiefEngineerGloves
-#  maxItems: 1
-#  items:
+# Floof section - Add missing Chief Engineer loadout items
+- type: characterItemGroup
+  id: LoadoutChiefEngineerGloves
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutChiefEngineerGlovesColorYellow
+# Floof section end
 
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerHead
@@ -80,6 +84,8 @@
   items:
     - type: loadout
       id: LoadoutCommandCEOuterWinter
+    - type: loadout # Floof - Add missing Chief Engineer loadout items
+      id: LoadoutChiefEngineerOuterLongcoat
 
 - type: characterItemGroup
   id: LoadoutChiefEngineerShoes
@@ -96,3 +102,9 @@
       id: LoadoutChiefEngineerUniformSuit
     - type: loadout
       id: LoadoutEngineeringChiefEngineerUniformSkirt
+# Floof section - Add missing Chief Engineer loadout items
+    - type: loadout
+      id: LoadoutChiefEngineerUniformTurtle
+    - type: loadout
+      id: LoadoutChiefEngineerUniformTurtleSkirt
+# Floof section end

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -40,16 +40,12 @@
 #  id: LoadoutChiefEngineerEyes
 #  maxItems: 1
 #  items:
-
-# Floof section - Add missing Chief Engineer loadout items
-- type: characterItemGroup
-  id: LoadoutChiefEngineerGloves
-  maxItems: 1
-  items:
-    - type: loadout
-      id: LoadoutChiefEngineerGlovesColorYellow
-# Floof section end
-
+#
+#- type: characterItemGroup
+#  id: LoadoutChiefEngineerGloves
+#  maxItems: 1
+#  items:
+#
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerHead
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -40,12 +40,12 @@
 #  id: LoadoutChiefEngineerEyes
 #  maxItems: 1
 #  items:
-#
+
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerGloves
 #  maxItems: 1
 #  items:
-#
+
 #- type: characterItemGroup
 #  id: LoadoutChiefEngineerHead
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/paramedic.yml
@@ -1,9 +1,17 @@
 # Paramedic
-#- type: characterItemGroup
-#  id: LoadoutParamedicBackpacks
-#  maxItems: 1
-#  items:
-#
+# Floof section - Paramedics get filled backpacks
+- type: characterItemGroup
+ id: LoadoutParamedicBackpacks
+ maxItems: 1
+ items:
+   - type: loadout
+     id: LoadoutBackpackParamedic
+   - type: loadout
+     id: LoadoutDuffelParamedic
+   - type: loadout
+     id: LoadoutSatchelParamedic
+# Floof section end
+
 #- type: characterItemGroup
 #  id: LoadoutParamedicBelt
 #  maxItems: 1

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/paramedic.yml
@@ -1,15 +1,15 @@
 # Paramedic
 # Floof section - Paramedics get filled backpacks
 - type: characterItemGroup
- id: LoadoutParamedicBackpacks
- maxItems: 1
- items:
-   - type: loadout
-     id: LoadoutBackpackParamedic
-   - type: loadout
-     id: LoadoutDuffelParamedic
-   - type: loadout
-     id: LoadoutSatchelParamedic
+  id: LoadoutParamedicBackpacks
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutParamedicBagBackpack
+    - type: loadout
+      id: LoadoutParamedicBagDuffel
+    - type: loadout
+      id: LoadoutParamedicBagSatchel
 # Floof section end
 
 #- type: characterItemGroup

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Command/uncategorized.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Command/uncategorized.yml
@@ -63,6 +63,20 @@
   items:
   - ClothingEyesGlassesCommand
 
+- type: loadout
+  id: LoadoutCommandEyesHudCommand
+  category: JobsCommandAUncategorized
+  cost: 1
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCommandEyes
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Command
+  items:
+  - ClothingEyesHudCommand
+
 # Gloves
 
 # Head

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -1,3 +1,15 @@
+# Chief Engineer
+# Backpacks
+
+# Belt
+
+# Ears
+
+# Equipment
+
+# Eyes
+
+# Gloves
 - type: loadout
   id: LoadoutClothingHandsChiefEngiWarmers
   category: JobsEngineeringChiefEngineer
@@ -10,6 +22,42 @@
     jobs:
     - ChiefEngineer
 
+- type: loadout
+  id: LoadoutChiefEngineerGlovesColorYellow
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  items:
+    - ClothingHandsGlovesColorYellow
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerGloves
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+
+# Head
+
+# Id
+
+# Neck
+
+# Mask
+
+# Outer
+- type: loadout
+  id: LoadoutChiefEngineerOuterLongcoat
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  items:
+    - ClothingLongcoatCE
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerOuter
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+
+# Shoes
 - type: loadout
   id: LoadoutClothingUnderSocksChiefEngi
   category: JobsEngineeringChiefEngineer
@@ -27,6 +75,7 @@
     jobs:
     - ChiefEngineer
 
+# Uniforms
 - type: loadout
   id: LoadoutClothingUniformChiefEngiThong
   category: JobsEngineeringChiefEngineer
@@ -38,3 +87,31 @@
   - !type:CharacterJobRequirement
     jobs:
     - ChiefEngineer
+
+- type: loadout
+  id: LoadoutChiefEngineerUniformTurtle
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformJumpsuitChiefEngineerTurtle
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer
+
+- type: loadout
+  id: LoadoutChiefEngineerUniformTurtleSkirt
+  category: JobsEngineeringChiefEngineer
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingUniformJumpskirtChiefEngineerTurtle
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefEngineerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefEngineer

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -22,19 +22,6 @@
     jobs:
     - ChiefEngineer
 
-- type: loadout
-  id: LoadoutChiefEngineerGlovesColorYellow
-  category: JobsEngineeringChiefEngineer
-  cost: 0
-  items:
-    - ClothingHandsGlovesColorYellow
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutChiefEngineerGloves
-    - !type:CharacterJobRequirement
-      jobs:
-        - ChiefEngineer
-
 # Head
 
 # Id

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/paramedic.yml
@@ -42,43 +42,46 @@
 
 # Backpacks
 - type: loadout
-  id: LoadoutBackpackParamedic
+  id: LoadoutParamedicBagBackpack
   category: JobsMedicalParamedic
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackParamedicFilled
+  - ClothingBackpackParamedicFilled
   requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutParamedicBackpacks
-    - !type:CharacterJobRequirement
-      jobs: Paramedic
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutParamedicBackpacks
+  - !type:CharacterJobRequirement
+    jobs:
+    - Paramedic
 
 - type: loadout
-  id: LoadoutDuffelParamedic
+  id: LoadoutParamedicBagDuffel
   category: JobsMedicalParamedic
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackDuffelParamedicFilled
+  - ClothingBackpackDuffelParamedicFilled
   requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutParamedicBackpacks
-    - !type:CharacterJobRequirement
-      jobs: Paramedic
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutParamedicBackpacks
+  - !type:CharacterJobRequirement
+    jobs:
+    - Paramedic
 
 - type: loadout
-  id: LoadoutSatchelParamedic
+  id: LoadoutParamedicBagSatchel
   category: JobsMedicalParamedic
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackSatchelParamedicFilled
+  - ClothingBackpackSatchelParamedicFilled
   requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutParamedicBackpacks
-    - !type:CharacterJobRequirement
-      jobs: Paramedic
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutParamedicBackpacks
+  - !type:CharacterJobRequirement
+    jobs:
+    - Paramedic
 
 # Belt
 

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Medical/paramedic.yml
@@ -39,7 +39,46 @@
   - !type:CharacterJobRequirement
     jobs:
     - Paramedic
+
 # Backpacks
+- type: loadout
+  id: LoadoutBackpackParamedic
+  category: JobsMedicalParamedic
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackParamedicFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutParamedicBackpacks
+    - !type:CharacterJobRequirement
+      jobs: Paramedic
+
+- type: loadout
+  id: LoadoutDuffelParamedic
+  category: JobsMedicalParamedic
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackDuffelParamedicFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutParamedicBackpacks
+    - !type:CharacterJobRequirement
+      jobs: Paramedic
+
+- type: loadout
+  id: LoadoutSatchelParamedic
+  category: JobsMedicalParamedic
+  cost: 0
+  exclusive: true
+  items:
+    - ClothingBackpackSatchelParamedicFilled
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutParamedicBackpacks
+    - !type:CharacterJobRequirement
+      jobs: Paramedic
 
 # Belt
 

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackCaptainFilled
+    - ClothingBackpackCaptainFilled # Floof - Captain bags are now filled by default.
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCaptainBackpacks
@@ -20,7 +20,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackSatchelCaptainFilled
+    - ClothingBackpackSatchelCaptainFilled # Floof - Captain bags are now filled by default.
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCaptainBackpacks
@@ -34,13 +34,57 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackDuffelCaptainFilled
+    - ClothingBackpackDuffelCaptainFilled # Floof - Captain bags are now filled by default.
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCaptainBackpacks
     - !type:CharacterJobRequirement
       jobs:
         - Captain
+
+# Floof removal - Captain bags are now filled by default. Indistinguishable duplicate loadouts removed.
+#- type: loadout
+#  id: LoadoutBackpackCaptainFilled
+#  category: JobsCommandCaptain
+#  cost: 0
+#  exclusive: true
+#  items:
+#    - ClothingBackpackCaptainFilled
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: LoadoutCaptainBackpacks
+#    - !type:CharacterJobRequirement
+#      jobs:
+#        - Captain
+#
+#- type: loadout
+#  id: LoadoutBackpackSatchelCaptainFilled
+#  category: JobsCommandCaptain
+#  cost: 0
+#  exclusive: true
+#  items:
+#    - ClothingBackpackSatchelCaptainFilled
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: LoadoutCaptainBackpacks
+#    - !type:CharacterJobRequirement
+#      jobs:
+#        - Captain
+#
+#- type: loadout
+#  id: LoadoutBackpackDuffelCaptainFilled
+#  category: JobsCommandCaptain
+#  cost: 0
+#  exclusive: true
+#  items:
+#    - ClothingBackpackDuffelCaptainFilled
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: LoadoutCaptainBackpacks
+#    - !type:CharacterJobRequirement
+#      jobs:
+#        - Captain
+# Floof removal end
 
 # Belt
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -6,7 +6,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackCaptain
+    - ClothingBackpackCaptainFilled
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutCaptainBackpacks
@@ -20,48 +20,6 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackSatchelCaptain
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-
-- type: loadout
-  id: LoadoutBackpackDuffelCaptain
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackDuffelCaptain
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-
-- type: loadout
-  id: LoadoutBackpackCaptainFilled
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  items:
-    - ClothingBackpackCaptainFilled
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutCaptainBackpacks
-    - !type:CharacterJobRequirement
-      jobs:
-        - Captain
-
-- type: loadout
-  id: LoadoutBackpackSatchelCaptainFilled
-  category: JobsCommandCaptain
-  cost: 0
-  exclusive: true
-  items:
     - ClothingBackpackSatchelCaptainFilled
   requirements:
     - !type:CharacterItemGroupRequirement
@@ -71,7 +29,7 @@
         - Captain
 
 - type: loadout
-  id: LoadoutBackpackDuffelCaptainFilled
+  id: LoadoutBackpackDuffelCaptain
   category: JobsCommandCaptain
   cost: 0
   exclusive: true


### PR DESCRIPTION
# Description

Removed empty captain bags from captain loadouts. The filled captain bags are still there. Added filled paramedic bags. These are the bags that a player will spawn with without any loadouts, so loadout choices should at least have parity with that.

Added missing longcoat, turtleneck jumpsuit, and turtleneck jumpskirt to chief engineer's loadout.

Added administration HUD to command loadout. It's a point cheaper than the administration glasses because it lacks flash protection.

---

# TODO

- [x] Remove unfilled captain bags
- [x] Add filled paramedic bags
- [x] Add missing Chief Engineer swag
- [x] Add administration HUD for command
- [x] Testing and fixes
- [x] Description

---

# Changelog

:cl:
- add: Filled paramedic bag loadouts
- add: Loadouts for chief engineer's longcoat, as well as turtleneck jumpsuit and jumpskirt
- add: Administration HUD command loadout
- remove: Removed unfilled captain bag loadouts. Filled captain bags remain.
