### PR TITLE
Fix Interaction Verbs Revealing Identity

### DIFF
--- a/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Contests;
 using Content.Shared.DoAfter;
 using Content.Shared.Ghost;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.InteractionVerbs.Events;
 using Content.Shared.Popups;
@@ -383,8 +384,8 @@ public abstract class SharedInteractionVerbsSystem : EntitySystem
 
             (string, object)[] localeArgs =
             [
-                ("user", user),
-                ("target", target),
+                ("user", Identity.Entity(user, EntityManager)), // Floof - use identity
+                ("target", Identity.Entity(target, EntityManager)), // Floof - use identity
                 ("used", used ?? EntityUid.Invalid),
                 ("selfTarget", user == target),
                 ("hasUsed", used != null)


### PR DESCRIPTION
# Description
Taken from here: https://github.com/Fansana/floof-frontier/pull/161

# Changelog
:cl:
- fix: Interaction verbs (looking, petting, etc) should no longer reveal the target's or user's identity.
