### PR TITLE
Fix Chaplain ID

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -370,8 +370,8 @@
     - state: subdepartment
       color: "#58C800"
     - state: chaplain
-    - type: PresetIdCard
-      job: Chaplain
+  - type: PresetIdCard
+    job: Chaplain
 
 - type: entity
   parent: IDCardStandard

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -370,8 +370,8 @@
     - state: subdepartment
       color: "#58C800"
     - state: chaplain
-  - type: PresetIdCard
-    job: Chaplain
+  - type: PresetIdCard # Floofstation - fixed indentation
+    job: Chaplain # Floofstation - fixed indentation
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes an upstream bug where Chaplain would show up under the "Unknown" department on the crew monitor, along with other strange behaviors around chaplain IDs such as those spawned from the entity spawn menu not having a job or access set.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Be confused for a long time since everything seems fine
- [x] Realize whitespace is wrong and flump over

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Eh. 

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed chaplain showing up under Unknown department on crew monitor and other strange behavior with chaplain ID
