### PR TITLE
Add Missing Chaplain's Stole and Crucifix to Loadout

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -16,7 +16,7 @@
     ClothingOuterPlagueSuit: 3
     ClothingMaskPlague: 3
     ClothingNeckScarfChaplainStole: 3
-    ClothingHeadsetService: 4
+    ClothingHeadsetScience: 4 # Floof - Chaplain is no longer service dept
     ClothingNeckCrucifix: 3
     ClothingNeckStoleChaplain: 1
     ClothingHandsChaplainWarmers: 1 # Floofstation

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/chaplain.yml
@@ -27,12 +27,14 @@
 #  id: LoadoutChaplainEyes
 #  maxItems: 1
 #  items:
-#
-#- type: characterItemGroup
-#  id: LoadoutChaplainGloves
-#  maxItems: 1
-#  items:
-#
+
+- type: characterItemGroup
+  id: LoadoutChaplainGloves
+  maxItems: 1
+  items:
+    - type: loadout # Floof - Add lingerie
+      id: LoadoutClothingHandChaplainWarmers
+
 - type: characterItemGroup
   id: LoadoutChaplainHead
   maxItems: 1
@@ -57,6 +59,12 @@
   items:
     - type: loadout
       id: LoadoutScienceNeckStoleChaplain
+# Floof section - Add missing chaplain loadouts
+    - type: loadout
+      id: LoadoutChaplainNeckScarfChaplainStole
+    - type: loadout
+      id: LoadoutChaplainNeckCrucifix
+# Floof section end
 
 - type: characterItemGroup
   id: LoadoutChaplainMask
@@ -77,12 +85,16 @@
       id: LoadoutScienceOuterHoodieBlack
     - type: loadout
       id: LoadoutScienceOuterHoodieChaplain
+    - type: loadout # Floof - Add missing chaplain loadouts
+      id: LoadoutClothingChaplainEpiMantle
 
-#- type: characterItemGroup
-#  id: LoadoutChaplainShoes
-#  maxItems: 1
-#  items:
-#
+- type: characterItemGroup
+  id: LoadoutChaplainShoes
+  maxItems: 1
+  items:
+    - type: loadout # Floof - Add lingerie
+      id: LoadoutClothingUnderSocksChaplain
+
 - type: characterItemGroup
   id: LoadoutChaplainUniforms
   maxItems: 1
@@ -95,3 +107,5 @@
       id: LoadoutScienceUniformJumpsuitMonasticRobeDark
     - type: loadout
       id: LoadoutScienceUniformJumpsuitMonasticRobeLight
+    - type: loadout # Floof - Add lingerie
+      id: LoadoutClothingUniformChaplainThong

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/Epistemics/chaplain.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/Epistemics/chaplain.yml
@@ -1,3 +1,15 @@
+# Chaplain
+# Backpacks
+
+# Belt
+
+# Ears
+
+# Equipment
+
+# Eyes
+
+# Gloves
 - type: loadout
   id: LoadoutClothingHandChaplainWarmers
   category: JobsEpistemicsChaplain
@@ -6,10 +18,63 @@
   items:
   - ClothingHandsChaplainWarmers
   requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainGloves
   - !type:CharacterJobRequirement
     jobs:
     - Chaplain
 
+# Head
+
+# Id
+
+# Neck
+- type: loadout
+  id: LoadoutChaplainNeckScarfChaplainStole
+  category: JobsEpistemicsChaplain
+  cost: 0
+  exclusive: true
+  items:
+  - ClothingNeckScarfChaplainStole
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainNeck
+  - !type:CharacterJobRequirement
+    jobs:
+    - Chaplain
+
+- type: loadout
+  id: LoadoutChaplainNeckCrucifix
+  category: JobsEpistemicsChaplain
+  cost: 0
+  exclusive: true
+  items:
+  - ClothingNeckCrucifix
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainNeck
+  - !type:CharacterJobRequirement
+    jobs:
+    - Chaplain
+
+# Mask
+
+# Outer
+- type: loadout
+  id: LoadoutClothingChaplainEpiMantle
+  category: JobsEpistemicsChaplain
+  cost: 0
+  exclusive: true
+  items:
+  - ClothingOuterEpiChaplainMantle
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainOuter
+  - !type:CharacterJobRequirement
+    jobs:
+    - Chaplain
+
+# Shoes
 - type: loadout
   id: LoadoutClothingUnderSocksChaplain
   category: JobsEpistemicsChaplain
@@ -18,6 +83,8 @@
   items:
   - ClothingUnderSocksChaplain
   requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainShoes
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -27,6 +94,7 @@
     jobs:
     - Chaplain
 
+# Uniforms
 - type: loadout
   id: LoadoutClothingUniformChaplainThong
   category: JobsEpistemicsChaplain
@@ -35,18 +103,8 @@
   items:
   - ClothingUniformChaplainThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Chaplain
-
-- type: loadout
-  id: LoadoutClothingChaplainEpiMantle
-  category: JobsEpistemicsChaplain
-  cost: 1
-  exclusive: true
-  items:
-  - ClothingOuterEpiChaplainMantle
-  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChaplainUniforms
   - !type:CharacterJobRequirement
     jobs:
     - Chaplain


### PR DESCRIPTION
# Description

Added chaplain's stole and crucifix to chaplain loadout, added loadout groups to chaplain's lingerie and mantle, removed cost from chaplain's mantle, and replaced service headsets with epistemics headset in the chaplain's vendor.

The chaplain's mantle has no particular advantages over other free uniform outerwear, and has no reason to cost a point.

---

# Changelog

:cl:
- add: Added Chaplain's stole and crucifix to loadout.
- tweak: Removed cost from Chaplain's mantle loadout.
