### PR TITLE
Check Out Desc Fix

### DIFF
--- a/Resources/Locale/en-US/interaction/verbs/noop.ftl
+++ b/Resources/Locale/en-US/interaction/verbs/noop.ftl
@@ -6,7 +6,7 @@ interaction-LookAt-success-others-popup = {THE($user)} looks at {THE($target)}.
 
 # Designed to not be seen by others, only you and your target.  Plays a light sound effect that is very unique to it to catch the attention of the party being eye'd up.
 interaction-CheckOut-name = Check out
-interaction-CheckOut-description = You are really eyeing up {THE($target)}, maybe they'll notice your attention.
+interaction-CheckOut-description = This lets you check someone out on the down low, only you and they will know you did.
 interaction-CheckOut-success-self-popup = You are really eyeballing {THE($target)}.
 interaction-CheckOut-success-target-popup = You think that {THE($user)} might be checking you out...
 


### PR DESCRIPTION
Title.

Fixes 
  V
![image](https://github.com/user-attachments/assets/bcdc8c45-d793-4e64-99eb-1ffb5dc55206)


cl: Fenny
- Does a sick kickflip over the check out verb to fix its description.