### PR TITLE
Select Fire Rifles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -21,6 +21,7 @@
     fireRate: 5
     selectedMode: FullAuto
     availableModes:
+      - SemiAuto
       - FullAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/batrifle.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -149,11 +149,15 @@
       minAngle: 21
       maxAngle: 32
       fireRate: 6
+      burstFireRate: 18
       selectedMode: FullAuto
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
       availableModes:
+        - Burst
         - FullAuto
+      shotsPerBurst: 3
+      burstCooldown: 0.375
       fireOnDropChance: 0.2
     - type: ItemSlots
       slots:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -101,7 +101,7 @@
   - type: Gun
     minAngle: 21
     maxAngle: 32
-    shotsPerBurst: 5
+    shotsPerBurst: 3
     availableModes:
     - SemiAuto
     - Burst
@@ -149,15 +149,14 @@
       minAngle: 21
       maxAngle: 32
       fireRate: 6
-      burstFireRate: 18
       selectedMode: FullAuto
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/atreides.ogg
       availableModes:
+        - SemiAuto
         - Burst
         - FullAuto
       shotsPerBurst: 3
-      burstCooldown: 0.375
       fireOnDropChance: 0.2
     - type: ItemSlots
       slots:
@@ -261,7 +260,7 @@
     angleIncrease: 1.5
     angleDecay: 6
     selectedMode: FullAuto
-    shotsPerBurst: 5
+    shotsPerBurst: 3
     availableModes:
     - SemiAuto
     - Burst


### PR DESCRIPTION
# Description

Added semi-automatic firemode to all rifles and SMGs, such as the AKMS, Lecter, and Drozd. This shouldn't affect balance at all, as single shots have always been achievable through lightly tapping the trigger (unless you're lagging a lot), and mostly improves *immersion*, *realism* and preventing the common occurrence of magdumping the cadet by accident.
(Help I am stuck in big font)
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [X] Add semi-auto mode to weapons.

---

# Changelog
:cl: Nox38
- tweak: Added semi-auto firemode to all automatic weapons.