### PR TITLE
Tiny Trait Patch

### DIFF
--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -117,6 +117,7 @@
     jobs:
     - Borg
     - MedicalBorg
+    - Captain # Balance, sorry for the tiny captains out there!
   - !type:CharacterHeightRequirement
     max: 158 # was based on minimum Oni size but now Oni are restricted - still ends up smaller than the current smallest races can be
   - !type:CharacterWidthRequirement
@@ -130,6 +131,10 @@
     inverted: true
     species:
     - Oni # incompatable due to use of the PlayerToolModifier and BonusMeleeDamage - a special trait will need to be made
+  - !type:CharacterDepartmentRequirement
+      inverted: true
+      departments:
+        - Security # No tiny sec, sad
   functions:
   - !type:TraitAddComponent
     components:

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -10,6 +10,10 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Security dept time requirement
     department: Security
     min: 14400 # Floofstation - 4 hours
+  - !type:CharacterTraitRequirement # Floofstation
+    inverted: true
+    traits:
+      - Tiny # Floofstation - Too much of an advantage in a gunfight or stealth
 
 - type: antag
   id: NukeopsMedic
@@ -23,6 +27,10 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Medical dept time requirement
     department: Medical
     min: 14400 # Floofstation - 4 hours
+  - !type:CharacterTraitRequirement # Floofstation
+    inverted: true
+    traits:
+      - Tiny # Floofstation - Too much of an advantage in a gunfight or stealth
 
 - type: antag
   id: NukeopsCommander
@@ -39,6 +47,10 @@
   - !type:CharacterDepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
     min: 14400 # Floofstation - 4 hours
+  - !type:CharacterTraitRequirement # Floofstation
+    inverted: true
+    traits:
+      - Tiny # Floofstation - Too much of an advantage in a gunfight or stealth
 
 #Lone Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -7,3 +7,7 @@
   requirements:
   - !type:CharacterOverallTimeRequirement # DeltaV - Playtime requirement
     min: 14400 # Floofstation - 4 hours
+  - !type:CharacterTraitRequirement # Floofstation
+    inverted: true
+    traits:
+      - Tiny # Floofstation - Too much of an advantage in a gunfight or stealth


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Balance patch to prevent captain, security, and antags from being tiny.

Note that a full rework will be coming later to fix visual issues, make it harder to struggle out of inventories, and likely other tweaks based on feedback.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Restrict security and captain
- [x] Restrict antags (not sure how)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/71d5aebc-f292-44ef-b5d2-bac722a1c791)
![image](https://github.com/user-attachments/assets/246b8ff5-bc6c-4330-84ae-4db8efdbe94c)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Captain, Security, and some antags can no longer be tiny
