### PR TITLE
QSI Fixes

### DIFF
--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -155,6 +155,13 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
         }
 
+        // can't predict if either entity doesn't exist on the client / is outside of PVS
+        if (_netMan.IsClient)
+        {
+            if (!Exists(uid) || Transform(uid).MapID == MapId.Nullspace || !Exists(linkedEnt) || Transform(linkedEnt).MapID == MapId.Nullspace)
+                return;
+        }
+
         var teleEnt = GetTeleportingEntity((uid, xform));
         var otherTeleEnt = GetTeleportingEntity((linkedEnt, Transform(linkedEnt)));
 
@@ -164,21 +171,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
         _container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var cont);
         _container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var otherCont);
 
-        if (otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
-            cont != null && !_container.CanInsert(otherTeleEnt, cont))
-        {
-            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail",
-                ("entity", Identity.Entity(linkedEnt, EntityManager))),
-                teleEnt,
-                teleEnt,
-                PopupType.MediumCaution);
-            return;
-        }
-
-
-        // Prevents teleporting to the polymorph zone or the cryosleep zone.
-        // Don't unlink because it might be temporary (polymorph). Let them figure it out and unlink it themselves.
-        if (_map.IsPaused(Transform(teleEnt).MapID) || _map.IsPaused(Transform(otherTeleEnt).MapID))
+        if (!CanTeleport(teleEnt,otherTeleEnt)) // Logic moved upon request
         {
             _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-fail",
                 ("entity", Identity.Entity(linkedEnt, EntityManager))),
@@ -196,6 +189,8 @@ public sealed class SwapTeleporterSystem : EntitySystem
             PopupType.MediumCaution);
 
         // break pulls before teleport so we dont break shit
+        // Ideally this situation would be well-handled by the physics engine, but until it is this needs to handle it
+        // https://github.com/space-wizards/space-station-14/issues/31214
         if (TryComp<PullableComponent>(teleEnt, out var pullable) && pullable.BeingPulled)
         {
             _pulling.TryStopPull(teleEnt, pullable);
@@ -218,14 +213,28 @@ public sealed class SwapTeleporterSystem : EntitySystem
             _pulling.TryStopPull(otherPullerComp.Pulling.Value, otherSubjectPulling);
         }
 
-        // can't predict if the target doesn't exist on the client / is outside of PVS
-        if (_netMan.IsClient)
-        {
-            if (!Exists(otherTeleEnt) || Transform(otherTeleEnt).MapID == MapId.Nullspace)
-                return;
-        }
-
         _transform.SwapPositions(teleEnt, otherTeleEnt);
+    }
+
+    public bool CanTeleport(EntityUid teleEnt, EntityUid otherTeleEnt)
+    {
+        _container.TryGetOuterContainer(teleEnt, Transform(teleEnt), out var cont);
+        _container.TryGetOuterContainer(otherTeleEnt, Transform(otherTeleEnt), out var otherCont);
+
+        // Checks if the objects can actually be swapped with respect to containers
+
+        bool containerBlocked = otherCont != null && !_container.CanInsert(teleEnt, otherCont) ||
+            cont != null && !_container.CanInsert(otherTeleEnt, cont);
+
+        // Prevents teleporting to the polymorph zone or the cryosleep zone.
+
+        bool pausedMap = _map.IsPaused(Transform(teleEnt).MapID) || _map.IsPaused(Transform(otherTeleEnt).MapID);
+
+        // Room for more logic in case more situations come up in the future
+
+        // Bring it all together
+
+        return !(containerBlocked || pausedMap);
     }
 
     /// <remarks>


### PR DESCRIPTION
# Description

The QSI fixes wizden doesn't want you to have

For my original PR:

Adds logic to SwapTeleporterSystem to:

- Cancel if it's clientside (that is, cancel prediction) and either party is outside of the visual range (fixes the Flesh Hallucination bug)
- Stop pulling and being pulled on both sides (fixes Teleporter Accidents allowing for infiltration)
- Cancel the teleport entirely if either side is on a Paused map (Prevents being sent to polymorph/cryo hell)

---

# TODO

- [ ] Fix a few incongruous lines between the wizden version and what needs to happen for the EE version

---

# Changelog

:cl:
- fix: QSI no longer causes nearby players to hallucinate, no longer causes teleporter accidents, and no longer can be used to send people to hell.
