### PR TITLE
Cherry-Pick "Update Vomit Organ Smite to Not Use Component.owner (#29926)"

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -283,18 +283,18 @@ public sealed partial class AdminVerbSystem
             {
                 Text = "Vomit organs",
                 Category = VerbCategory.Smite,
-                Icon = new SpriteSpecifier.Rsi(new ("/Textures/Fluids/vomit_toxin.rsi"), "vomit_toxin-1"),
+                Icon = new SpriteSpecifier.Rsi(new("/Textures/Fluids/vomit_toxin.rsi"), "vomit_toxin-1"),
                 Act = () =>
                 {
                     _vomitSystem.Vomit(args.Target, -1000, -1000); // You feel hollow!
-                    var organs = _bodySystem.GetBodyOrganComponents<TransformComponent>(args.Target, body);
+                    var organs = _bodySystem.GetBodyOrganEntityComps<TransformComponent>((args.Target, body));
                     var baseXform = Transform(args.Target);
-                    foreach (var (xform, organ) in organs)
+                    foreach (var organ in organs)
                     {
-                        if (HasComp<BrainComponent>(xform.Owner) || HasComp<EyeComponent>(xform.Owner))
+                        if (HasComp<BrainComponent>(organ.Owner) || HasComp<EyeComponent>(organ.Owner))
                             continue;
 
-                        _transformSystem.AttachToGridOrMap(organ.Owner);
+                        _transformSystem.PlaceNextTo((organ.Owner, organ.Comp1), (args.Target, baseXform));
                     }
 
                     _popupSystem.PopupEntity(Loc.GetString("admin-smite-vomit-organs-self"), args.Target,

--- a/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Organs.cs
@@ -219,6 +219,30 @@ public partial class SharedBodySystem
     }
 
     /// <summary>
+    /// Returns a list of Entity<<see cref="T"/>, <see cref="OrganComponent"/>>
+    /// for each organ of the body
+    /// </summary>
+    /// <typeparam name="T">The component that we want to return</typeparam>
+    /// <param name="entity">The body to check the organs of</param>
+    public List<Entity<T, OrganComponent>> GetBodyOrganEntityComps<T>(
+        Entity<BodyComponent?> entity)
+        where T : IComponent
+    {
+        if (!Resolve(entity, ref entity.Comp))
+            return new List<Entity<T, OrganComponent>>();
+
+        var query = GetEntityQuery<T>();
+        var list = new List<Entity<T, OrganComponent>>(3);
+        foreach (var organ in GetBodyOrgans(entity.Owner, entity.Comp))
+        {
+            if (query.TryGetComponent(organ.Id, out var comp))
+                list.Add((organ.Id, comp, organ.Component));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     ///     Tries to get a list of ValueTuples of <see cref="T"/> and OrganComponent on each organs
     ///     in the given body.
     /// </summary>


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This cherry-pick from WizDen, number 29926 includes back end changes relating to organs and how they are handled.

This is necessary if we are to port stuff such as recent DeltaV merges that interact with organs in any manner. My PRs, #612 and #623 is reliant on these changes due to the usage of `GetBodyOrganEntityComps` and so on forth.

No change log is needed as this is purely a codebase change.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Cherry-pick the PR
- [x] Send it
