### PR TITLE
Examine Detail Range Increase

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -40,7 +40,7 @@ namespace Content.Shared.Examine
         public const float DeadExamineRange = 0.75f;
 
         public const float ExamineRange = 16f;
-        protected const float ExamineDetailsRange = 3f;
+        protected const float ExamineDetailsRange = 16f; /// Floof Change, TK420634 wuz here
 
         protected const float ExamineBlurrinessMult = 2.5f;
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description
Ups the examine details visibility range from 3 to 16.

Would be nice if i knew how to make it not auto-close the window as well, but it's a step in the right direction.  

![image](https://github.com/user-attachments/assets/0ae76b20-18d0-478f-a747-47a2d10ef130)

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

🆑 Fenny
- tweak: Examine range to 16 tiles so you no longer have to walk up to people and oogle them from point blank range to read about their heaving cleavage.