### PR TITLE
Add toolshed faction commands

### DIFF
--- a/Content.Server/FloofStation/NPC/Commands/AdminFactionCommand.cs
+++ b/Content.Server/FloofStation/NPC/Commands/AdminFactionCommand.cs
@@ -1,0 +1,53 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Server.NPC.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Toolshed;
+using Robust.Shared.Toolshed.Syntax;
+using Robust.Shared.Toolshed.TypeParsers;
+using Content.Server.NPC.Components;
+
+namespace Content.Server.FloofStation.NPC.Commands;
+
+[ToolshedCommand(Name = "faction"), AdminCommand(AdminFlags.Admin)]
+public sealed class AdminFactionCommand : ToolshedCommand
+{
+    private NpcFactionSystem? _factionField;
+    private NpcFactionSystem Factions => _factionField ??= GetSys<NpcFactionSystem>();
+
+    [CommandImplementation("add")]
+    public EntityUid AddFaction(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input,
+        [CommandArgument] string faction
+    )
+    {
+        Factions.AddFaction(input, faction);
+
+        return input;
+    }
+
+    [CommandImplementation("rm")]
+    public EntityUid RmFaction(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input,
+        [CommandArgument] string faction
+    )
+    {
+        Factions.RemoveFaction(input, faction);
+
+        return input;
+    }
+
+    [CommandImplementation("clear")]
+    public EntityUid ClearFaction(
+        [CommandInvocationContext] IInvocationContext ctx,
+        [PipedArgument] EntityUid input
+    )
+    {
+        Factions.ClearFactions(input);
+
+        return input;
+    }
+
+}

--- a/Resources/Locale/en-US/Floof/npc/commands.ftl
+++ b/Resources/Locale/en-US/Floof/npc/commands.ftl
@@ -1,0 +1,3 @@
+command-description-faction-add = Adds a new faction to the piped entity. Recalculates friendly/enemy factions afterwards.
+command-description-faction-rm = Removes an existing faction from the piped entity. Recalculates friendly/enemy factions afterwards.
+command-description-faction-clear = Removes all existing faction from the piped entity. Recalculates friendly/enemy factions afterwards.


### PR DESCRIPTION
# Description

Adds toolshed piped commands to manipulate the factions on an entity. Allows for greater flexibility for dealing with making "friendly" versions of normally antagonistic prototypes, including allowing players to /ghost from the inhabited entity without it turning hostile to those around them. The commands also return the entity, allowing you to chain them together

Usage:
[entity] faction:add [faction]
[entity] faction:rm [faction]
[entity] faction:clear

e.g., after using the Mark admin verb on a player inhabiting a normally hostile entity that wishes to become friendly to the crew:

`marked first faction:clear faction:add "NanoTrasen"`

to also give them access to Tau-Ceti Basic:

`marked first faction:clear faction:add "NanoTrasen" language:add "TauCetiBasic" true true`

to make an entity non-hostile, give it access to Basic, and assign a player to it:

`marked first faction:clear faction:add "NanoTrasen" language:add "TauCetiBasic" true true mind:control [player's username]`

turns out these toolshed commands are kinda neat

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
ADMIN:
- add: New toolshed command to manipulate factions for NPCs and have it actually reflect in who they aggro against
