### PR TITLE
Admin Painting And Soaping

### DIFF
--- a/Content.Server/Paint/PaintSystem.cs
+++ b/Content.Server/Paint/PaintSystem.cs
@@ -15,6 +15,8 @@ using Content.Server.Nutrition.EntitySystems;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
+using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
 
 namespace Content.Server.Paint;
 
@@ -30,6 +32,7 @@ public sealed class PaintSystem : SharedPaintSystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly OpenableSystem _openable = default!;
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
 
 
     public override void Initialize()
@@ -53,7 +56,7 @@ public sealed class PaintSystem : SharedPaintSystem
 
     private void OnPaintVerb(EntityUid uid, PaintComponent component, GetVerbsEvent<UtilityVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess)
+        if ((!args.CanInteract || !args.CanAccess) && !_admin.HasAdminFlag(args.User, AdminFlags.Admin)) // Floof: Admins can remove paint on anything they can get verbs for
             return;
 
         var paintText = Loc.GetString("paint-verb");

--- a/Content.Shared/Paint/PaintRemoverSystem.cs
+++ b/Content.Shared/Paint/PaintRemoverSystem.cs
@@ -5,6 +5,8 @@ using Content.Shared.Verbs;
 using Content.Shared.Sprite;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Timing;
+using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
 
 namespace Content.Shared.Paint;
 
@@ -14,6 +16,7 @@ public sealed class PaintRemoverSystem : SharedPaintSystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
 
 
     public override void Initialize()
@@ -65,7 +68,7 @@ public sealed class PaintRemoverSystem : SharedPaintSystem
 
     private void OnPaintRemoveVerb(EntityUid uid, PaintRemoverComponent component, GetVerbsEvent<UtilityVerb> args)
     {
-        if (!args.CanInteract || !args.CanAccess)
+        if ((!args.CanInteract || !args.CanAccess) && !_admin.HasAdminFlag(args.User, AdminFlags.Admin)) // Floof: Admins can remove paint on anything they can get verbs for
             return;
 
         var verb = new UtilityVerb()


### PR DESCRIPTION
# Description

Allows admins to use spray cans and soap on anything that can be/is painted that they can get verbs for. One less thing that they have to use VV for in a way that might break something.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
ADMIN:
- tweak: Admins can now adjust paint using spray cans/soap on any items as long as they can get verbs on them.
