### PR TITLE
Reparent some PDAs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -193,7 +193,7 @@
       - SecWatchCartridge
 
 - type: entity
-  parent: BasePDA
+  parent: SciencePDA # Floof - reparented
   id: ResearchAssistantPDA
   name: research assistant PDA
   description: Why isn't it purple?
@@ -1261,7 +1261,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: BasePDA
+  parent: EngineerPDA
   id: SeniorEngineerPDA
   name: senior engineer PDA
   description: Seems to have been taken apart and put back together several times.
@@ -1276,7 +1276,7 @@
     state: pda-seniorengineer
 
 - type: entity
-  parent: BasePDA
+  parent: SciencePDA # Floof - reparented
   id: SeniorResearcherPDA
   name: senior researcher PDA
   description: Looks like it's been through years of chemical burns and explosions.
@@ -1314,7 +1314,7 @@
     state: pda-seniorphysician
 
 - type: entity
-  parent: BasePDA
+  parent: SecurityPDA
   id: SeniorOfficerPDA
   name: senior officer PDA
   description: Beaten, battered and broken, but just barely useable.

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1261,7 +1261,7 @@
   - type: Unremoveable
 
 - type: entity
-  parent: EngineerPDA
+  parent: EngineerPDA # Floof - reparented
   id: SeniorEngineerPDA
   name: senior engineer PDA
   description: Seems to have been taken apart and put back together several times.
@@ -1314,7 +1314,7 @@
     state: pda-seniorphysician
 
 - type: entity
-  parent: SecurityPDA
+  parent: SecurityPDA # Floof - reparented
   id: SeniorOfficerPDA
   name: senior officer PDA
   description: Beaten, battered and broken, but just barely useable.


### PR DESCRIPTION
# Description
Reparents senior PDAs and research assistant's PDAs to fix some issues like the missing glimmer monitor on research seniors and interns.

# Changelog
:cl:
- fix: Research seniors and interns should now have the glimmer monitor app installed on their PDAs by default.
